### PR TITLE
Link deepl and threema apps

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -216,8 +216,8 @@
     <icon drawable="@drawable/davx5" package="at.bitfire.davdroid" name="DAVx5" />
     <icon drawable="@drawable/db_navigator" package="de.hafas.android.db" name="DB Navigator" />
     <icon drawable="@drawable/deepl" package="com.deepl.mobiletranslator" name="DeepL" />
-    <icon drawable="@drawable/deepl" package="com.jamal2367.deepl" name="DeepL" />
     <icon drawable="@drawable/deepl" package="com.example.deeplviewer" name="DeepL" />
+    <icon drawable="@drawable/deepl" package="com.jamal2367.deepl" name="DeepL" />
     <icon drawable="@drawable/deezer" package="deezer.android.app" name="Deezer" />
     <icon drawable="@drawable/deezer" package="f.f.freezer" name="Freezer" />
     <icon drawable="@drawable/degiro" package="nl.degiro.trader" name="DEGIRO" />
@@ -860,8 +860,8 @@
     <icon drawable="@drawable/theathletic" package="com.theathletic" name="The Athletic" />
     <icon drawable="@drawable/themes" package="com.android.thememanager" name="Themes" />
     <icon drawable="@drawable/threema" package="ch.threema.app" name="Threema" />
-    <icon drawable="@drawable/threema" package="ch.threema.app.hws" name="Threema" />
     <icon drawable="@drawable/threema" package="ch.threema.app.fdroid" name="Threema" />
+    <icon drawable="@drawable/threema" package="ch.threema.app.hws" name="Threema" />
     <icon drawable="@drawable/threema" package="ch.threema.app.libre" name="Threema Libre" />
     <icon drawable="@drawable/ticktick" package="com.ticktick.task" name="TickTick" />
     <icon drawable="@drawable/tidal" package="com.aspiro.tidal" name="Tidal" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -216,6 +216,8 @@
     <icon drawable="@drawable/davx5" package="at.bitfire.davdroid" name="DAVx5" />
     <icon drawable="@drawable/db_navigator" package="de.hafas.android.db" name="DB Navigator" />
     <icon drawable="@drawable/deepl" package="com.deepl.mobiletranslator" name="DeepL" />
+    <icon drawable="@drawable/deepl" package="com.jamal2367.deepl" name="DeepL" />
+    <icon drawable="@drawable/deepl" package="com.example.deeplviewer" name="DeepL" />
     <icon drawable="@drawable/deezer" package="deezer.android.app" name="Deezer" />
     <icon drawable="@drawable/deezer" package="f.f.freezer" name="Freezer" />
     <icon drawable="@drawable/degiro" package="nl.degiro.trader" name="DEGIRO" />
@@ -858,6 +860,8 @@
     <icon drawable="@drawable/theathletic" package="com.theathletic" name="The Athletic" />
     <icon drawable="@drawable/themes" package="com.android.thememanager" name="Themes" />
     <icon drawable="@drawable/threema" package="ch.threema.app" name="Threema" />
+    <icon drawable="@drawable/threema" package="ch.threema.app.hws" name="Threema" />
+    <icon drawable="@drawable/threema" package="ch.threema.app.fdroid" name="Threema" />
     <icon drawable="@drawable/threema" package="ch.threema.app.libre" name="Threema Libre" />
     <icon drawable="@drawable/ticktick" package="com.ticktick.task" name="TickTick" />
     <icon drawable="@drawable/tidal" package="com.aspiro.tidal" name="Tidal" />


### PR DESCRIPTION
## Description

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

## Icons addition information

### Icons linked
* DeepL (linked `com.jamal2367.deepl` to `@drawable/deepl`)
* DeepL (linked `com.example.deeplviewer` to `@drawable/deepl`)
* Threema (linked `ch.threema.app.hws` to `@drawable/threema`)
* Threema (linked `ch.threema.app.fdroid` to `@drawable/threema`)
