### PR TITLE
Support GCam variant from Wichaya8

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -78,6 +78,7 @@
     <icon drawable="@drawable/camera" package="app.grapheneos.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.asus.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.GoogleCamera.mwp83" name="Camera" />
+    <icon drawable="@drawable/camera" package="com.googleCamera.Wichaya8" name="Camera" />
     <icon drawable="@drawable/camera" package="com.android.MGC.not.stable" name="Camera" />
     <icon drawable="@drawable/camera" package="com.android.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.android.camera2" name="Camera" />


### PR DESCRIPTION
This update is just to allow a GCam variant use the existing camera icon.

The package that'll be supported is:

```
com.googleCamera.Wichaya8
````