### PR TITLE
Revert "Bump com.sergei-lapin.napt from 1.17 to 1.18"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application") version "7.3.1" apply false
     id("com.android.library") version "7.3.1" apply false
     id("org.jetbrains.kotlin.android") version "1.7.20" apply false
-    id("com.sergei-lapin.napt") version "1.18" apply false
+    id("com.sergei-lapin.napt") version "1.17" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false
     id("com.google.android.gms.oss-licenses-plugin") version "0.10.5" apply false
     id("org.jmailen.kotlinter") version "3.12.0" apply false


### PR DESCRIPTION
## Description

See https://github.com/LawnchairLauncher/lawnicons/pull/815#discussion_r1020803580

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories like copyediting)
