### PR TITLE
Add icon for Teufel apps

### DIFF
--- a/app/src/main/res/drawable/teufel.xml
+++ b/app/src/main/res/drawable/teufel.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="m168.56,22.03h-112c-24.52,0 -38.66,23.11 -24.67,45.03"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m107.67,22.03 l-12.1,114.46c-2.62,24.82 -30.05,36.91 -51.1,32.58"
+      android:strokeLineJoin="round"
+      android:strokeWidth="12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -897,6 +897,10 @@
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegram" name="Telegram X" />
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegramtwo" name="Telegram X" />
     <icon drawable="@drawable/termux" package="com.termux" name="Termux" />
+    <icon drawable="@drawable/teufel" package="com.raumfeld.android.controller" name="Teufel Raumfeld" />
+    <icon drawable="@drawable/teufel" package="com.teufel.SmartAudio" name="Teufel Remote" />
+    <icon drawable="@drawable/teufel" package="com.wifiaudio.Teufel" name="Teufel HOLIST" />
+    <icon drawable="@drawable/teufel" package="de.teufel.android.app.bluetooth.playstore" name="Teufel Headphones" />
     <icon drawable="@drawable/textra" package="com.textra" name="Textra"/>
     <icon drawable="@drawable/the_battle_cats" package="jp.co.ponos.battlecatsen" name="The Battle Cats" />
     <icon drawable="@drawable/the_economist" package="com.economist.lamarr" name="Economist" />

--- a/svgs/teufel.svg
+++ b/svgs/teufel.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="192" height="192" version="1.1" viewBox="0 0 192 192" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="15" stroke-width="12"><path d="m168.56 22.035h-112c-24.522 0-38.658 23.107-24.666 45.032" style="paint-order:markers stroke fill"/><path d="m107.67 22.035-12.103 114.46c-2.6244 24.819-30.046 36.908-51.105 32.581" style="paint-order:markers stroke fill"/></g></svg>


### PR DESCRIPTION
## Description

Added the teufel logo for a couple of apps. The apps themselves always have the same logo, but in different colors. This does not apply to this icon pack so I linked all of them :)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->
### Icons added
* App Name (`com.raumfeld.android.controller`)

### Icons linked
* App Name (linked `com.raumfeld.android.controller` to `@drawable/teufel`)
* App Name (linked `com.teufel.SmartAudio` to `@drawable/teufel`)
* App Name (linked `com.wifiaudio.Teufel` to `@drawable/teufel`)
* App Name (linked `de.teufel.android.app.bluetooth.playstore` to `@drawable/teufel`)
