### PR TITLE
 Link `@drawable/gallery` to `org.stingle.photos`

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -196,6 +196,7 @@
     <icon drawable="@drawable/gallery" package="com.miui.gallery" name="Gallery" />
     <icon drawable="@drawable/gallery" package="com.oneplus.gallery" name="Gallery" />
     <icon drawable="@drawable/gallery" package="com.oppo.gallery3d" name="Gallery" />
+    <icon drawable="@drawable/gallery" package="org.stingle.photos" name="Gallery" />
     <icon drawable="@drawable/gallery" package="com.vivo.gallery" name="Gallery" />
     <icon drawable="@drawable/gallery" package="com.sec.android.gallery3d" name="Gallery" />
     <icon drawable="@drawable/gallery_go" package="com.google.android.apps.photosgo" name="Gallery Go" />


### PR DESCRIPTION


Adds support for Stingle Photos as a gallery
