### PR TITLE
Link 4 icons

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -321,6 +321,7 @@
     <icon drawable="@drawable/ebay_kleinanzeigen" package="com.ebay.kleinanzeigen" name="eBay Kleinanzeigen" />
     <icon drawable="@drawable/eight_ball_pool" package="com.miniclip.eightballpool" name="8 Ball Pool" />
     <icon drawable="@drawable/eksi_sozluk" package="com.eksiteknoloji.eksisozluk" name="ekşi sözlük" />
+    <icon drawable="@drawable/eksi_sozluk" package="com.drdisagree.iconify" name="Iconify" />
     <icon drawable="@drawable/electron" package="com.mahersafadi.electron" name="Electron" />
     <icon drawable="@drawable/element" package="im.vector.app" name="Element" />
     <icon drawable="@drawable/ella" package="rocks.poopjournal.Ella" name="Ella" />
@@ -452,6 +453,7 @@
     <icon drawable="@drawable/google_photos" package="com.google.android.apps.photos" name="Google Photos" />
     <icon drawable="@drawable/google_pixel_watch" package="com.google.android.apps.wear.companion" name="Google Pixel Watch" />
     <icon drawable="@drawable/google_play_books" package="com.google.android.apps.books" name="Google Play Books" />
+    <icon drawable="@drawable/google_play_books" package="com.foobnix.pro.pdf.reader" name="Librera FD" />
     <icon drawable="@drawable/google_play_games" package="com.google.android.play.games" name="Google Play Games" />
     <icon drawable="@drawable/google_play_store" package="com.android.vending" name="Google Play Store" />
     <icon drawable="@drawable/google_podcasts" package="com.google.android.apps.podcasts" name="Google Podcasts" />
@@ -678,6 +680,7 @@
     <icon drawable="@drawable/newpipe" package="org.schabi.newpipe.nightly" name="NewPipe" />
     <icon drawable="@drawable/newpipe" package="org.schabi.newpipelegacy" name="NewPipe" />
     <icon drawable="@drawable/news" package="co.appreactor.news" name="News / Nachrichten" />
+    <icon drawable="@drawable/news" package="com.asdoi.timetable" name="TimeTable" />
     <icon drawable="@drawable/nextcloud" package="com.nextcloud.android.beta" name="Nextcloud Dev" />
     <icon drawable="@drawable/nextcloud" package="com.nextcloud.client" name="Nextcloud" />
     <icon drawable="@drawable/nextcloud_deck" package="it.niedermann.nextcloud.deck" name="Deck" />
@@ -1012,6 +1015,7 @@
     <icon drawable="@drawable/tricount" package="com.trilab.tricount.android" name="Tricount" />
     <icon drawable="@drawable/trime" package="com.osfans.trime" name="Trime" />
     <icon drawable="@drawable/trust_wallet" package="com.wallet.crypto.trustapp" name="Trust Wallet" />
+    <icon drawable="@drawable/trust_wallet" package="app.fedilab.nitterizeme" name="UntrackMe" />
     <icon drawable="@drawable/turbotel" package="ellipi.messenger" name="TurboTel" />
     <icon drawable="@drawable/tutanota" package="de.tutao.tutanota" name="Tutanota" />
     <icon drawable="@drawable/tv_time" package="com.tozelabs.tvshowtime" name="TV Time" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -321,7 +321,7 @@
     <icon drawable="@drawable/ebay_kleinanzeigen" package="com.ebay.kleinanzeigen" name="eBay Kleinanzeigen" />
     <icon drawable="@drawable/eight_ball_pool" package="com.miniclip.eightballpool" name="8 Ball Pool" />
     <icon drawable="@drawable/eksi_sozluk" package="com.eksiteknoloji.eksisozluk" name="ekşi sözlük" />
-    <icon drawable="@drawable/eksi_sozluk" package="com.drdisagree.iconify" name="Iconify" />
+    <icon drawable="@drawable/eksi_sozluk" package="com.drdisagree.iconify" name="ekşi sözlük" />
     <icon drawable="@drawable/electron" package="com.mahersafadi.electron" name="Electron" />
     <icon drawable="@drawable/element" package="im.vector.app" name="Element" />
     <icon drawable="@drawable/ella" package="rocks.poopjournal.Ella" name="Ella" />
@@ -453,7 +453,7 @@
     <icon drawable="@drawable/google_photos" package="com.google.android.apps.photos" name="Google Photos" />
     <icon drawable="@drawable/google_pixel_watch" package="com.google.android.apps.wear.companion" name="Google Pixel Watch" />
     <icon drawable="@drawable/google_play_books" package="com.google.android.apps.books" name="Google Play Books" />
-    <icon drawable="@drawable/google_play_books" package="com.foobnix.pro.pdf.reader" name="Librera FD" />
+    <icon drawable="@drawable/google_play_books" package="com.foobnix.pro.pdf.reader" name="Google Play Books" />
     <icon drawable="@drawable/google_play_games" package="com.google.android.play.games" name="Google Play Games" />
     <icon drawable="@drawable/google_play_store" package="com.android.vending" name="Google Play Store" />
     <icon drawable="@drawable/google_podcasts" package="com.google.android.apps.podcasts" name="Google Podcasts" />
