### PR TITLE
Link Greatness's GCam mod to camera

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -180,6 +180,7 @@
     <icon drawable="@drawable/camera" package="com.google.android.GoogleCameraGood" name="Camera" />
     <icon drawable="@drawable/camera" package="com.google.android.GoogleCameraLMC" name="Camera" />
     <icon drawable="@drawable/camera" package="com.google.android.apps.cameralite" name="Camera" />
+    <icon drawable="@drawable/camera" package="com.google.android.GoogleCamera.cameralite" name="Camera" />
     <icon drawable="@drawable/camera" package="com.googleCamera.Wichaya8" name="Camera" />
     <icon drawable="@drawable/camera" package="com.hmdglobal.app.camera" name="Camera" />
     <icon drawable="@drawable/camera" package="com.hmdglobal.camera2" name="Camera" />


### PR DESCRIPTION
## Description
https://www.celsoazevedo.com/files/android/google-camera/dev-greatness/f/dl6/

## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
✅ : Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)


### Icons linked
* App Name (linked `com.google.android.GoogleCamera.cameralite` to `@drawable/camera`)

