### PR TITLE
Link Marc's Files

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -364,6 +364,7 @@
     <icon drawable="@drawable/files" package="com.coloros.files" name="Files" />
     <icon drawable="@drawable/files" package="com.google.android.documentsui" name="Files" />
     <icon drawable="@drawable/files" package="com.huawei.hidisk" name="Files" />
+    <icon drawable="@drawable/files" package="com.marc.files" name="Files" />
     <icon drawable="@drawable/files" package="com.oneplus.filemanager" name="Files" />
     <icon drawable="@drawable/files" package="com.sec.android.app.myfiles" name="Files" />
     <icon drawable="@drawable/files" package="com.simplemobiletools.filemanager" name="Simple File Manager" />


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

Just clean-installed a custom ROM and found out that the current Files Shortcut app that I previously used didn't link to the proper stock file manager app that I prefer, so I installed another one, and thought of theming it with the already existing drawable ^^

https://play.google.com/store/apps/details?id=com.marc.files

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->

### Icons linked
* Files (linked `com.marc.files` to `@drawable/files`)
