### PR TITLE
Link calendar icon to lineageos calendar

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -122,6 +122,7 @@
     <icon drawable="@drawable/calendar" package="com.samsung.android.calendar" name="Calendar" />
     <icon drawable="@drawable/calendar" package="foundation.e.calendar" name="Calendar" />
     <icon drawable="@drawable/calendar" package="com.appgenix.bizcal" name="Calendar" />
+    <icon drawable="@drawable/calendar" package="org.lineageos.etar" name="Calendar" />
     <icon drawable="@drawable/calendar" package="ws.xsoh.etar" name="Calendar" />
     <icon drawable="@drawable/calculator" package="com.android.bbkcalculator" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.android.calculator2" name="Calculator" />


### PR DESCRIPTION
## Description
Link calendar icon to lineageos calendar
<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
 linked

* Calendar (linked `org.lineageos.etar` to `@drawable/calendar`)
