### PR TITLE
Link Burger King IE + NewPipe Legacy

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -411,6 +411,7 @@
     <icon drawable="@drawable/netzclub" package="com.telefonica.netzclub.csc" name="Netzclub" />
     <icon drawable="@drawable/newpipe" package="org.schabi.newpipe" name="NewPipe" />
     <icon drawable="@drawable/newpipe" package="org.polymorphicshade.newpipe" name="NewPipe" />
+    <icon drawable="@drawable/newpipe" package="org.schabi.newpipelegacy" name="NewPipe" />
     <icon drawable="@drawable/nextcloud" package="com.nextcloud.client" name="Nextcloud" />
     <icon drawable="@drawable/notenapp" package="com.notenapp" name="Notenapp" />
     <icon drawable="@drawable/ns" package="nl.ns.android.activity" name="NS" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -72,6 +72,7 @@
     <icon drawable="@drawable/burger_king" package="com.spoonstream.bklebanon" name="Burger King" />
     <icon drawable="@drawable/burger_king" package="com.tapston.burgerking" name="Burger King" />
     <icon drawable="@drawable/burger_king" package="com.tillster.bk_kw_mobile" name="Burger King" />
+    <icon drawable="@drawable/burger_king" package="ie.whopper.android" name="Burger King" />
     <icon drawable="@drawable/burger_king" package="in.burgerking.android" name="Burger King" />
     <icon drawable="@drawable/burger_king" package="it.burgerking.android" name="Burger King" />
     <icon drawable="@drawable/burger_king" package="jp.co.burgerkingjapan" name="Burger King" />


### PR DESCRIPTION
## Description
Links 2 packages to icons

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
### Icons linked
* Burger King Ireland (linked `ie.whopper.android` to `@drawable/burger_king`)
* NewPipe Legacy (linked `org.schabi.newpipelegacy` to `@drawable/newpipe`)
