### PR TITLE
Add icons for GrapheneOS apps

### DIFF
--- a/app/src/main/res/drawable/grapheneos_apps.xml
+++ b/app/src/main/res/drawable/grapheneos_apps.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="50.8"
+    android:viewportHeight="50.8">
+  <path
+      android:pathData="M43.833,13.587 L25.4,21.377L25.4,45.003L43.833,37.213Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.128"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M43.833,13.587 L25.4,5.797 6.967,13.587 25.4,21.377Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.128"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M25.4,21.377 L6.967,13.587L6.967,37.213L25.4,45.003Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.128"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/grapheneos_auditor.xml
+++ b/app/src/main/res/drawable/grapheneos_auditor.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="50.8"
+    android:viewportHeight="50.8">
+  <path
+      android:pathData="M10.583,26.458H24.342V44.161"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m41.435,24.077h-14.976V6.35"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M23.946,6.134 L11.381,11.717c-1.292,0.574 -2.136,1.867 -2.136,3.285v8.437c0,9.963 6.893,19.279 16.156,21.541 9.263,-2.262 16.156,-11.578 16.156,-21.541v-8.437c0,-1.418 -0.844,-2.711 -2.136,-3.285L26.854,6.134c-0.915,-0.413 -1.993,-0.413 -2.908,0z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -299,6 +299,7 @@
     <icon drawable="@drawable/govee_home" package="com.govee.home" name="Govee Home" />
     <icon drawable="@drawable/grab" package="com.grabtaxi.driver2" name="Grab" />
     <icon drawable="@drawable/grab" package="com.grabtaxi.passenger" name="Grab" />
+    <icon drawable="@drawable/grapheneos_apps" package="app.grapheneos.apps" name="Apps" />
     <icon drawable="@drawable/hago" package="com.yy.hiyo" name="Hago" />
     <icon drawable="@drawable/hex_installer" package="project.vivid.hex.bodhi" name="Hex Installer" />
     <icon drawable="@drawable/ho" package="it.homobile.ho" name="ho." />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -300,6 +300,7 @@
     <icon drawable="@drawable/grab" package="com.grabtaxi.driver2" name="Grab" />
     <icon drawable="@drawable/grab" package="com.grabtaxi.passenger" name="Grab" />
     <icon drawable="@drawable/grapheneos_apps" package="app.grapheneos.apps" name="Apps" />
+    <icon drawable="@drawable/grapheneos_auditor" package="app.attestation.auditor" name="Auditor" />
     <icon drawable="@drawable/hago" package="com.yy.hiyo" name="Hago" />
     <icon drawable="@drawable/hex_installer" package="project.vivid.hex.bodhi" name="Hex Installer" />
     <icon drawable="@drawable/ho" package="it.homobile.ho" name="ho." />

--- a/svgs/grapheneos_apps.svg
+++ b/svgs/grapheneos_apps.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xml:space="preserve"
+   id="svg7618"
+   version="1.1"
+   viewBox="0 0 50.799999 50.8"
+   height="192"
+   width="192"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs7615" /><g
+     id="layer1"><g
+       transform="matrix(0.26067701,0,0,0.26067701,25.4,25.400033)"
+       id="g17139"
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"><path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 70.7107,-45.3154 0,-15.4318 V 75.199 L 70.7107,45.3154 Z"
+         id="path17133" /><path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 70.7107,-45.3154 0,-75.199 -70.7107,-45.3154 0,-15.4318 Z"
+         id="path17135" /><path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 0,-15.4318 -70.7107,-45.3154 V 45.3154 L 0,75.199 Z"
+         id="path17137" /></g></g></svg>

--- a/svgs/grapheneos_auditor.svg
+++ b/svgs/grapheneos_auditor.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 50.799999 50.8"
+   version="1.1"
+   id="svg18261"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs18258" /><g
+     id="layer1"><g
+       id="g20465"><path
+         id="path18443"
+         style="fill:none;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round"
+         d="M 10.583333,26.458333 H 24.341666 V 44.161208" /><path
+         id="path18443-6"
+         style="fill:none;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round"
+         d="m 41.434633,24.077083 h -14.9763 V 6.3499999" /><path
+         d="M 23.945994,6.1339496 11.380519,11.71661 c -1.292449,0.574422 -2.13613,1.866871 -2.13613,3.284977 v 8.436816 c 0,9.962625 6.89306,19.279031 16.155611,21.540815 9.26255,-2.261784 16.15561,-11.57819 16.15561,-21.540815 v -8.436816 c 0,-1.418106 -0.843681,-2.710555 -2.13613,-3.284977 L 26.854004,6.1339496 c -0.915486,-0.4128646 -1.992526,-0.4128646 -2.90801,0 z"
+         style="fill:none;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         id="path18454" /></g></g></svg>


### PR DESCRIPTION
## Description

Added icons for 2 apps [GrapheneOS](https://grapheneos.org/) comes preinstalled with: [Apps](https://github.com/GrapheneOS/Apps) and [Auditor](https://github.com/GrapheneOS/Auditor).

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
### Icons added
* Apps (`app.grapheneos.apps`)
* Auditor (`app.attestation.auditor`)