### PR TITLE
Support view icon info when tapping an icon

### DIFF
--- a/app/src/main/kotlin/app/lawnchair/lawnicons/model/IconInfo.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/model/IconInfo.kt
@@ -2,5 +2,7 @@ package app.lawnchair.lawnicons.model
 
 data class IconInfo(
     val name: String,
+    val drawableName: String,
+    val packageName: String,
     val id: Int,
 )

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/ClickableIcon.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/ClickableIcon.kt
@@ -2,7 +2,6 @@ package app.lawnchair.lawnicons.ui.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
@@ -12,7 +11,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -38,19 +36,4 @@ fun ClickableIcon(
             tint = tint,
         )
     }
-}
-
-@Composable
-fun ClickableIcon(
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit,
-    painter: Painter,
-    tint: Color = MaterialTheme.colorScheme.onSurface,
-) {
-    Icon(
-        painter = painter,
-        contentDescription = null,
-        modifier = modifier.fillMaxSize(fraction = 0.6f).clickable(onClick = onClick),
-        tint = tint,
-    )
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/ClickableIcon.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/ClickableIcon.kt
@@ -2,6 +2,7 @@ package app.lawnchair.lawnicons.ui.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
@@ -11,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -36,4 +38,18 @@ fun ClickableIcon(
             tint = tint,
         )
     }
+}
+@Composable
+fun ClickableIcon(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    painter: Painter,
+    tint: Color = MaterialTheme.colorScheme.onSurface,
+) {
+        Icon(
+            painter = painter,
+            contentDescription = null,
+            modifier = modifier.fillMaxSize(fraction = 0.6f).clickable(onClick = onClick),
+            tint = tint,
+        )
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/ClickableIcon.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/ClickableIcon.kt
@@ -39,6 +39,7 @@ fun ClickableIcon(
         )
     }
 }
