### PR TITLE
Link Vanadium to Chrome

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -463,6 +463,7 @@
     <icon drawable="@drawable/google_chrome" package="com.android.chrome" name="Google Chrome" />
     <icon drawable="@drawable/google_chrome" package="org.chromium.chrome" name="Chromium" />
     <icon drawable="@drawable/google_chrome" package="org.ungoogled.chromium.stable" name="Ungoogled Chromium" />
+    <icon drawable="@drawable/google_chrome" package="app.vanadium.browser" name="Vanadium" />
     <icon drawable="@drawable/google_chrome_beta" package="com.chrome.beta" name="Google Chrome Beta" />
     <icon drawable="@drawable/google_chrome_canary" package="com.chrome.canary" name="Google Chrome Canary" />
     <icon drawable="@drawable/google_chrome_dev" package="com.chrome.dev" name="Google Chrome Dev" />


### PR DESCRIPTION
## Description

[Vanadium](https://vanadium.app) is a hardened fork of Chromium for the GrapheneOS project. It shares the same icon style as the base projects (Chromium, Chrome), so it should be linked that way.

## Type of change
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

## Icons addition information

### Icons linked
* Vanadium (linked `app.vanadium.browser` to `@drawable/google_chrome`)
