### PR TITLE
Add icon link for QR Scanner, Session Fdroid, Fork Client

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -867,6 +867,7 @@
     <icon drawable="@drawable/qksms" package="com.moez.QKSMS" name="QKSMS" />
     <icon drawable="@drawable/qobuz" package="com.qobuz.music" name="Qobuz" />
     <icon drawable="@drawable/qr_reader" package="com.teacapps.barcodescanner" name="QR Reader" />
+    <icon drawable="@drawable/qr_reader" package="com.secuso.privacyFriendlyCodeScanner" name="QR Scanner" />
     <icon drawable="@drawable/qr_reader" package="com.tomfong.simpleqr" name="Simple QR" />
     <icon drawable="@drawable/qr_reader" package="org.barcodescanner" name="QR &amp; Barcode Scanner" />
     <icon drawable="@drawable/quickedit" package="com.rhmsoft.edit" name="QuickEdit" />
@@ -938,6 +939,7 @@
     <icon drawable="@drawable/seriesguide" package="com.battlelancer.seriesguide" name="SeriesGuide" />
     <icon drawable="@drawable/sesame" package="ninja.sesame.app.edge" name="Sesame" />
     <icon drawable="@drawable/session" package="network.loki.messenger" name="Session" />
+    <icon drawable="@drawable/session" package="network.loki.messenger.fdroid" name="Session" />
     <icon drawable="@drawable/settings" package="com.android.settings" name="Settings" />
     <icon drawable="@drawable/share_me" package="com.xiaomi.midrop" name="ShareMe"/>
     <icon drawable="@drawable/share_me" package="com.xiaomi.midrop.SplashScreen" name="ShareMe"/>
@@ -1043,6 +1045,7 @@
     <icon drawable="@drawable/telegram" package="org.telegram.messenger.web" name="Telegram" />
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegram" name="Telegram X" />
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegramtwo" name="Telegram X" />
+    <icon drawable="@drawable/telegram" package="org.forkclient.messenger.beta" name="Fork Client" />
     <icon drawable="@drawable/telegram" package="org.forkgram.messenger" name="Fork Client" />
     <icon drawable="@drawable/termux" package="com.termux" name="Termux" />
     <icon drawable="@drawable/textra" package="com.textra" name="Textra"/>


### PR DESCRIPTION
## Description

Linked icons for QR Scanner (https://github.com/SecUSo/privacy-friendly-qr-scanner)
Session Fdroid (https://f-droid.org/ru/packages/network.loki.messenger.fdroid)
Fork Client (https://github.com/Forkgram/TelegramAndroid)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information

### Icons linked
* QR Scanner (linked `com.secuso.privacyFriendlyCodeScanner` to `@drawable/qr_reader`)
* Session Fdroid (linked `network.loki.messenger.fdroid` to `@drawable/session`)
* Fork Client (linked `org.forkclient.messenger.beta` to `@drawable/telegram`)
