### PR TITLE
Link blokada v4 ,v5 and v6 to blokada

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -59,6 +59,9 @@
     <icon drawable="@drawable/blockinger" package="org.blockinger.game" name="Blockinger" />
     <icon drawable="@drawable/blokada" package="org.blokada.alarm.dnschanger" name="Blokada" />
     <icon drawable="@drawable/blokada" package="org.blokada.fem.fdroid" name="Blokada" />
+    <icon drawable="@drawable/blokada" package="org.blokada.fyra" name="Blokada" />
+    <icon drawable="@drawable/blokada" package="org.blokada.origin.alarm" name="Blokada" />
+    <icon drawable="@drawable/blokada" package="org.blokada.sex" name="Blokada" />
     <icon drawable="@drawable/bloons_td_6" package="com.ninjakiwi.bloonstd6" name="Bloons TD 6" />
     <icon drawable="@drawable/bni_mobile" package="src.com.bni" name="BNI Mobile Banking" />
     <icon drawable="@drawable/boi" package="com.bankofireland.mobilebanking" name="BOI Mobile" />


### PR DESCRIPTION
## Description


## Type of change


:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)


### Icons linked
* Blokada 6 (linked `org.blokada.sex` to `@drawable/blokada`)
* Blokada 5 (linked `org.blokada.origin.alarm` to `@drawable/blokada`)
* Blokada 4 (linked `org.blokada.fyra` to `@drawable/blokada`)
