### PR TITLE
Link another Nextcloud Cookbook

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -220,6 +220,7 @@
     <icon drawable="@drawable/contacts" package="com.simplemobiletools.contacts.pro" name="Simple Contacts Pro" />
     <icon drawable="@drawable/contacts" package="com.simplemobiletools.contacts" name="Simple Contacts" />
     <icon drawable="@drawable/cookbook" package="com.nextcloud_cookbook_flutter" name="Nextcloud Cookbook" />
+    <icon drawable="@drawable/cookbook" package="de.micmun.android.nextcloudcookbook" name="Nextcloud Cookbook" />
     <icon drawable="@drawable/coolors" package="co.coolors.android" name="Coolors" />
     <icon drawable="@drawable/corona_tracing" package="de.corona.tracing" name="Corona Tracing" />
     <icon drawable="@drawable/corona_warn" package="de.rki.coronawarnapp" name="Corona-Warn" />


### PR DESCRIPTION
## Description


## Type of change


:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

## Icons addition information

### Icons linked
* Nextcloud Cookbook (linked `de.micmun.android.nextcloudcookbook` to `@drawable/cookbook`)
