### PR TITLE
Add icon link for Molly

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -933,6 +933,7 @@
     <icon drawable="@drawable/shopee" package="com.shopee.vn" name="Shopee" />
     <icon drawable="@drawable/showly" package="com.michaldrabik.showly2" name="Showly" />
     <icon drawable="@drawable/signal" package="org.thoughtcrime.securesms" name="Signal" />
+    <icon drawable="@drawable/signal" package="im.molly.app" name="Signal" />
     <icon drawable="@drawable/sim_toolkit" package="com.android.stk" name="SIM Toolkit" />
     <icon drawable="@drawable/simpl_pay" package="com.simpl.android" name="Simpl Pay Later" />
     <icon drawable="@drawable/simple_gallery" package="com.google.android.apps.wallpaper" name="Styles &amp; Wallpapers" />


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
✅ Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icon addition
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->

* App Name (`package.name`) - added from icon request form

### Icons linked
* Molly (linked `im.molly.app` to `@drawable/signal`)

Molly is a fork of Signal messenger, so I'm linking the Signal icon to it.