### PR TITLE
Add 3 icons & fix Mullvad VPN icon

### DIFF
--- a/app/src/main/res/drawable/adidas.xml
+++ b/app/src/main/res/drawable/adidas.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="50.8"
+    android:viewportHeight="50.8">
+  <path
+      android:pathData="m5.821,35.64 l5.795,-3.336 2.919,5.081H6.853Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m15.565,26.215 l5.787,-3.332 8.37,14.502h-7.682z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m25.374,16.747 l5.787,-3.332 13.818,23.97h-7.682z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/geometry_dash.xml
+++ b/app/src/main/res/drawable/geometry_dash.xml
@@ -1,0 +1,54 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="50.8"
+    android:viewportHeight="50.8">
+  <path
+      android:pathData="m22.093,20.77 l2.646,2.646 -2.646,2.646 -2.646,-2.646z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.11666"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5.821,43.127H15.875l-5.08,-10.054z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M15.705,43.656H39.734"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.11666"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m28.046,14.817 l2.646,2.646 -2.646,2.646 -2.646,-2.646z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.11666"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m34.396,18.918 l2.646,2.646 -10.848,10.848 -2.646,-2.646z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.11666"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M28.707,7.673 L44.979,24.077 28.707,40.481 12.435,24.077Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/kicker.xml
+++ b/app/src/main/res/drawable/kicker.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="50.8"
+    android:viewportHeight="50.8">
+  <path
+      android:pathData="M9.062,5.821L19.513,5.821L19.513,28.707L27.583,19.05h13.494L29.17,31.353 41.738,44.979L27.98,44.979L19.513,34.793L19.513,44.979L9.062,44.979Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.175"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/mullvad_vpn.xml
+++ b/app/src/main/res/drawable/mullvad_vpn.xml
@@ -76,14 +76,6 @@
       android:fillType="evenOdd"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M25.4,12.239Z"
-      android:strokeLineJoin="round"
-      android:strokeWidth="3.175"
-      android:fillColor="#00000000"
-      android:strokeColor="#000000"
-      android:fillType="evenOdd"
-      android:strokeLineCap="round"/>
-  <path
       android:pathData="m27.137,8.067c1.163,-0.822 2.326,-1.644 3.586,-1.997 1.26,-0.353 2.616,-0.236 3.76,0.003 1.144,0.239 2.076,0.599 3.12,1.239 1.044,0.64 2.202,1.56 3.073,2.695 0.872,1.134 1.457,2.482 1.538,4.039 0.081,1.557 -0.344,3.323 -0.87,4.658 -0.526,1.335 -1.152,2.24 -1.509,2.966 -0.357,0.726 -0.445,1.274 -0.386,1.852 0.059,0.577 0.263,1.184 0.468,1.789"
       android:strokeLineJoin="round"
       android:strokeWidth="3.17498"

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -542,6 +542,7 @@
     <icon drawable="@drawable/keepassdx" package="com.kunzisoft.keepass.free" name="KeePassDX" />
     <icon drawable="@drawable/keepassdx" package="com.kunzisoft.keepass.libre" name="KeePassDX" />
     <icon drawable="@drawable/khan_academy" package="org.khanacademy.android" name="Khan Academy" />
+    <icon drawable="@drawable/kicker" package="com.netbiscuits.kicker" name="kicker" />
     <icon drawable="@drawable/kiwi_browser" package="com.kiwibrowser.browser" name="Kiwi Browser" />
     <icon drawable="@drawable/kiwi_browser" package="com.kiwibrowser.browser.dev" name="Kiwi Browser" />
     <icon drawable="@drawable/klck" package="org.kustom.lockscreen" name="KLCK" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -413,6 +413,7 @@
     <icon drawable="@drawable/genius" package="com.genius.android" name="Genius" />
     <icon drawable="@drawable/genshin_impact" package="com.miHoYo.GenshinImpact" name="Genshin Impact" />
     <icon drawable="@drawable/geometric_weather" package="wangdaye.com.geometricweather" name="Geometric Weather" />
+    <icon drawable="@drawable/geometry_dash" package="com.robtopx.geometryjump" name="Geometry Dash" />
     <icon drawable="@drawable/github" package="com.github.android" name="GitHub" />
     <icon drawable="@drawable/globeone" package="ph.com.globe.globeonesuperapp" name="GlobeOne" />
     <icon drawable="@drawable/gmail" package="com.google.android.gm" name="Gmail" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -5,6 +5,7 @@
     <icon drawable="@drawable/acronis_mobile" package="com.acronis.acronistrueimage" name="Acronis Mobile" />
     <icon drawable="@drawable/actionbound" package="de.actionbound" name="Actionbound" />
     <icon drawable="@drawable/adaway" package="org.adaway" name="AdAway" />
+    <icon drawable="@drawable/adidas" package="com.adidas.app" name="adidas" />
     <icon drawable="@drawable/adobe" package="com.adobe.reader" name="Adobe Acrobat Reader" />
     <icon drawable="@drawable/advanced_download_manager" package="com.dv.adm" name="Advanced Download Manager" />
     <icon drawable="@drawable/advanced_download_manager" package="com.dv.adm.pay" name="Advanced Download Manager" />

