### PR TITLE
Link Neo Backup, Neo Store

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -648,7 +648,9 @@
     <icon drawable="@drawable/nekogram" package="nekox.messenger" name="Nekogram" />
     <icon drawable="@drawable/nekogram" package="tw.nekomimi.nekogram" name="Nekogram" />
     <icon drawable="@drawable/neo_backup" package="com.machiav3lli.backup" name="Neo Backup" />
-    <icon drawable="@drawable/neo_store" package="com.machiav3lli.fdroid" name="Neo Store" />
+	<icon drawable="@drawable/neo_backup" package="com.machiav3lli.backup.neo" name="Neo Backup" />
+	<icon drawable="@drawable/neo_store" package="com.machiav3lli.fdroid" name="Neo Store" />
+	<icon drawable="@drawable/neo_store" package="com.machiav3lli.fdroid.neo" name="Neo Store" />
     <icon drawable="@drawable/netflix" package="com.netflix.mediaclient" name="Netflix" />
     <icon drawable="@drawable/netguard" package="eu.faircode.netguard" name="NetGuard" />
     <icon drawable="@drawable/netzclub" package="com.telefonica.netzclub.csc" name="Netzclub" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -648,9 +648,9 @@
     <icon drawable="@drawable/nekogram" package="nekox.messenger" name="Nekogram" />
     <icon drawable="@drawable/nekogram" package="tw.nekomimi.nekogram" name="Nekogram" />
     <icon drawable="@drawable/neo_backup" package="com.machiav3lli.backup" name="Neo Backup" />
-	<icon drawable="@drawable/neo_backup" package="com.machiav3lli.backup.neo" name="Neo Backup" />
-	<icon drawable="@drawable/neo_store" package="com.machiav3lli.fdroid" name="Neo Store" />
-	<icon drawable="@drawable/neo_store" package="com.machiav3lli.fdroid.neo" name="Neo Store" />
+	  <icon drawable="@drawable/neo_backup" package="com.machiav3lli.backup.neo" name="Neo Backup" />
+	  <icon drawable="@drawable/neo_store" package="com.machiav3lli.fdroid" name="Neo Store" />
+	  <icon drawable="@drawable/neo_store" package="com.machiav3lli.fdroid.neo" name="Neo Store" />
     <icon drawable="@drawable/netflix" package="com.netflix.mediaclient" name="Netflix" />
     <icon drawable="@drawable/netguard" package="eu.faircode.netguard" name="NetGuard" />
     <icon drawable="@drawable/netzclub" package="com.telefonica.netzclub.csc" name="Netzclub" />


### PR DESCRIPTION
## Description

Link another neo-store and neo-backup

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)


### Icons linked
* App Name (linked `com.machiav3lli.fdroid.neo` to `@drawable/neo_store`)
* App Name (linked `com.machiav3lli.backup.neo` to `@drawable/neo_backup`)
