### PR TITLE
Several icons added

### DIFF
--- a/app/src/main/res/drawable/asos.xml
+++ b/app/src/main/res/drawable/asos.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M96,96m-74,0a74,74 0,1 1,148 0a74,74 0,1 1,-148 0"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:pathData="M116,98.5C116,112.32 105.42,123 93,123C80.58,123 70,112.32 70,98.5C70,84.68 80.58,74 93,74C105.42,74 116,84.68 116,98.5Z"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:pathData="M116,75L116,122"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/black_screen.xml
+++ b/app/src/main/res/drawable/black_screen.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M53,22h86.95v148h-86.95z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/oxygen_updater.xml
+++ b/app/src/main/res/drawable/oxygen_updater.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M33,85H69.26V138.5H122.75V85H159.01L96,22L33,85Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M40.13,170H151.88"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/roblox.xml
+++ b/app/src/main/res/drawable/roblox.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M29.88,57.55l103.97,-27.86l27.86,103.97l-103.97,27.86z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:pathData="M80,87l25.11,-6.73l6.73,25.11l-25.11,6.73z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/stats_fm.xml
+++ b/app/src/main/res/drawable/stats_fm.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M39,71.87L39,170"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M96,22L96,170"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M153,116.91L153,170"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/stocard.xml
+++ b/app/src/main/res/drawable/stocard.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M79.76,48.38L67.9,36.52L22,82.41L49.33,109.74L123.07,36L170,82.93L96.26,156.67L68.93,129.34"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M124,82m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/white_border.xml
+++ b/app/src/main/res/drawable/white_border.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M44,44m-14,0a14,14 0,1 1,28 0a14,14 0,1 1,-28 0"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:pathData="M70,66L22,153H118L70,66Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M56,153H170L113,50L87.82,95.5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/zepp_life.xml
+++ b/app/src/main/res/drawable/zepp_life.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M93,99m-71,0a71,71 0,1 1,142 0a71,71 0,1 1,-142 0"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:pathData="M142,50m-28,0a28,28 0,1 1,56 0a28,28 0,1 1,-56 0"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -554,6 +554,7 @@
     <icon drawable="@drawable/ovo" package="ovo.id" name="OVO" />
     <icon drawable="@drawable/owlgram" package="it.owlgram.android" name="OwlGram" />
     <icon drawable="@drawable/oxigen_hd" package="com.cris87.oxygen" name="Oxigen HD" />
+    <icon drawable="@drawable/oxygen_updater" package="com.arjanvlek.oxygenupdater" name="Oxygen Updater" />
     <icon drawable="@drawable/package_manager" package="sarangal.packagemanager" name="Package Manager" />
     <icon drawable="@drawable/pager_duty" package="com.pagerduty.android" name="Pager Duty" />
     <icon drawable="@drawable/parsec" package="tv.parsec.client" name="Parsec" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -658,6 +658,7 @@
     <icon drawable="@drawable/retro_music" package="io.github.muntashirakon.Music" name="Metro" />
     <icon drawable="@drawable/revolut" package="com.revolut.revolut" name="Revolut" />
     <icon drawable="@drawable/riot_mobile" package="com.riotgames.mobile.leagueconnect" name="Riot Mobile" />
+    <icon drawable="@drawable/roblox" package="com.roblox.client" name="Roblox" />
     <icon drawable="@drawable/rockman_x_dive" package="tw.com.capcom.rxd" name="ROCKMAN X DiVE" />
     <icon drawable="@drawable/roku" package="com.roku.remote" name="Roku" />
     <icon drawable="@drawable/s_pushtan" package="com.starfinanz.mobile.android.pushtan" name="S-pushTAN" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -730,6 +730,7 @@
     <icon drawable="@drawable/spotify" package="com.spotify.music" name="Spotify" />
     <icon drawable="@drawable/squircle" package="com.blacksquircle.ui" name="Squircle IDE" />
     <icon drawable="@drawable/standard_notes" package="com.standardnotes" name="Standard Notes" />
