### PR TITLE
link feeder playstore version to feeder and revanced manager to youtube revanced

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -204,6 +204,7 @@
     <icon drawable="@drawable/fairemail" package="eu.faircode.email" name="FairEmail" />
     <icon drawable="@drawable/fdroid" package="org.fdroid.fdroid" name="F-Droid" />
     <icon drawable="@drawable/feeder" package="com.nononsenseapps.feeder" name="Feeder" />
+    <icon drawable="@drawable/feeder" package="com.nononsenseapps.feeder.play" name="Feeder" />
     <icon drawable="@drawable/files_by_google" package="com.google.android.apps.nbu.files" name="Files by Google" />
     <icon drawable="@drawable/files" package="com.android.documentsui" name="Files" />
     <icon drawable="@drawable/files" package="com.android.filemanager" name="File Manager" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -632,6 +632,7 @@
     <icon drawable="@drawable/ymusic" package="com.kapp.youtube.final" name="YMusic" />
     <icon drawable="@drawable/youtube_music" package="com.google.android.apps.youtube.music" name="YouTube Music" />
     <icon drawable="@drawable/youtube_revanced" package="app.revanced.android.youtube" name="YouTube ReVanced" />
+    <icon drawable="@drawable/youtube_revanced" package="app.revanced.manager.flutter" name="ReVanced Manager" />
     <icon drawable="@drawable/youtube_tv" package="com.google.android.apps.youtube.unplugged" name="YouTube TV" />
     <icon drawable="@drawable/youtube_vanced" package="com.vanced.android.youtube" name="YouTube Vanced" />
     <icon drawable="@drawable/youtube" package="com.google.android.youtube" name="YouTube" />


### PR DESCRIPTION
## Description

:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)


### Icons linked
* Feeder (linked `com.nononsenseapps.feeder.play` to `@drawable/feeder`)
* Revanced Manager (linked `app.revanced.manager.flutter` to `@drawable/youtube_revanced`)

