### PR TITLE
Added links for motorola recorder app

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -748,6 +748,7 @@
     <icon drawable="@drawable/raindrop" package="io.raindrop.raindropio" name="Raindrop" />
     <icon drawable="@drawable/recorder" package="com.android.bbksoundrecorder" name="Recorder" />
     <icon drawable="@drawable/recorder" package="com.android.soundrecorder" name="Recorder" />
+    <icon drawable="@drawable/recorder" package="com.motorola.audiorecorder" name="Recorder" />
     <icon drawable="@drawable/recorder" package="com.google.android.apps.recorder" name="Recorder" />
     <icon drawable="@drawable/recorder" package="com.oneplus.soundrecorder" name="Recorder" />
     <icon drawable="@drawable/recorder" package="com.sec.android.app.voicenote" name="Recorder" />


### PR DESCRIPTION
## Description
Added a link to the motorola recorder app.

## Type of change
❌ Bug fix (non-breaking change which fixes an issue)
✅ Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
❌ General change (non-breaking change that doesn't fit the above categories like copyediting)

## Icons addition information

### Icons linked
* App Name (linked `com.motorola.audiorecorder` to `@drawable/recorder`)
