### PR TITLE
Link AOSP FM Radio to FM Radio

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -250,6 +250,7 @@
     <icon drawable="drawable/flud" package="com.delphicoder.flud.paid" name="Flud" />
     <icon drawable="@drawable/flux" package="de.bendix.flux" name="Flux" />
     <icon drawable="@drawable/fm_radio" package="com.caf.fmradio" name="FM Radio" />
+    <icon drawable="@drawable/fm_radio" package="com.android.fmradio" name="FM Radio" />
     <icon drawable="@drawable/focus_todo" package="com.superelement.pomodoro" name="Focus To-Do" />
     <icon drawable="@drawable/fortnite" package="com.epicgames.fortnite" name="Fortnite" />
     <icon drawable="@drawable/fox_mmm" package="com.fox2code.mmm" name="Fox's Magisk Module Manager" />


### PR DESCRIPTION
## Description


## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)


## Icons addition information

### Icons linked
* FM Radio (linked `com.android.fmradio` to `@drawable/fm_radio`)
