### PR TITLE
 Link `@drawable/find_my_device` to `de.nulide.findmydevice`

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -181,6 +181,7 @@
     <icon drawable="@drawable/files_by_google" package="com.google.android.apps.nbu.files" name="Files by Google" />
     <icon drawable="@drawable/fingerprint" package="ro.andreimircius.remotefingerauth" name="Remote Fingerprint Unlock" />
     <icon drawable="@drawable/find_my_device" package="com.google.android.apps.adm" name="Find My Device" />
+    <icon drawable="@drawable/find_my_device" package="de.nulide.findmydevice" name="Find My Device" />
     <icon drawable="@drawable/firefox" package="org.mozilla.fennec_fdroid" name="Fennec" />
     <icon drawable="@drawable/firefox" package="org.mozilla.fenix" name="Firefox" />
     <icon drawable="@drawable/firefox" package="org.mozilla.firefox" name="Firefox" />


### PR DESCRIPTION
Adds support for Nulide's Find My Device