### PR TITLE
Link MiXplorer icon to “com.mixplorer” package

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -35,5 +35,6 @@
     <icon drawable="@drawable/poweramp" package="com.maxmpz.audioplayer" name="Poweramp" />
     <icon drawable="@drawable/mixplorer" package="com.mixplorer.silver" name="MiXplorer" />
     <icon drawable="@drawable/mixplorer" package="com.mixplorer.beta" name="MiXplorer" />
+    <icon drawable="@drawable/mixplorer" package="com.mixplorer" name="MiXplorer" />
     <icon drawable="@drawable/whatsapp_business" package="com.whatsapp.w4b" name="WhatsApp Business" />
 </icons>


### PR DESCRIPTION
MiXplorer v6.57.1-API26-RC from Xda has “com.mixplorer” package name

<img src="https://user-images.githubusercontent.com/20245745/140076596-9d8b4d85-2c52-4ec4-8b2d-8c755b2b3572.png" alt="Screenshot_20211103-161202_App Manager" width="500"/>