--- a/svgs/adidas.svg
+++ b/svgs/adidas.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 50.799999 50.8"
+   version="1.1"
+   id="svg5"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showgrid="false" /><defs
+     id="defs2" /><path
+     style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+     d="m 5.8206395,35.640069 5.7946865,-3.335726 2.919177,5.081081 H 6.8526021 Z"
+     id="path2091"
+     sodipodi:nodetypes="ccccc" /><path
+     style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+     d="m 15.565191,26.215481 5.787259,-3.332308 8.369856,14.502251 h -7.681901 z"
+     id="path5025"
+     sodipodi:nodetypes="ccccc" /><path
+     style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+     d="m 25.374307,16.746825 5.787258,-3.332309 13.81785,23.970086 h -7.681902 z"
+     id="path5027"
+     sodipodi:nodetypes="ccccc" /></svg>

--- a/svgs/geometry_dash.svg
+++ b/svgs/geometry_dash.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 50.799999 50.8"
+   version="1.1"
+   id="svg5"
+   xml:space="preserve"
+   inkscape:export-filename="geometry_dash.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showgrid="false" /><defs
+     id="defs2" /><path
+     id="rect1890"
+     style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none"
+     d="m 22.092755,20.76975 2.645917,2.645907 -2.645918,2.645906 -2.645917,-2.645906 z" /><path
+     style="display:inline;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.8207391,43.12708 H 15.874946 l -5.08002,-10.054166 z"
+     id="path965"
+     sodipodi:nodetypes="cccc" /><path
+     style="display:inline;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+     d="M 15.705018,43.656245 H 39.733791"
+     id="path1063"
+     sodipodi:nodetypes="cc" /><path
+     id="rect1081"
+     style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none"
+     d="m 28.04586,14.816625 2.645918,2.645908 -2.645918,2.645906 -2.645918,-2.645907 z" /><path
+     id="rect1087"
+     style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none"
+     d="m 34.395817,18.917667 2.645918,2.645908 -10.847967,10.847984 -2.645917,-2.645907 z"
+     sodipodi:nodetypes="ccccc" /><path
+     id="rect1092"
+     style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+     d="M 28.707288,7.6728524 44.979228,24.077084 28.707288,40.481249 12.435349,24.077084 Z"
+     sodipodi:nodetypes="ccccc" /></svg>

--- a/svgs/kicker.svg
+++ b/svgs/kicker.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 50.800001 50.8"
+   version="1.1"
+   id="svg5"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs2" /><g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-0.33062718)"><path
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="M 9.3927084,5.8208334 H 19.84375 V 28.707292 L 27.913542,19.05 h 13.49375 L 29.501042,31.353125 42.06875,44.979167 H 28.310417 L 19.84375,34.792709 V 44.979167 H 9.3927084 Z"
+       id="path3472" /></g></svg>

--- a/svgs/mullvad_vpn.svg
+++ b/svgs/mullvad_vpn.svg
@@ -134,9 +134,6 @@
        cy="16.089407"
        rx="1.5223016"
        ry="1.1315954" /><path
-       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
-       d="M 25.4,12.238917 Z"
-       id="path1151" /><path
        style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.17498;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
        d="m 27.136968,8.0671286 c 1.162987,-0.8220309 2.325896,-1.6440063 3.585639,-1.9966309 1.259744,-0.3526247 2.615953,-0.2359319 3.759941,0.00266 1.143989,0.2385878 2.075581,0.5989422 3.120033,1.2392869 1.044452,0.6403448 2.201668,1.5604951 3.073204,2.6945394 0.871535,1.134044 1.457439,2.481758 1.537985,4.038694 0.08055,1.556937 -0.344093,3.323039 -0.869662,4.658256 -0.525568,1.335216 -1.15201,2.239521 -1.50908,2.965874 -0.357069,0.726354 -0.444723,1.274499 -0.386116,1.85178 0.05861,0.577281 0.263329,1.183542 0.467948,1.789496"
        id="path1217"


### PR DESCRIPTION
## Description
I made icons for:
* [kicker](https://play.google.com/store/apps/details?id=com.netbiscuits.kicker&hl=en_GB&gl=US)
* [Geometry Dash](https://play.google.com/store/apps/details?id=com.robtopx.geometryjump&hl=en_GB&gl=US)
* [adidas](https://play.google.com/store/apps/details?id=com.adidas.app&hl=en_GB&gl=US)

and fixed a small error I noticed on the Mullvad VPN icon:
![mullvad_vpn_before](https://user-images.githubusercontent.com/104420015/202556427-c8b0c16a-7860-49cd-9bbc-2a16f614b158.svg)
![mullvad_vpn_after](https://user-images.githubusercontent.com/104420015/202556418-58b9ffe9-613e-4ed8-ab51-841fc0fcc74a.svg)

<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark:  Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->
### Icons added
* kicker (`com.netbiscuits.kicker`)
* Geometry Dash (`com.robtopx.geometryjump`)
* adidas (`com.adidas.app`)

### Icons updated
* Mullvad VPN (`net.mullvad.mullvadvpn`)

