### PR TITLE
Add svgprocessor module

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,4 +39,7 @@ rootProject.name = "Lawnicons"
 
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 
-include(":app")
+include(
+    ":svgprocessor",
+    ":app",
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,6 @@ rootProject.name = "Lawnicons"
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 
 include(
-    ":svgprocessor",
     ":app",
+    ":svgprocessor",
 )

--- a/svgprocessor/build.gradle.kts
+++ b/svgprocessor/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    application
+}
+
+application {
+    mainClass.set("app.lawnchair.lawnicons.helper.ApplicationKt")
+}
+
+dependencies {
+    implementation("com.android.tools:sdk-common:30.3.1")
+    implementation("org.dom4j:dom4j:2.1.3")
+}

--- a/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/Application.kt
+++ b/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/Application.kt
@@ -1,0 +1,18 @@
+package app.lawnchair.lawnicons.helper
+
+fun main() {
+    val rootDir = ".."
+    val sourceDir = "$rootDir/svgs/"
+    val darkResDir = "$rootDir/app/src/dark/res"
+    val lightResDir = "$rootDir/app/src/light/res"
+    val appFilterFile = "$rootDir/app/assets/appfilter.xml"
+
+    // Convert svg to drawable in runtime
+    SvgFilesProcessor.process(sourceDir, "$darkResDir/drawable", "dark")
+    SvgFilesProcessor.process(sourceDir, "$lightResDir/drawable", "light")
+
+    // Read appfilter xml and create icon, drawable xml file.
+    ConfigProcessor.loadAndCreateConfigs(appFilterFile, darkResDir, lightResDir)
+
+    println("SvgToVector task completed")
+}

--- a/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/ConfigProcessor.kt
+++ b/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/ConfigProcessor.kt
@@ -1,0 +1,90 @@
+package app.lawnchair.lawnicons.helper
+
+import java.util.Locale
+import org.dom4j.Document
+import org.dom4j.tree.DefaultDocument
+
+object ConfigProcessor {
+    private const val ITEM = "item"
+    private const val COMPONENT = "component"
+    private const val PACKAGE = "package"
+    private const val DRAWABLE = "drawable"
+    private const val ICONS = "icons"
+    private const val ICON = "icon"
+    private const val RESOURCES = "resources"
+    private const val NAME = "name"
+    private const val VERSION = "version"
+
+    fun loadAndCreateConfigs(appFilterFile: String, vararg resDirs: String) {
+        val (appFilterDocument, drawableMap, iconMap) = loadConfigFromXml(appFilterFile)
+        val sortedDrawableMap = drawableMap.toList().sortedBy { (_, value) -> value }.toMap()
+
+        resDirs.forEach {
+            // Create Drawable files
+            writeDrawableToFile(sortedDrawableMap, "$it/xml/drawable.xml")
+            // Create Icon Map files
+            writeIconMapToFile(sortedDrawableMap, iconMap, "$it/xml/grayscale_icon_map.xml")
+            // Write AppFilter to resource directory
+            XmlUtil.writeDocumentToFile(appFilterDocument, "$it/xml/appfilter.xml")
+        }
+    }
+
+    private fun loadConfigFromXml(appFilterFile: String):
+        Triple<Document, Map<String, String>, Map<String, String>> {
+        val drawableMap = mutableMapOf<String, String>()
+        val iconMap = mutableMapOf<String, String>()
+        val componentStart = "ComponentInfo{"
+        val componentEnd = "}"
+        val appFilterDocument = XmlUtil.getDocument(appFilterFile)
+        val appFilterElements = XmlUtil.getElements(appFilterDocument, ITEM)
+        for (element in appFilterElements) {
+            val componentInfo = element.attribute(COMPONENT).value
+            val drawable = element.attribute(DRAWABLE).value
+            val name = element.attribute(NAME).value
+            if (componentInfo.startsWith(componentStart) && componentInfo.endsWith(componentEnd)) {
+                val component = componentInfo.substring(
+                    componentStart.length,
+                    componentInfo.length - componentEnd.length,
+                )
+                drawableMap[component] = drawable
+                iconMap[component] = name
+            }
+        }
+        return Triple(appFilterDocument, drawableMap.toMap(), iconMap.toMap())
+    }
+
+    private fun writeIconMapToFile(
+        drawableMap: Map<String, String>,
+        iconMap: Map<String, String>,
+        filename: String,
+    ) {
+        val iconsDocument = DefaultDocument().apply { addElement(ICONS) }
+        drawableMap.forEach { (componentInfo, drawable) ->
+            val component = componentInfo.split("/").toTypedArray()
+            val name = iconMap.getOrDefault(
+                componentInfo,
+                drawable.replace("_".toRegex(), " ").capitalize(),
+            )
+            iconsDocument.rootElement.addElement(ICON)
+                .addAttribute(DRAWABLE, "@drawable/$drawable")
+                .addAttribute(PACKAGE, component[0])
+                .addAttribute(NAME, name)
+        }
+        XmlUtil.writeDocumentToFile(iconsDocument, filename)
+    }
+
+    private fun writeDrawableToFile(drawableMap: Map<String, String>, filename: String) {
+        val resourceDocument = DefaultDocument().apply {
+            addElement(RESOURCES)
+            rootElement.addElement(VERSION).addText("1")
+        }
+        drawableMap.values.distinct().forEach { drawable: String? ->
+            resourceDocument.rootElement.addElement(ITEM).addAttribute(DRAWABLE, drawable)
+        }
+        XmlUtil.writeDocumentToFile(resourceDocument, filename)
+    }
+
+    private fun String.capitalize(): String = replaceFirstChar {
+        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+    }
+}

