### PR TITLE
mBank CZ, SK and FOSS Browser icons

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -193,6 +193,8 @@
     <icon drawable="@drawable/marindeck" package="online.hisubway.marindeck" name="MarinDeck" />
     <icon drawable="@drawable/material_catalog" package="io.material.catalog" name="Material Catalog" />
     <icon drawable="@drawable/mbank" package="pl.mbank" name="mBank" />
+    <icon drawable="@drawable/mbank" package="cz.mbank" name="mBank" />
+    <icon drawable="@drawable/mbank" package="sk.mbank" name="mBank" />
     <icon drawable="@drawable/mega" package="mega.privacy.android.app" name="Mega" />
     <icon drawable="@drawable/messages" package="com.android.messaging" name="Messages" />
     <icon drawable="@drawable/messages" package="com.android.messaging" name="Messaging" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -26,6 +26,7 @@
     <icon drawable="@drawable/bromite" package="org.bromite.bromite" name="Bromite" />
     <icon drawable="@drawable/browser" package="org.droidtr.jelly" name="Browser" />
     <icon drawable="@drawable/browser" package="org.lineageos.jelly" name="Browser" />
+    <icon drawable="@drawable/browser" package="de.baumann.browser" name="FOSS Browser" />
     <icon drawable="@drawable/bundle" package="com.dwarfplanet.bundle" name="Bundle" />
     <icon drawable="@drawable/calculator" package="com.android.calculator2" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.google.android.calculator" name="Calculator" />


### PR DESCRIPTION
Use mBank PL icon for CZ and SK versions as well.

FOSS Browser's icon is very similar existing Jelly one, as you can see in pictures below:
![image](https://user-images.githubusercontent.com/62813600/154143512-19319b16-5714-4e6f-aa86-2043483aa4b8.png)
![image](https://user-images.githubusercontent.com/62813600/154143565-17d6b5a0-1330-4ee2-8807-bc1c721bedba.png)