### PR TITLE
Add notesnook

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -679,6 +679,7 @@
     <icon drawable="@drawable/notenapp" package="com.notenapp" name="Notenapp" />
     <icon drawable="@drawable/notes" package="com.miui.notes" name="Notes" />
     <icon drawable="@drawable/notes" package="com.oneplus.note" name="Notes" />
+    <icon drawable="@drawable/notesnook" package="com.streetwriters.notesnook" name="Notesnook" />
     <icon drawable="@drawable/notion" package="notion.id" name="Notion" />
     <icon drawable="@drawable/noto" package="com.noto" name="Noto" />
     <icon drawable="@drawable/ns" package="nl.ns.android.activity" name="NS" />


### PR DESCRIPTION
## Description
SVG and drawable xml are preset but no entry in grayscale.xml


## Type of change


:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

