### PR TITLE
link lineage os 20 camera to camera

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -123,6 +123,7 @@
     <icon drawable="@drawable/camera" package="org.codeaurora.qcamera3" name="Camera" />
     <icon drawable="@drawable/camera" package="org.codeaurora.snapcam" name="Camera" />
     <icon drawable="@drawable/camera" package="org.lineageos.snap" name="Camera" />
+    <icon drawable="@drawable/camera" package="org.lineageos.selfie" name="Camera" />
     <icon drawable="@drawable/camera" package="com.android.MGC_8_5_300" name="Camera" />
     <icon drawable="@drawable/catogram" package="org.nift4.catox" name="Catogram" />
     <icon drawable="@drawable/catogram" package="ua.itaysonlab.messenger" name="Catogram" />


### PR DESCRIPTION



:✓:Icon addition (non-breaking change that adds/modifies Lawnicons's icons)

### Icons linked
* Camera (linked `org.lineageos.selfie` to `@drawable/camera`)

