### PR TITLE
Add Etar Calender

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -118,6 +118,7 @@
     <icon drawable="@drawable/calendar" package="com.samsung.android.calendar" name="Calendar" />
     <icon drawable="@drawable/calendar" package="foundation.e.calendar" name="Calendar" />
     <icon drawable="@drawable/calendar" package="com.appgenix.bizcal" name="Calendar" />
+    <icon drawable="@drawable/calendar" package="ws.xsoh.etar" name="Calendar" />
     <icon drawable="@drawable/calculator" package="com.android.bbkcalculator" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.android.calculator2" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.google.android.calculator" name="Calculator" />


### PR DESCRIPTION
## Description

Add Icon for [Etar](https://f-droid.org/en/packages/ws.xsoh.etar/): `<icon** drawable="@drawable/calendar" package="ws.xsoh.etar" name="Calendar" />`

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information

### Icons linked
* App Name (linked `@drawable/calendar` to `ws.xsoh.etar`)