+    <icon drawable="@drawable/stats_fm" package="dev.netlob.spotistats" name="Stats.fm" />
     <icon drawable="@drawable/stealth" package="com.cosmos.unreddit" name="Stealth" />
     <icon drawable="@drawable/steam" package="com.valvesoftware.android.steam.community" name="Steam" />
     <icon drawable="@drawable/steam_link" package="com.valvesoftware.steamlink" name="Steam Link" />
@@ -808,6 +809,7 @@
     <icon drawable="@drawable/wear_os" package="com.google.android.wearable.app" name="Wear OS" />
     <icon drawable="@drawable/wear" package="com.samsung.android.app.watchmanager" name="Samsung Wear" />
     <icon drawable="@drawable/weather" package="com.miui.weather2" name="Weather" />
+    <icon drawable="drawable/weather" package="net.oneplus.weather" name="Weather" />
     <icon drawable="@drawable/wetter_online" package="de.wetteronline.wetterapp" name="Wetter Online" />
     <icon drawable="@drawable/wetter_online" package="de.wetteronline.wetterapppro" name="Wetter Online" />
     <icon drawable="@drawable/whatsapp_business" package="com.whatsapp.w4b" name="WhatsApp Business" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -47,6 +47,7 @@
     <icon drawable="@drawable/binance" package="com.binance.dev" name="Binance" />
     <icon drawable="@drawable/binary_eye" package="de.markusfisch.android.binaryeye" name="Binary Eye" />
     <icon drawable="@drawable/bitwarden" package="com.x8bit.bitwarden" name="Bitwarden" />
+    <icon drawable="@drawable/black_screen" package="io.japp.blackscreen" name="Black Screen" />
     <icon drawable="@drawable/blokada" package="org.blokada.alarm.dnschanger" name="Blokada" />
     <icon drawable="@drawable/blokada" package="org.blokada.fem.fdroid" name="Blokada" />
     <icon drawable="@drawable/bloons_td_6" package="com.ninjakiwi.bloonstd6" name="Bloons TD 6" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -844,5 +844,6 @@
     <icon drawable="@drawable/zalando" package="de.zalando.mobile" name="Zalando" />
     <icon drawable="@drawable/zara" package="com.inditex.zara" name="Zara" />
     <icon drawable="@drawable/zarchiver" package="ru.zdevs.zarchiver" name="ZArchiver" />
+    <icon drawable="@drawable/zepp_life" package="com.xiaomi.hm.health" name="Zepp Life" />
     <icon drawable="@drawable/zoom" package="us.zoom.videomeetings" name="Zoom" />
 </icons>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -815,6 +815,7 @@
     <icon drawable="@drawable/wetter_online" package="de.wetteronline.wetterapppro" name="Wetter Online" />
     <icon drawable="@drawable/whatsapp_business" package="com.whatsapp.w4b" name="WhatsApp Business" />
     <icon drawable="@drawable/whatsapp" package="com.whatsapp" name="WhatsApp" />
+    <icon drawable="@drawable/white_border" package="com.vector123.whiteborder" name="White Border" />
     <icon drawable="@drawable/who_touched_my_phone" package="com.wtmp.svdsoftware" name="WTMP - Who touched my phone?" />
     <icon drawable="@drawable/wikipedia" package="org.wikipedia" name="Wikipedia" />
     <icon drawable="@drawable/wild_rift" package="com.riotgames.league.wildrift" name="Wild Rift" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -739,6 +739,7 @@
     <icon drawable="@drawable/steam" package="com.valvesoftware.android.steam.community" name="Steam" />
     <icon drawable="@drawable/steam_link" package="com.valvesoftware.steamlink" name="Steam Link" />
     <icon drawable="@drawable/stellio" package="io.stellio.music" name="Stellio" />
