### PR TITLE
Add "com.oneplus.mms" to messages category.

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -179,6 +179,7 @@
     <icon drawable="@drawable/messages" package="com.android.messaging" name="Messages" />
     <icon drawable="@drawable/messages" package="com.android.messaging" name="Messaging" />
     <icon drawable="@drawable/messages" package="com.android.mms" name="Messages" />
+    <icon drawable="@drawable/messages" package="com.oneplus.mms" name="Messages" />
     <icon drawable="@drawable/messages" package="com.google.android.apps.messaging" name="Messages" />
     <icon drawable="@drawable/messages" package="com.samsung.android.messaging" name="Messages" />
     <icon drawable="@drawable/messenger" package="com.facebook.mlite" name="Messenger" />


### PR DESCRIPTION
I saw the SMS on OxygenOS icon was not themed, so I figured out opening a PR could help.