### PR TITLE
Add another vodafone link

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -630,6 +630,7 @@
     <icon drawable="@drawable/meinvodafone" package="com.VodafoneIreland.MyVodafone" name="MeinVodafone / My Vodafone" />
     <icon drawable="@drawable/meinvodafone" package="com.myvodafoneapp" name="MeinVodafone / My Vodafone" />
     <icon drawable="@drawable/meinvodafone" package="com.vodafone.android" name="MeinVodafone / My Vodafone" />
+    <icon drawable="@drawable/meinvodafone" package="com.vodafone.selfservis" name="MeinVodafone / My Vodafone" />
     <icon drawable="@drawable/meinvodafone" package="it.vodafone.my190" name="MeinVodafone / My Vodafone" />
     <icon drawable="@drawable/messages" package="com.android.messaging" name="Messages" />
     <icon drawable="@drawable/messages" package="com.android.mms" name="Messages" />


### PR DESCRIPTION
## Description
Link another vodafone app

## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)


## Icons addition information

### Icons linked
* App Name (linked `com.vodafone.selfservis` to `@drawable/meinvodafone`)