@@ -680,7 +680,7 @@
     <icon drawable="@drawable/newpipe" package="org.schabi.newpipe.nightly" name="NewPipe" />
     <icon drawable="@drawable/newpipe" package="org.schabi.newpipelegacy" name="NewPipe" />
     <icon drawable="@drawable/news" package="co.appreactor.news" name="News / Nachrichten" />
-    <icon drawable="@drawable/news" package="com.asdoi.timetable" name="TimeTable" />
+    <icon drawable="@drawable/news" package="com.asdoi.timetable" name="News / Nachrichten" />
     <icon drawable="@drawable/nextcloud" package="com.nextcloud.android.beta" name="Nextcloud Dev" />
     <icon drawable="@drawable/nextcloud" package="com.nextcloud.client" name="Nextcloud" />
     <icon drawable="@drawable/nextcloud_deck" package="it.niedermann.nextcloud.deck" name="Deck" />
@@ -1015,7 +1015,7 @@
     <icon drawable="@drawable/tricount" package="com.trilab.tricount.android" name="Tricount" />
     <icon drawable="@drawable/trime" package="com.osfans.trime" name="Trime" />
     <icon drawable="@drawable/trust_wallet" package="com.wallet.crypto.trustapp" name="Trust Wallet" />
-    <icon drawable="@drawable/trust_wallet" package="app.fedilab.nitterizeme" name="UntrackMe" />
+    <icon drawable="@drawable/trust_wallet" package="app.fedilab.nitterizeme" name="Trust Wallet" />
     <icon drawable="@drawable/turbotel" package="ellipi.messenger" name="TurboTel" />
     <icon drawable="@drawable/tutanota" package="de.tutao.tutanota" name="Tutanota" />
     <icon drawable="@drawable/tv_time" package="com.tozelabs.tvshowtime" name="TV Time" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -280,6 +280,7 @@
     <icon drawable="@drawable/dialer" package="com.sh.smart.caller" name="Phone" />
     <icon drawable="@drawable/dialer" package="com.truecaller" name="Phone" />
     <icon drawable="@drawable/dialer" package="jp.ad.iij.miodial" name="Phone" />
+    <icon drawable="@drawable/dialer" package="com.simplemobiletools.dialer" name="Phone" />
     <icon drawable="@drawable/digital_wellbeing" package="com.google.android.apps.wellbeing" name="Digital Wellbeing" />
     <icon drawable="@drawable/digital_wellbeing" package="com.samsung.android.forest" name="Digital Wellbeing" />
     <icon drawable="@drawable/discord" package="com.aliucord" name="Aliucord" />
@@ -611,6 +612,7 @@
     <icon drawable="@drawable/mi_freeform" package="com.sunshine.freeform" name="Mi Freeform" />
     <icon drawable="@drawable/mi_music" package="com.miui.player" name="Music" />
     <icon drawable="@drawable/mi_music" package="org.lineageos.eleven" name="Music" />
+    <icon drawable="@drawable/mi_music" package="com.zionhuang.music" name="InnerTune" />
     <icon drawable="@drawable/mi_remote" package="com.duokan.phone.remotecontroller" name="Mi Remote" />
     <icon drawable="@drawable/mi_video" package="com.miui.videoplayer" name="Mi Video" />
     <icon drawable="@drawable/microflux" package="com.constantin.microflux" name="Microflux" />
@@ -838,6 +840,7 @@
     <icon drawable="@drawable/recorder" package="com.sec.android.app.voicenote" name="Recorder" />
     <icon drawable="@drawable/recorder" package="org.lineageos.recorder" name="Recorder" />
     <icon drawable="@drawable/recorder" package="org.calyxos.recorder" name="Recorder" />
+    <icon drawable="@drawable/recorder" package="com.simplemobiletools.voicerecorder" name="Recorder" />
     <icon drawable="@drawable/redbus" package="in.redbus.android" name="RedBus" />
     <icon drawable="@drawable/reddit" package="com.devgary.ready" name="Ready" />
     <icon drawable="@drawable/reddit" package="com.reddit.frontpage" name="Reddit" />
@@ -978,6 +981,7 @@
     <icon drawable="@drawable/telegram" package="org.telegram.messenger.web" name="Telegram" />
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegram" name="Telegram X" />
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegramtwo" name="Telegram X" />
+    <icon drawable="@drawable/telegram" package="org.forkgram.messenger" name="Fork Client" />
     <icon drawable="@drawable/termux" package="com.termux" name="Termux" />
     <icon drawable="@drawable/textra" package="com.textra" name="Textra"/>
     <icon drawable="@drawable/the_battle_cats" package="jp.co.ponos.battlecatsen" name="The Battle Cats" />


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->

### Icons linked
* UntrackMe (linked `app.fedilab.nitterizeme` to `@drawable/trust_wallet`)
* TimeTable - a FOSS timetable app, icon looks very similar to the news glyph, even though the app has a different purpose (linked `com.asdoi.timetable` to `@drawable/news`)
* Librera Reader - not related to google, but icon looks very similar to google books glyph (linked `com.foobnix.pro.pdf.reader` to `@drawable/google_play_books`)
* Iconify - a FOSS UI customization app, again, totally unrelated to the original glyph but looks very similar (linked `com.drdisagree.iconify` to `@drawable/eksi_sozluk`)