### PR TITLE
Link Magisk Delta to Magisk

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -649,6 +649,7 @@
     <icon drawable="@drawable/magic_poser" package="com.magicposernew" name="MagicPoser" />
     <icon drawable="@drawable/magisk" package="com.thehitman7.cygisk" name="Magisk" />
     <icon drawable="@drawable/magisk" package="com.topjohnwu.magisk" name="Magisk" />
+    <icon drawable="@drawable/magisk" package="io.github.huskydg.magisk" name="Magisk Delta" />
     <icon drawable="@drawable/manipal_hospitals" package="com.manipal.manipalhospitals" name="Manipal Hospitals" />
     <icon drawable="@drawable/maps" package="com.google.android.apps.maps" name="Google Maps" />
     <icon drawable="@drawable/maps" package="com.google.android.apps.mapslite" name="Google Maps" />


### PR DESCRIPTION
## Description

<!-- 
Linked up the magisk delta app to the magisk drawable

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->


<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->

### Icons linked
* Magisk Delta (linked `io.github.huskydg.magisk` to `@drawable/magisk`)
