### PR TITLE
Add Litrato photo editor

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -810,8 +810,8 @@
     <icon drawable="@drawable/pedulilindungi" package="com.telkom.tracencare" name="PeduliLindungi" />
     <icon drawable="@drawable/personal_safety" package="com.google.android.apps.safetyhub" name="Personal Safety" />
     <icon drawable="@drawable/photo_compare" package="com.vincentengelsoftware.vesandroidimagecompare" name="VES - Image and Photo Compare" />
-    <icon drawable="@drawable/photo_editor" package="com.iudesk.android.photo.editor" name="Photo Editor" />
     <icon drawable="@drawable/photo_editor" package="com.example.retouchephoto" name="Photo Editor" />
+    <icon drawable="@drawable/photo_editor" package="com.iudesk.android.photo.editor" name="Photo Editor" />
     <icon drawable="@drawable/phototan" package="ch.raiffeisen.phototan" name="PhotoTAN" />
     <icon drawable="@drawable/physics_wallah" package="xyz.penpencil.physicswala" name="Physics Wallah" />
     <icon drawable="@drawable/picpay" package="com.picpay" name="PicPay" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -811,6 +811,7 @@
     <icon drawable="@drawable/personal_safety" package="com.google.android.apps.safetyhub" name="Personal Safety" />
     <icon drawable="@drawable/photo_compare" package="com.vincentengelsoftware.vesandroidimagecompare" name="VES - Image and Photo Compare" />
     <icon drawable="@drawable/photo_editor" package="com.iudesk.android.photo.editor" name="Photo Editor" />
+    <icon drawable="@drawable/photo_editor" package="com.example.retouchephoto" name="Photo Editor" />
     <icon drawable="@drawable/phototan" package="ch.raiffeisen.phototan" name="PhotoTAN" />
     <icon drawable="@drawable/physics_wallah" package="xyz.penpencil.physicswala" name="Physics Wallah" />
     <icon drawable="@drawable/picpay" package="com.picpay" name="PicPay" />

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -810,7 +810,7 @@
     <icon drawable="@drawable/pedulilindungi" package="com.telkom.tracencare" name="PeduliLindungi" />
     <icon drawable="@drawable/personal_safety" package="com.google.android.apps.safetyhub" name="Personal Safety" />
     <icon drawable="@drawable/photo_compare" package="com.vincentengelsoftware.vesandroidimagecompare" name="VES - Image and Photo Compare" />
-    <icon drawable="@drawable/photo_editor" package="com.example.retouchephoto" name="Photo Editor" />
+    <icon drawable="@drawable/photo_editor" package="com.example.retouchephoto" name="Litrato" />
     <icon drawable="@drawable/photo_editor" package="com.iudesk.android.photo.editor" name="Photo Editor" />
     <icon drawable="@drawable/phototan" package="ch.raiffeisen.phototan" name="PhotoTAN" />
     <icon drawable="@drawable/physics_wallah" package="xyz.penpencil.physicswala" name="Physics Wallah" />


### PR DESCRIPTION
## Description


https://apt.izzysoft.de/fdroid/index/apk/com.example.retouchephoto



<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
✅ Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->


### Icons linked
* Litrato (linked `com.example.retouchephoto` to `@drawable/photo_editor`)
