### PR TITLE
Migrate Kapt to Napt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ import java.util.Properties
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.kapt")
+    id("com.sergei-lapin.napt")
     id("dagger.hilt.android.plugin")
     id("com.google.android.gms.oss-licenses-plugin")
 }
@@ -109,7 +109,7 @@ dependencies {
     implementation("com.google.accompanist:accompanist-navigation-animation:$accompanistVersion")
     implementation("com.github.fornewid:material-motion-compose:0.8.0-beta01")
     implementation("com.google.dagger:hilt-android:$hiltVersion")
-    kapt("com.google.dagger:hilt-android-compiler:$hiltVersion")
+    annotationProcessor("com.google.dagger:hilt-android-compiler:$hiltVersion")
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
     implementation("com.github.LawnchairLauncher:oss-notices:1.0.2")
     implementation("io.coil-kt:coil-compose:2.2.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,12 +50,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     buildFeatures {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,6 @@ android {
         targetSdk = 31
         versionCode = 2
         versionName = "1.1.0"
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     val lifecycleVersion = "2.5.1"
     val composeVersion = "1.2.1"
     val accompanistVersion = "0.25.1"
-    val hiltVersion = "2.43.2"
+    val hiltVersion = "2.44"
     val retrofitVersion = "2.9.0"
 
     implementation("androidx.core:core-ktx:1.9.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,8 @@ android {
     }
 }
 
+hilt.enableAggregatingTask = false
+
 dependencies {
     val lifecycleVersion = "2.5.1"
     val composeVersion = "1.2.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application") version "7.3.0" apply false
     id("com.android.library") version "7.3.0" apply false
     id("org.jetbrains.kotlin.android") version "1.7.10" apply false
+    id("com.sergei-lapin.napt") version "1.17" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false
     id("com.google.android.gms.oss-licenses-plugin") version "0.10.5" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application") version "7.3.0" apply false
     id("com.android.library") version "7.3.0" apply false
     id("org.jetbrains.kotlin.android") version "1.7.10" apply false
-    id("com.google.dagger.hilt.android") version "2.43.2" apply false
+    id("com.google.dagger.hilt.android") version "2.44" apply false
     id("com.google.android.gms.oss-licenses-plugin") version "0.10.5" apply false
 }
 


### PR DESCRIPTION
## Description

Migrate to Napt to avoid sutb generating, once Hilt support support KSP we can migrate to it.

Ref https://github.com/chrisbanes/tivi/pull/951.

https://github.com/sergei-lapin/napt
https://github.com/google/dagger/releases/tag/dagger-2.44

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
### Icons added
* App Name (`package.name`)
* App Name (`package.name`)

### Icons updated
* App Name (`package.name`)
* App Name (`package.name`)

### Icons linked
* App Name (linked `package.name` to `@drawable/package`)
* App Name (linked `package.name` to `@drawable/package`)
