### PR TITLE
Add icon for Michelin Guide

### DIFF
--- a/app/src/main/res/drawable/michelin_guide.xml
+++ b/app/src/main/res/drawable/michelin_guide.xml
@@ -1,0 +1,73 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M95.46,172c0,0 38.94,1.41 12.35,-53.56"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M95.46,172c0,0 -38.94,1.41 -12.35,-53.56"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M30.48,134.31c0,0 18.11,34.5 52.63,-15.88"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M30.48,134.31c0,0 -20.56,-33.1 40.36,-37.33"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M107.82,117.87c32.26,51.85 51.88,18.18 51.88,18.18"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M121.03,96.98c60.67,6.91 38.67,39.07 38.67,39.07"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M30.04,60.14c0,0 -20.17,33.34 40.8,36.84"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M30.04,60.14c0,0 17.7,-34.71 52.81,15.25"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M81.52,26.33c-7.59,5.75 -12.72,18.92 1.63,49.05"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M165.16,73.42c-0.69,9.75 -8.94,21.65 -44.13,23.41"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M109.9,73.42c25.79,0.14 44.36,-9.06 44.35,-26.32c0.23,-3.94 -1.8,-7.27 -3.83,-9.59c-2.44,-2.77 -5.82,-4.58 -9.49,-4.9c-0.51,-0.04 -1.02,-0.06 -1.52,-0.04c-3.6,0.17 -6.18,1.6 -7.31,2.33c0.06,-1.34 0,-4.3 -1.65,-7.49c-0.23,-0.45 -0.5,-0.88 -0.8,-1.3c-2.12,-3.02 -5.39,-5.03 -9,-5.75c-3.02,-0.6 -6.92,-0.69 -10.21,1.49C95.49,30.5 96.84,51.18 109.9,73.42z"
+      android:strokeWidth="8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -722,6 +722,7 @@
     <icon drawable="@drawable/mi_remote" package="com.duokan.phone.remotecontroller" name="Mi Remote" />
     <icon drawable="@drawable/mi_security" package="com.miui.securitycenter" name="MIUI Security" />
     <icon drawable="@drawable/mi_video" package="com.miui.videoplayer" name="Mi Video" />
+    <icon drawable="@drawable/michelin_guide" package="com.viamichelin.android.gm21" name="Michelin Guide" />
     <icon drawable="@drawable/microflux" package="com.constantin.microflux" name="Microflux" />
     <icon drawable="@drawable/microg_settings" package="com.google.android.gms" name="microG Settings" />
     <icon drawable="@drawable/microg_settings" package="com.mgoogle.android.gms" name="Vanced microG Settings" />

--- a/svgs/michelin_guide.svg
+++ b/svgs/michelin_guide.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="图层_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="192px" height="192px" viewBox="201.641 324.945 192 192" enable-background="new 201.641 324.945 192 192"
+	 xml:space="preserve">
+<g id="图层_2" display="none">
+	
+		<image display="inline" overflow="visible" enable-background="new    " width="720" height="790" xlink:href="../../Downloads/clipart3340070.png"  transform="matrix(1 0 0 1 -62.3584 -72.2034)">
+	</image>
+	<path display="inline" fill="none" d="M297.64,794.89c0,0,193.359,7,61.359-266"/>
+	<path display="inline" fill="none" d="M297.641,794.89c0,0-193.359,7-61.359-266"/>
+	<g display="inline">
+		<path fill="none" d="M297.64,794.89c0,0,193.359,7,61.359-266"/>
+		<path fill="none" d="M297.641,794.89c0,0-193.359,7-61.359-266"/>
+	</g>
+</g>
+<g>
+	<g>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M297.105,496.942c0,0,38.937,1.409,12.355-53.565"
+			/>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M297.105,496.942c0,0-38.937,1.409-12.355-53.565"
+			/>
+	</g>
+	<g>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M232.12,459.252c0,0,18.112,34.497,52.629-15.875"
+			/>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M232.12,459.252c0,0-20.559-33.097,40.357-37.325"
+			/>
+	</g>
+	<g>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M309.46,442.814
+			c32.259,51.847,51.877,18.184,51.877,18.184"/>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M322.667,421.927
+			c60.671,6.914,38.669,39.072,38.669,39.072"/>
+	</g>
+	<g>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" d="M231.681,385.084
+			c0,0-20.166,33.338,40.797,36.842"/>
+		<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" d="M231.68,385.085
+			c0,0,17.701-34.709,52.814,15.249"/>
+	</g>
+	<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M283.16,351.28
+		c-7.595,5.751-12.715,18.924,1.628,49.054"/>
+	<path fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" d="M366.797,398.368
+		c-0.686,9.747-8.937,21.645-44.13,23.408"/>
+	<path fill="none" stroke="#000000" stroke-width="8" d="M311.539,398.367c25.79,0.137,44.357-9.065,44.345-26.316
+		c0.232-3.942-1.799-7.271-3.834-9.586c-2.436-2.768-5.816-4.581-9.492-4.902c-0.511-0.043-1.023-0.062-1.525-0.036
+		c-3.597,0.168-6.175,1.604-7.309,2.329c0.057-1.342,0.003-4.298-1.653-7.491c-0.234-0.447-0.505-0.884-0.796-1.302
+		c-2.122-3.018-5.387-5.031-9.003-5.752c-3.022-0.6-6.921-0.685-10.214,1.493C297.127,355.449,298.479,376.13,311.539,398.367z"/>
+</g>
+</svg>


### PR DESCRIPTION
## Description
https://play.google.com/store/apps/details?id=com.viamichelin.android.gm21

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)

<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->
### Icons added

* App Name (`com.viamichelin.android.gm21`)

### Icons linked
* App Name (linked `com.viamichelin.android.gm21` to `@michelin_guide`)

