### PR TITLE
Link Oneplus Note app, Ready app

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -629,6 +629,7 @@
     <icon drawable="@drawable/notally" package="com.omgodse.notally" name="Notally" />
     <icon drawable="@drawable/notenapp" package="com.notenapp" name="Notenapp" />
     <icon drawable="@drawable/notes" package="com.miui.notes" name="Notes" />
+    <icon drawable="@drawable/notes" package="com.oneplus.note" name="Notes" />
     <icon drawable="@drawable/ns" package="nl.ns.android.activity" name="NS" />
     <icon drawable="@drawable/nubank" package="com.nu.production" name="Nubank" />
     <icon drawable="@drawable/obimy" package="com.empat.wory" name="Obimy" />
@@ -769,6 +770,7 @@
     <icon drawable="@drawable/recorder" package="org.lineageos.recorder" name="Recorder" />
     <icon drawable="@drawable/redbus" package="in.redbus.android" name="RedBus" />
     <icon drawable="@drawable/reddit" package="com.reddit.frontpage" name="Reddit" />
+    <icon drawable="@drawable/reddit" package="com.devgary.ready" name="Ready" />
     <icon drawable="@drawable/relay" package="free.reddit.news" name="Relay" />
     <icon drawable="@drawable/relay" package="reddit.news" name="Relay" />
     <icon drawable="@drawable/repainter" package="dev.kdrag0n.dyntheme" name="Repainter" />


### PR DESCRIPTION
## Description

- Linked com.oneplus.note to drawable/notes
- Linked com.devgary.ready to drawable/reddit


## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
:heavy_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information

### Icons linked
* App Name (linked `com.oneplus.note` to `@drawable/notes`)
* App Name (linked `com.devgary.ready` to `@drawable/reddit`)
