### PR TITLE
Add icon for Bandcamp

### DIFF
--- a/app/src/main/res/drawable/bandcamp.xml
+++ b/app/src/main/res/drawable/bandcamp.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="m170.01,51.41 l-41.11,89.36 -106.9,-0.42 40.99,-89.13z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -58,6 +58,7 @@
     <icon drawable="@drawable/axisnet" package="com.axis.net" name="AXISnet" />
     <icon drawable="@drawable/babbel" package="com.babbel.mobile.android.en" name="Babbel" />
     <icon drawable="@drawable/backdrops" package="com.backdrops.wallpapers" name="Backdrops" />
+    <icon drawable="@drawable/bandcamp" package="com.bandcamp.android" name="Bandcamp" />
     <icon drawable="@drawable/bandlab" package="com.bandlab.bandlab" name="BandLab" />
     <icon drawable="@drawable/bandsintown" package="com.bandsintown" name="Bandsintown" />
     <icon drawable="@drawable/bank_jago" package="com.jago.digitalbanking" name="Jago" />

--- a/svgs/bandcamp.svg
+++ b/svgs/bandcamp.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="192" height="192" version="1.1" viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
+ <path d="m170.01 51.408-41.111 89.365-106.9-0.41928 40.992-89.125z" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="15" stroke-width="12" style="paint-order:markers stroke fill"/>
+</svg>


### PR DESCRIPTION
## Description

Adding icon for music app bandcamp.

## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

### Icons added
* App Name (`com.bandcamp.android`)

### Icons linked
* App Name (linked `com.bandcamp.android` to `@drawable/bandcamp`)
