### PR TITLE
link `@drawable/dialer` to `com.asus.dialer`

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -144,6 +144,7 @@
     <icon drawable="@drawable/dialer" package="com.android.dialer" name="Phone" />
     <icon drawable="@drawable/dialer" package="com.android.incallui" name="Phone" />
     <icon drawable="@drawable/dialer" package="com.android.phone" name="Phone" />
+    <icon drawable="@drawable/dialer" package="com.asus.dialer" name="Phone" />
     <icon drawable="@drawable/dialer" package="com.google.android.dialer" name="Phone" />
     <icon drawable="@drawable/dialer" package="com.oneplus.dialer" name="Phone" />
     <icon drawable="@drawable/dialer" package="com.samsung.android.dialer" name="Phone" />


### PR DESCRIPTION
Resolves #577
`com.asus.camera` was already in *grayscale_icon_map.xml*