### PR TITLE
Add icon for Klarna

### DIFF
--- a/app/src/main/res/drawable/klarna.xml
+++ b/app/src/main/res/drawable/klarna.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="m34.32,22.03 l-0.09,147.94"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m120.12,22.03c-0.35,53.18 -41.04,80.91 -41.04,80.91l47.97,67.03"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M160.09,169.97a2.33,2.33 0,1 0,4.66 0a2.33,2.33 0,1 0,-4.66 0z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="7.3392"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -568,6 +568,7 @@
     <icon drawable="@drawable/kicker" package="com.netbiscuits.kicker" name="kicker" />
     <icon drawable="@drawable/kiwi_browser" package="com.kiwibrowser.browser" name="Kiwi Browser" />
     <icon drawable="@drawable/kiwi_browser" package="com.kiwibrowser.browser.dev" name="Kiwi Browser" />
+    <icon drawable="@drawable/klarna" package="com.myklarnamobile" name="Klarna" />
     <icon drawable="@drawable/klck" package="org.kustom.lockscreen" name="KLCK" />
     <icon drawable="@drawable/klwp" package="org.kustom.wallpaper" name="KLWP" />
     <icon drawable="@drawable/knife_hit" package="com.ketchapp.knifehit" name="Knife Hit" />

--- a/svgs/klarna.svg
+++ b/svgs/klarna.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="192" height="192" version="1.1" viewBox="0 0 192 192" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><g stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="15"><path d="m34.324 22.031-0.08658 147.94" fill="none" stroke-width="12" style="paint-order:markers stroke fill"/><path d="m120.12 22.031c-0.34635 53.176-41.045 80.909-41.045 80.909l47.975 67.03" fill="none" stroke-width="12" style="paint-order:markers stroke fill"/><ellipse cx="162.42" cy="169.97" rx="2.3304" ry="2.3304" stroke-width="7.3392" style="paint-order:markers stroke fill"/></g></svg>


### PR DESCRIPTION
## Description

Adding icon for the Klarna app. I am not sure about the dot; I made it to have a diameter of 12.

https://play.google.com/store/apps/details?id=com.myklarnamobile

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->
### Icons added
* App Name (`com.myklarnamobile`)

### Icons linked
* App Name (linked `com.myklarnamobile` to `@drawable/klarna`)
