### PR TITLE
Link nextcloud dev to nextcloud

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -435,6 +435,7 @@
     <icon drawable="@drawable/newpipe" package="org.polymorphicshade.newpipe" name="NewPipe" />
     <icon drawable="@drawable/newpipe" package="org.schabi.newpipelegacy" name="NewPipe" />
     <icon drawable="@drawable/nextcloud" package="com.nextcloud.client" name="Nextcloud" />
+    <icon drawable="@drawable/nextcloud" package="com.nextcloud.android.beta" name="Nextcloud Dev" />
     <icon drawable="@drawable/notally" package="com.omgodse.notally" name="Notally" />
     <icon drawable="@drawable/notenapp" package="com.notenapp" name="Notenapp" />
     <icon drawable="@drawable/ns" package="nl.ns.android.activity" name="NS" />


### PR DESCRIPTION
## Description



## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)



### Icons linked
* Nextcloud Dev (linked `com.nextcloud.android.beta` to `@drawable/nextcloud`)