+
 @Composable
 fun ClickableIcon(
     modifier: Modifier = Modifier,
@@ -46,10 +47,10 @@ fun ClickableIcon(
     painter: Painter,
     tint: Color = MaterialTheme.colorScheme.onSurface,
 ) {
-        Icon(
-            painter = painter,
-            contentDescription = null,
-            modifier = modifier.fillMaxSize(fraction = 0.6f).clickable(onClick = onClick),
-            tint = tint,
-        )
+    Icon(
+        painter = painter,
+        contentDescription = null,
+        modifier = modifier.fillMaxSize(fraction = 0.6f).clickable(onClick = onClick),
+        tint = tint,
+    )
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
@@ -1,95 +1,69 @@
 package app.lawnchair.lawnicons.ui.component
 
-import androidx.annotation.DrawableRes
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
+import app.lawnchair.lawnicons.R
+import app.lawnchair.lawnicons.model.IconInfo
 import app.lawnchair.lawnicons.ui.util.StringConstants
 
 @Composable
 fun IconInfoPopup(
-    @DrawableRes iconId: Int,
-    iconName: String,
-    iconDrawableName: String,
-    iconPackageName: String,
+    iconInfo: IconInfo,
     isPopupShown: MutableState<Boolean>,
 ) {
-    Dialog(
+    AlertDialog(
         onDismissRequest = { isPopupShown.value = false },
-    ) {
-        Column(
-            modifier = Modifier
-                .background(
-                    color = MaterialTheme.colorScheme.background,
-                    shape = RoundedCornerShape(10),
-                )
-                .padding(all = 20.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+        title = { Text(text = iconInfo.name) },
+        icon = {
             Icon(
-                painter = painterResource(id = iconId),
-                contentDescription = null,
+                painter = painterResource(id = iconInfo.id),
+                contentDescription = iconInfo.drawableName,
+                modifier = Modifier.size(250.dp),
                 tint = MaterialTheme.colorScheme.onBackground,
-                modifier = Modifier.size(200.dp),
             )
-            Column(
-                horizontalAlignment = Alignment.Start,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(
-                    buildAnnotatedString {
-                        pushStyle(SpanStyle(color = MaterialTheme.colorScheme.onBackground))
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append("Drawable:" + StringConstants.NON_BREAKABLE_SPACE_CHARACTER)
-                        }
-                        append(iconDrawableName)
-                    },
-                )
-                Text(
-                    buildAnnotatedString {
-                        pushStyle(SpanStyle(color = MaterialTheme.colorScheme.onBackground))
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append("Package:" + StringConstants.NON_BREAKABLE_SPACE_CHARACTER)
-                        }
+        },
+        confirmButton = {
+            TextButton(onClick = { isPopupShown.value = false }) {
+                Text(text = stringResource(id = R.string.ok_button))
+            }
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    pushStyle(SpanStyle(color = MaterialTheme.colorScheme.onBackground))
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                         append(
-                            iconName.replace(
-                                StringConstants.SPACE_CHARACTER,
-                                StringConstants.NON_BREAKABLE_SPACE_CHARACTER,
-                            ),
+                            stringResource(
+                                id = R.string.drawable_prefix,
+                            ) + StringConstants.NON_BREAKABLE_SPACE_CHARACTER,
                         )
-                        append("($iconPackageName)")
-                    },
-                    softWrap = true,
-                )
-            }
-            Column(
-                horizontalAlignment = Alignment.End,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                TextButton(onClick = { isPopupShown.value = false }) {
-                    Text(text = "OK")
-                }
-            }
-        }
-    }
+                    }
+                    append(iconInfo.drawableName)
+                    append("\n")
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(
+                            stringResource(
+                                id = R.string.package_prefix,
+                            ) + StringConstants.NON_BREAKABLE_SPACE_CHARACTER,
+                        )
+                    }
+                    append(iconInfo.packageName)
+                },
+            )
+        },
+    )
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
@@ -1,0 +1,79 @@
+package app.lawnchair.lawnicons.ui.component
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.*
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import app.lawnchair.lawnicons.ui.util.StringConstants
+
+@Composable
+fun IconInfoPopup(@DrawableRes iconId: Int, iconName: String ,iconDrawableName: String, iconPackageName: String, isPopupShown : MutableState<Boolean>) {
+
+    Dialog(
+        onDismissRequest = { isPopupShown.value = false },
+    ) {
+        Column(
+            modifier = Modifier
+                .background(
+                    color = MaterialTheme.colorScheme.background,
+                    shape = RoundedCornerShape(10)
+                )
+                .padding(all = 20.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painter = painterResource(id = iconId),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.size(200.dp)
+            )
+            Column(
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    buildAnnotatedString {
+                        pushStyle(SpanStyle(color = MaterialTheme.colorScheme.onBackground))
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)){
+                            append("Drawable:" + StringConstants.NON_BREAKABLE_SPACE_CHARACTER)
+                        }
+                        append(iconDrawableName)
+                    }
+                )
+                Text(
+                    buildAnnotatedString {
+                        pushStyle(SpanStyle(color = MaterialTheme.colorScheme.onBackground))
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)){
+                            append("Package:" + StringConstants.NON_BREAKABLE_SPACE_CHARACTER)
+                        }
+                        append(iconName.replace(StringConstants.SPACE_CHARACTER, StringConstants.NON_BREAKABLE_SPACE_CHARACTER))
+                        append("("+iconPackageName+")")
+                    },
+                    softWrap = true
+                )
+            }
+            Column(
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                TextButton(onClick = { isPopupShown.value = false }) {
+                    Text(text = "OK")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
@@ -2,11 +2,11 @@ package app.lawnchair.lawnicons.ui.component
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -26,8 +26,13 @@ import androidx.compose.ui.window.Dialog
 import app.lawnchair.lawnicons.ui.util.StringConstants
 
 @Composable
-fun IconInfoPopup(@DrawableRes iconId: Int, iconName: String ,iconDrawableName: String, iconPackageName: String, isPopupShown : MutableState<Boolean>) {
-
+fun IconInfoPopup(
+    @DrawableRes iconId: Int,
+    iconName: String,
+    iconDrawableName: String,
+    iconPackageName: String,
+    isPopupShown: MutableState<Boolean>,
+) {
     Dialog(
         onDismissRequest = { isPopupShown.value = false },
     ) {
@@ -35,46 +40,51 @@ fun IconInfoPopup(@DrawableRes iconId: Int, iconName: String ,iconDrawableName: 
             modifier = Modifier
                 .background(
                     color = MaterialTheme.colorScheme.background,
-                    shape = RoundedCornerShape(10)
+                    shape = RoundedCornerShape(10),
                 )
                 .padding(all = 20.dp),
             verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(
                 painter = painterResource(id = iconId),
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
-                modifier = Modifier.size(200.dp)
+                modifier = Modifier.size(200.dp),
             )
             Column(
                 horizontalAlignment = Alignment.Start,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
                     buildAnnotatedString {
                         pushStyle(SpanStyle(color = MaterialTheme.colorScheme.onBackground))
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)){
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                             append("Drawable:" + StringConstants.NON_BREAKABLE_SPACE_CHARACTER)
                         }
                         append(iconDrawableName)
-                    }
+                    },
                 )
                 Text(
                     buildAnnotatedString {
                         pushStyle(SpanStyle(color = MaterialTheme.colorScheme.onBackground))
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)){
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                             append("Package:" + StringConstants.NON_BREAKABLE_SPACE_CHARACTER)
                         }
-                        append(iconName.replace(StringConstants.SPACE_CHARACTER, StringConstants.NON_BREAKABLE_SPACE_CHARACTER))
-                        append("("+iconPackageName+")")
+                        append(
+                            iconName.replace(
+                                StringConstants.SPACE_CHARACTER,
+                                StringConstants.NON_BREAKABLE_SPACE_CHARACTER,
+                            ),
+                        )
+                        append("($iconPackageName)")
                     },
-                    softWrap = true
+                    softWrap = true,
                 )
             }
             Column(
                 horizontalAlignment = Alignment.End,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 TextButton(onClick = { isPopupShown.value = false }) {
                     Text(text = "OK")

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconInfoPopup.kt
@@ -2,7 +2,11 @@ package app.lawnchair.lawnicons.ui.component
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -13,8 +17,10 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.*
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import app.lawnchair.lawnicons.ui.util.StringConstants

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreview.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreview.kt
@@ -1,11 +1,13 @@
 package app.lawnchair.lawnicons.ui.component
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -15,16 +17,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import app.lawnchair.lawnicons.model.IconInfo
 import app.lawnchair.lawnicons.ui.util.Elevation
 import app.lawnchair.lawnicons.ui.util.surfaceColorAtElevation
 
 @Composable
 fun IconPreview(
-    @DrawableRes iconId: Int,
-    iconName: String,
-    iconDrawableName: String,
-    iconPackageName: String,
+    iconInfo: IconInfo,
 ) {
+    val isIconInfoShown = remember { mutableStateOf(false) }
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -32,24 +33,31 @@ fun IconPreview(
             .aspectRatio(ratio = 1F)
             .clip(shape = CircleShape)
             .background(
-                color = MaterialTheme.colorScheme.surfaceColorAtElevation(Elevation.Level1),
-            ),
-    ) {
-        val isIconInfoShown = remember { mutableStateOf(false) }
-        ClickableIcon(
-            painter = painterResource(id = iconId),
-            modifier = Modifier,
-            tint = MaterialTheme.colorScheme.onBackground,
-            onClick = { isIconInfoShown.value = true },
-        )
-        if (isIconInfoShown.value) {
-            IconInfoPopup(
-                iconId = iconId,
-                iconDrawableName = iconDrawableName,
-                iconPackageName = iconPackageName,
-                iconName = iconName,
-                isPopupShown = isIconInfoShown,
+                color = if (isIconInfoShown.value) {
+                    MaterialTheme.colorScheme.surfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.surfaceColorAtElevation(
+                        Elevation.Level1,
+                    )
+                },
             )
-        }
+            .clickable(onClick = { isIconInfoShown.value = true }),
+    ) {
+        Icon(
+            painter = painterResource(id = iconInfo.id),
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(0.6f),
+            tint = if (isIconInfoShown.value) {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            } else {
+                MaterialTheme.colorScheme.onBackground
+            },
+        )
+    }
+    if (isIconInfoShown.value) {
+        IconInfoPopup(
+            iconInfo = iconInfo,
+            isPopupShown = isIconInfoShown,
+        )
     }
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreview.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreview.kt
@@ -4,12 +4,12 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -19,7 +19,7 @@ import app.lawnchair.lawnicons.ui.util.Elevation
 import app.lawnchair.lawnicons.ui.util.surfaceColorAtElevation
 
 @Composable
-fun IconPreview(@DrawableRes iconId: Int) {
+fun IconPreview(@DrawableRes iconId: Int, iconName: String, iconDrawableName: String, iconPackageName: String) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -30,11 +30,21 @@ fun IconPreview(@DrawableRes iconId: Int) {
                 color = MaterialTheme.colorScheme.surfaceColorAtElevation(Elevation.Level1),
             ),
     ) {
-        Icon(
+        val isIconInfoShown = remember { mutableStateOf(false) }
+        ClickableIcon(
             painter = painterResource(id = iconId),
-            contentDescription = null,
-            modifier = Modifier.fillMaxSize(fraction = 0.6f),
+            modifier = Modifier,
             tint = MaterialTheme.colorScheme.onBackground,
+            onClick = { isIconInfoShown.value = true }
         )
+        if(isIconInfoShown.value) {
+            IconInfoPopup(
+                iconId = iconId,
+                iconDrawableName = iconDrawableName,
+                iconPackageName = iconPackageName,
+                iconName = iconName,
+                isPopupShown = isIconInfoShown,
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreview.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreview.kt
@@ -19,7 +19,12 @@ import app.lawnchair.lawnicons.ui.util.Elevation
 import app.lawnchair.lawnicons.ui.util.surfaceColorAtElevation
 
 @Composable
-fun IconPreview(@DrawableRes iconId: Int, iconName: String, iconDrawableName: String, iconPackageName: String) {
+fun IconPreview(
+    @DrawableRes iconId: Int,
+    iconName: String,
+    iconDrawableName: String,
+    iconPackageName: String,
+) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -35,9 +40,9 @@ fun IconPreview(@DrawableRes iconId: Int, iconName: String, iconDrawableName: St
             painter = painterResource(id = iconId),
             modifier = Modifier,
             tint = MaterialTheme.colorScheme.onBackground,
-            onClick = { isIconInfoShown.value = true }
+            onClick = { isIconInfoShown.value = true },
         )
-        if(isIconInfoShown.value) {
+        if (isIconInfoShown.value) {
             IconInfoPopup(
                 iconId = iconId,
                 iconDrawableName = iconDrawableName,

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreviewGrid.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreviewGrid.kt
@@ -29,10 +29,7 @@ fun IconPreviewGrid(
     ) {
         items(items = iconInfo) { iconInfo ->
             IconPreview(
-                iconId = iconInfo.id,
-                iconName = iconInfo.name,
-                iconDrawableName = iconInfo.drawableName,
-                iconPackageName = iconInfo.packageName,
+                iconInfo = iconInfo,
             )
         }
     }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreviewGrid.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreviewGrid.kt
@@ -28,7 +28,7 @@ fun IconPreviewGrid(
         ),
     ) {
         items(items = iconInfo) { iconInfo ->
-            IconPreview(iconId = iconInfo.id)
+            IconPreview(iconId = iconInfo.id, iconName = iconInfo.name, iconDrawableName = iconInfo.drawableName, iconPackageName = iconInfo.packageName)
         }
     }
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreviewGrid.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/component/IconPreviewGrid.kt
@@ -28,7 +28,12 @@ fun IconPreviewGrid(
         ),
     ) {
         items(items = iconInfo) { iconInfo ->
-            IconPreview(iconId = iconInfo.id, iconName = iconInfo.name, iconDrawableName = iconInfo.drawableName, iconPackageName = iconInfo.packageName)
+            IconPreview(
+                iconId = iconInfo.id,
+                iconName = iconInfo.name,
+                iconDrawableName = iconInfo.drawableName,
+                iconPackageName = iconInfo.packageName,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/util/StringConstants.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/util/StringConstants.kt
@@ -1,0 +1,6 @@
+package app.lawnchair.lawnicons.ui.util
+
+object StringConstants {
+    const val SPACE_CHARACTER = ' '
+    const val NON_BREAKABLE_SPACE_CHARACTER = '\u00A0'
+}

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/util/GetIconInfo.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/util/GetIconInfo.kt
@@ -26,8 +26,9 @@ fun Context.getIconInfo(): List<IconInfo> {
                     val pkg = parser.getAttributeValue(null, "package")
                     val iconName = parser.getAttributeValue(null, "name")
                     val iconId = parser.getAttributeResourceValue(null, "drawable", 0)
+                    val iconDrawable = resources.getResourceEntryName(iconId)
                     if (iconId != 0 && pkg.isNotEmpty()) {
-                        iconInfo += IconInfo(iconName, iconId)
+                        iconInfo += IconInfo(iconName, iconDrawable, pkg, iconId)
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,13 @@
     <string name="special_thanks_icon">For inspiring the app icon.</string>
     <!-- Subtitle displayed below the user who named the app -->
     <string name="special_thanks_name">For naming the app.</string>
+
+    <!-- Icon Information Popup window -->
+
+    <!-- Drawable prefix -->
+    <string name="drawable_prefix">Drawable:</string>
+    <!-- Package prefix -->
+    <string name="package_prefix">Package:</string>
+    <!-- OK button -->
+    <string name="ok_button">OK</string>
 </resources>


### PR DESCRIPTION
## Description
Added the ability to view information about the icon when clicking on it
<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

Fixes #787

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->