### PR TITLE
map Firefox Nightly to Firefox stable

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -58,6 +58,7 @@
     <icon drawable="@drawable/telegram_x" package="org.thunderdog.challegramtwo" name="Telegram X" />
     <icon drawable="@drawable/firefox" package="org.mozilla.firefox" name="Firefox" />
     <icon drawable="@drawable/firefox_beta" package="org.mozilla.firefox_beta" name="Firefox Beta" />
+    <icon drawable="@drawable/firefox" package="org.mozilla.fenix" name="Firefox Nightly" />
     <icon drawable="@drawable/signal" package="org.thoughtcrime.securesms" name="Signal" />
     <icon drawable="@drawable/skype" package="com.skype.raider" name="Skype" />
     <icon drawable="@drawable/termux" package="com.termux" name="Termux" />


### PR DESCRIPTION
The Firefox Nightly icon is closer matching to the stable icon so a seperate drawable isn't needed