+    <icon drawable="drawable/stocard" package="de.stocard.stocard" name="Stocard" />
     <icon drawable="@drawable/strava" package="com.strava" name="Strava" />
     <icon drawable="@drawable/streetcomplete" package="de.westnordost.streetcomplete" name="StreetComplete" />
     <icon drawable="@drawable/stremio" package="com.stremio.one" name="Stremio" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -32,6 +32,7 @@
     <icon drawable="@drawable/application_inspector" package="com.ubqsoft.sec01" name="Application Inspector" />
     <icon drawable="@drawable/ar_zone" package="com.samsung.android.arzone" name="AR Zone" />
     <icon drawable="@drawable/asana" package="com.asana.app" name="Asana" />
+    <icon drawable="@drawable/asos" package="com.asos.app" name="Asos" />
     <icon drawable="@drawable/audiofx" package="org.lineageos.audiofx" name="AudioFX" />
     <icon drawable="@drawable/aurora_droid" package="com.aurora.adroid" name="Aurora Droid" />
     <icon drawable="@drawable/aurora_store" package="com.aurora.store" name="Aurora Store" />

--- a/svgs/asos.svg
+++ b/svgs/asos.svg
@@ -1,0 +1,5 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="96" cy="96" r="74" stroke="black" stroke-width="12"/>
+<path d="M116 98.5C116 112.32 105.421 123 93 123C80.579 123 70 112.32 70 98.5C70 84.6803 80.579 74 93 74C105.421 74 116 84.6803 116 98.5Z" stroke="black" stroke-width="12"/>
+<path d="M116 75L116 122" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/svgs/black_screen.svg
+++ b/svgs/black_screen.svg
@@ -1,0 +1,3 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="53" y="22" width="86.95" height="148" stroke="black" stroke-width="12" stroke-linejoin="round"/>
+</svg>

--- a/svgs/oxygen_updater.svg
+++ b/svgs/oxygen_updater.svg
@@ -1,0 +1,4 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M33 85.004H69.257V138.498H122.751V85.004H159.008L96.004 22L33 85.004Z" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M40.1326 170H151.876" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/svgs/roblox.svg
+++ b/svgs/roblox.svg
@@ -1,0 +1,4 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="29.8787" y="57.5487" width="107.634" height="107.634" transform="rotate(-15 29.8787 57.5487)" stroke="black" stroke-width="12" stroke-linejoin="round"/>
+<rect x="80" y="87" width="26" height="26" transform="rotate(-15 80 87)" stroke="black" stroke-width="12" stroke-linejoin="round"/>
+</svg>

--- a/svgs/stats_fm.svg
+++ b/svgs/stats_fm.svg
@@ -1,0 +1,5 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M39 71.8696L39 170" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M96 22L96 170" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M153 116.913L153 170" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/svgs/stocard.svg
+++ b/svgs/stocard.svg
@@ -1,0 +1,4 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M79.7561 48.3763L67.8955 36.5157L22 82.4112L49.331 109.742L123.073 36L170 82.9268L96.2578 156.669L68.9268 129.338" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="124" cy="82" r="12" fill="black"/>
+</svg>

--- a/svgs/white_border.svg
+++ b/svgs/white_border.svg
@@ -1,0 +1,5 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="44" cy="44" r="14" stroke="black" stroke-width="12"/>
+<path d="M70 66L22 153H118L70 66Z" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M56 153H170L113 50L87.8204 95.5" stroke="black" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/svgs/zepp_life.svg
+++ b/svgs/zepp_life.svg
@@ -1,0 +1,4 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="93" cy="99" r="71" stroke="black" stroke-width="12"/>
+<circle cx="142" cy="50" r="28" stroke="black" stroke-width="12"/>
+</svg>


### PR DESCRIPTION
## Description
All fairly simple shapes
## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
### Icons added
* Stats.fm (`dev.netlob.spotistats`)
* Roblox (`com.roblox.client`)
* Black Screen (`io.japp.blackscreen`)
* Oxygen Updater (`com.arjanvlek.oxygenupdater`)
* Zepp Life (`com.xiaomi.hm.health`)
* Asos (`com.asos.app`)
* Stocard (`de.stocard.stocard`)
* White Border (`com.vector123.whiteborder`)

### Icons Linked
* Linked `weather.svg` to `net.oneplus.weather`