--- a/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/SvgFilesProcessor.kt
+++ b/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/SvgFilesProcessor.kt
@@ -1,0 +1,101 @@
+package app.lawnchair.lawnicons.helper
+
+import com.android.ide.common.vectordrawable.Svg2Vector
+import java.io.FileOutputStream
+import java.io.IOException
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.FileVisitor
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.EnumSet
+import org.dom4j.DocumentException
+
+object SvgFilesProcessor {
+    private lateinit var sourceSvgPath: Path
+    private lateinit var destinationVectorPath: Path
+    private lateinit var mode: String
+
+    fun process(sourceDirectory: String, destDirectory: String, mode: String) {
+        this.sourceSvgPath = Paths.get(sourceDirectory)
+        this.destinationVectorPath = Paths.get(destDirectory)
+        this.mode = mode
+        try {
+            val options = EnumSet.of(FileVisitOption.FOLLOW_LINKS)
+            // check first if source is a directory
+            if (Files.isDirectory(sourceSvgPath)) {
+                Files.walkFileTree(sourceSvgPath, options, Int.MAX_VALUE, fileVisitor)
+            } else {
+                println("source not a directory")
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+
+    private val fileVisitor = object : FileVisitor<Path> {
+        override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult =
+            FileVisitResult.CONTINUE
+
+        override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes?): FileVisitResult {
+            // Skip folder which is processing svgs to xml
+            if (dir == destinationVectorPath) {
+                return FileVisitResult.SKIP_SUBTREE
+            }
+            val newDirectory = destinationVectorPath.resolve(sourceSvgPath.relativize(dir))
+            try {
+                Files.createDirectories(newDirectory)
+            } catch (e: FileAlreadyExistsException) {
+                e.printStackTrace()
+            } catch (e: IOException) {
+                e.printStackTrace()
+                return FileVisitResult.SKIP_SUBTREE
+            }
+            return FileVisitResult.CONTINUE
+        }
+
+        override fun visitFile(file: Path, attrs: BasicFileAttributes?): FileVisitResult {
+            convertToVector(file, destinationVectorPath.resolve(sourceSvgPath.relativize(file)))
+            return FileVisitResult.CONTINUE
+        }
+
+        override fun visitFileFailed(file: Path, exc: IOException?): FileVisitResult =
+            FileVisitResult.CONTINUE
+    }
+
+    private fun convertToVector(svgSource: Path, vectorTargetPath: Path) {
+        // convert only if it is .svg
+        if (svgSource.fileName.toString().endsWith(".svg")) {
+            val targetFile = XmlUtil.getFileWithExtension(vectorTargetPath)
+            val fileOutputStream = FileOutputStream(targetFile)
+            Svg2Vector.parseSvgToXml(svgSource.toFile(), fileOutputStream)
+            try {
+                val attrValue = if (mode == "dark") "#000" else "#fff"
+                updateXmlPath(targetFile, "android:strokeColor", attrValue)
+                updateXmlPath(targetFile, "android:fillColor", attrValue)
+            } catch (e: DocumentException) {
+                throw RuntimeException(e)
+            }
+        } else {
+            println("Skipping file as its not svg " + svgSource.fileName)
+        }
+    }
+
+    private fun updateXmlPath(xmlPath: String, searchKey: String, attributeValue: String) {
+        val xmlDocument = XmlUtil.getDocument(xmlPath)
+        val keyWithoutNameSpace = searchKey.substring(searchKey.indexOf(":") + 1)
+        if (xmlDocument.rootElement != null) {
+            for (e in xmlDocument.rootElement.elements("path")) {
+                val attr = e.attribute(keyWithoutNameSpace)
+                if (attr != null) {
+                    if (attr.value != "#00000000") {
+                        attr.value = attributeValue
+                    }
+                }
+            }
+            XmlUtil.writeDocumentToFile(xmlDocument, xmlPath)
+        }
+    }
+}

--- a/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/XmlUtil.kt
+++ b/svgprocessor/src/main/kotlin/app/lawnchair/lawnicons/helper/XmlUtil.kt
@@ -1,0 +1,43 @@
+package app.lawnchair.lawnicons.helper
+
+import java.io.File
+import java.io.FileWriter
+import java.nio.file.Path
+import org.dom4j.Document
+import org.dom4j.Element
+import org.dom4j.io.OutputFormat
+import org.dom4j.io.SAXReader
+import org.dom4j.io.XMLWriter
+
+object XmlUtil {
+    private val UTF_8 = Charsets.UTF_8.name()
+
+    fun getElements(document: Document, path: String): List<Element> {
+        return document.rootElement.elements(path)
+    }
+
+    fun getDocument(xmlPath: String): Document {
+        return SAXReader().apply { encoding = UTF_8 }.read(xmlPath)
+    }
+
+    fun getFileWithExtension(target: Path, extension: String = "xml"): String {
+        val svgFilePath = target.toFile().absolutePath
+        val index = svgFilePath.lastIndexOf(".")
+        return buildString {
+            if (index != -1) {
+                append(svgFilePath.substring(0, index))
+            }
+            append(".$extension")
+        }
+    }
+
+    fun writeDocumentToFile(outDocument: Document, outputConfigPath: String) {
+        File(outputConfigPath).parentFile.mkdirs()
+        FileWriter(outputConfigPath).use { fw ->
+            XMLWriter(fw, OutputFormat.createPrettyPrint()).apply {
+                write(outDocument)
+                close()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce automation to reduce some maintance work.
- Since lawncions will act as icon pack, we need to add components details to appfilter.xml , drawabale.xml and grayscale_icon_map.xml . Even now developers are creating svg files and vector assests.
- Idea is to let developer create svg file and appfilter.xml file alone and helper script to create others file during build.

Related pr : https://github.com/LawnchairLauncher/lawnicons/pull/815