### PR TITLE
Link OpenCalc to calculator

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -138,6 +138,7 @@
     <icon drawable="@drawable/by_u" package="com.byu.id" name="by.U" />
     <icon drawable="@drawable/calculator" package="com.android.bbkcalculator" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.android.calculator2" name="Calculator" />
+    <icon drawable="@drawable/calculator" package="com.darkempire78.opencalculator" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.google.android.calculator" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.inator.calculator" name="Calculator" />
     <icon drawable="@drawable/calculator" package="com.miui.calculator" name="Calculator" />


### PR DESCRIPTION
## Description

https://github.com/Darkempire78/OpenCalc

## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)


### Icons linked
* OpenCalc (linked `com.darkempire78.opencalculator` to `@drawable/calculator`)

