### PR TITLE
Bump oss-licenses-plugin to 0.10.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,18 +4,12 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.7.20" apply false
     id("com.sergei-lapin.napt") version "1.19" apply false
     id("com.google.dagger.hilt.android") version "2.44.2" apply false
-    id("com.google.android.gms.oss-licenses-plugin") version "0.10.5" apply false
+    id("com.google.android.gms.oss-licenses-plugin") version "0.10.6" apply false
     id("org.jmailen.kotlinter") version "3.13.0" apply false
 }
 
 allprojects {
     apply(plugin = "org.jmailen.kotlinter")
-
-    tasks.matching {
-        it.name.contains("OssLicensesTask")
-    }.configureEach {
-        notCompatibleWithConfigurationCache("https://github.com/google/play-services-plugins/issues/206")
-    }
 }
 
 tasks.register("clean") {


### PR DESCRIPTION
## Description

https://developers.google.com/android/guides/releases#december_05_2022

Link https://github.com/LawnchairLauncher/lawnchair/pull/3217.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories like copyediting)
