### PR TITLE
Refine ProtonMail icon

### DIFF
--- a/app/src/main/res/drawable/protonmail.xml
+++ b/app/src/main/res/drawable/protonmail.xml
@@ -4,18 +4,8 @@
     android:viewportWidth="192"
     android:viewportHeight="192">
   <path
-      android:pathData="M50,94L142,94A4,4 0,0 1,146 98L146,166A4,4 0,0 1,142 170L50,170A4,4 0,0 1,46 166L46,98A4,4 0,0 1,50 94z"
+      android:pathData="m146,72c0,-27.614 -22.386,-50 -50,-50 -27.614,0 -50,22.386 -50,50v32l43.14,25.884c4.222,2.533 9.498,2.533 13.72,0l43.14,-25.884zM50,82h92c2.216,0 4,1.784 4,4v72c0,2.216 -1.784,4 -4,4h-92c-2.216,0 -4,-1.784 -4,-4v-72c0,-2.216 1.784,-4 4,-4z"
       android:strokeWidth="12"
       android:fillColor="#00000000"
-      android:strokeColor="#000000"/>
-  <path
-      android:pathData="M46,94L87.515,135.515C92.201,140.201 99.799,140.201 104.485,135.515L146,94"
-      android:strokeWidth="12"
-      android:fillColor="#00000000"
-      android:strokeColor="#000000"/>
-  <path
-      android:pathData="M46,100V72C46,44.386 68.386,22 96,22V22C123.614,22 146,44.386 146,72V100"
-      android:strokeWidth="12"
-      android:fillColor="#00000000"
-      android:strokeColor="#000000"/>
+      android:strokeColor="#000"/>
 </vector>

--- a/svgs/protonmail.svg
+++ b/svgs/protonmail.svg
@@ -1,5 +1,3 @@
-<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="46" y="94" width="100" height="76" rx="4" stroke="black" stroke-width="12"/>
-<path d="M46 94L87.5147 135.515C92.201 140.201 99.799 140.201 104.485 135.515L146 94" stroke="black" stroke-width="12"/>
-<path d="M46 100V72C46 44.3858 68.3858 22 96 22V22C123.614 22 146 44.3858 146 72V100" stroke="black" stroke-width="12"/>
+<svg width="192" height="192" fill="none" version="1.1" viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
+    <path d="m146 72c0-27.614-22.386-50-50-50-27.614 0-50 22.386-50 50v32l43.14 25.884c4.2224 2.5335 9.4975 2.5335 13.72 0l43.14-25.884zm-96 10h92c2.216 0 4 1.784 4 4v72c0 2.216-1.784 4-4 4h-92c-2.216 0-4-1.784-4-4v-72c0-2.216 1.784-4 4-4z" fill="none" stroke="black" stroke-width="12"/>
 </svg>


### PR DESCRIPTION
Made the ProtonMail icon more accurate to its original version
## Screenshots
### Before:
![Before](https://user-images.githubusercontent.com/62820070/152645864-a50fbeb9-2401-49ca-9630-db0254f35a46.png)
### After:
![After](https://user-images.githubusercontent.com/62820070/152645862-a4a9c1cf-b8a9-4bf0-b69f-a18c580f50fc.png)

