### PR TITLE
Add icon link for ViMusic

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -636,6 +636,7 @@
     <icon drawable="@drawable/mi_music" package="com.miui.player" name="Music" />
     <icon drawable="@drawable/mi_music" package="org.lineageos.eleven" name="Music" />
     <icon drawable="@drawable/mi_music" package="com.zionhuang.music" name="InnerTune" />
+    <icon drawable="@drawable/mi_music" package="it.vfsfitvnm.vimusic" name="Music" />
     <icon drawable="@drawable/mi_remote" package="com.duokan.phone.remotecontroller" name="Mi Remote" />
     <icon drawable="@drawable/mi_video" package="com.miui.videoplayer" name="Mi Video" />
     <icon drawable="@drawable/microflux" package="com.constantin.microflux" name="Microflux" />


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
✅  Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->

### Icons linked
* ViMusic (linked `it.vfsfitvnm.vimusic` to `@drawable/mi_music`)
