### PR TITLE
Add icon for Scrambled Exif

### DIFF
--- a/app/src/main/res/drawable/scrambled_exif.xml
+++ b/app/src/main/res/drawable/scrambled_exif.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="50.8"
+    android:viewportHeight="50.8">
+  <path
+      android:pathData="M7.144,24.739a18.918,18.918 0,1 0,37.835 0a18.918,18.918 0,1 0,-37.835 0z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.17501"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M33.87,21.144m-8.996,0a8.996,8.996 0,1 1,17.992 0a8.996,8.996 0,1 1,-17.992 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.17492"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -525,6 +525,7 @@
     <icon drawable="@drawable/samsung_notes" package="com.samsung.android.app.notes" name="Samsung Notes" />
     <icon drawable="@drawable/schoolplanner" package="daldev.android.gradehelper" name="School Planner" />
     <icon drawable="@drawable/schulmanager" package="online.schulmanager.app" name="Schulmanager" />
+    <icon drawable="@drawable/scrambled_exif" package="com.jarsilio.android.scrambledeggsif" name="Scrambled Exif" />
     <icon drawable="@drawable/sennheiser_smart_control" package="com.sennheiser.control" name="Sennheiser Smart Control" />
     <icon drawable="@drawable/sensor_box" package="imoblife.androidsensorbox" name="Sensor Box" />
     <icon drawable="@drawable/settings" package="com.android.settings" name="Settings" />

--- a/svgs/scrambled_exif.svg
+++ b/svgs/scrambled_exif.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 50.799999 50.8"
+   version="1.1"
+   id="svg5"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs2" /><g
+     id="layer1"><ellipse
+       style="fill:none;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round"
+       id="path354"
+       cx="33.664082"
+       cy="21.394712"
+       rx="27.529398"
+       ry="20.321142" /><g
+       id="g1041"
+       transform="translate(-2.2992533,2.4200757)"><ellipse
+         style="fill:none;stroke:#000000;stroke-width:3.17501;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         id="path358"
+         cx="28.360712"
+         cy="22.318464"
+         rx="18.917704"
+         ry="18.917702" /><circle
+         style="fill:none;stroke:#000000;stroke-width:3.17492;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         id="path914"
+         cx="36.16959"
+         cy="18.723463"
+         r="8.9958706" /></g></g></svg>


### PR DESCRIPTION
## Description

Added icon for [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif).

Note that the icon is purposely not centered and anchored in the top-right corner of the 160x160 content area, similar to the [original icon](https://gitlab.com/juanitobananas/scrambled-exif/-/blob/master/fastlane/standard/metadata/android/en-US/images/icon.png). If it would be better to be centered instead (or perhaps scaled down so the offset is more obvious), let me know.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

## Icons addition information
### Icons added
* Scrambled Exif (`com.jarsilio.android.scrambledeggsif`)
