### PR TITLE
Lawnicons: Link Oppo/realme Camera to Camera Icon

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -8,6 +8,8 @@
     <icon drawable="@drawable/camera" package="com.sec.android.app.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.google.android.apps.cameralite" name="Camera" />
     <icon drawable="@drawable/camera" package="com.oneplus.camera" name="Camera" />
+    <icon drawable="@drawable/camera" package="com.oppo.camera" name="Camera" />
+    <icon drawable="@drawable/camera" package="com.oplus.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.android.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.huawei.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.honor.camera" name="Camera" />


### PR DESCRIPTION
* com.oppo.camera is package name of Oppo/Realme Camera on ColorOS 7/realmeUI 1 , ColorOS 6 & Lower.
* com.oplus.camera is package name of Oppo/Realme Camera on ColorOS 11/realmeUI 2  & ColorOS 12/realmeUI 3.
* ( oplus = merged codename of oppo + realme + oneplus blobs & packages, all Realme & Oppo Devices with RUI 2/Cos11 use oplus stuff, Oneplus with Nord 2 uses Oplus stuff too )

Change-Id: I9dbbeeec919ce133cfa8a5df53c9ffa2795ca201
Signed-off-by: techyminati <sinha.aryan03@gmail.com>