### PR TITLE
Link all termux apps to termux

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -1225,6 +1225,12 @@
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegram" name="Telegram X" />
     <icon drawable="@drawable/telegram" package="org.thunderdog.challegramtwo" name="Telegram X" />
     <icon drawable="@drawable/termux" package="com.termux" name="Termux" />
+    <icon drawable="@drawable/termux" package="com.termux.api" name="Termux" />
+    <icon drawable="@drawable/termux" package="com.termux.boot" name="Termux" />
+    <icon drawable="@drawable/termux" package="com.termux.styling" name="Termux" />
+    <icon drawable="@drawable/termux" package="com.termux.tasker" name="Termux" />
+    <icon drawable="@drawable/termux" package="com.termux.widget" name="Termux" />
+    <icon drawable="@drawable/termux" package="com.termux.window" name="Termux" />
     <icon drawable="@drawable/tether" package="com.tplink.tether" name="Tether" />
     <icon drawable="@drawable/teufel" package="com.raumfeld.android.controller" name="Teufel Raumfeld" />
     <icon drawable="@drawable/teufel" package="com.teufel.SmartAudio" name="Teufel Remote" />


### PR DESCRIPTION
## Description

https://f-droid.org/en/packages/com.termux.styling
https://f-droid.org/en/packages/com.termux.window
https://f-droid.org/en/packages/com.termux.widget
https://f-droid.org/en/packages/com.termux.api
https://f-droid.org/en/packages/com.termux.boot
https://f-droid.org/en/packages/com.termux.tasker

## Type of change


:x: Bug fix (non-breaking change which fixes an issue)
✅  Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories like copyediting)



### Icons linked
* Termux Styling (linked `com.termux.styling` to `@drawable/termux`)
* Termux Float (linked `com.termux.window` to `@drawable/termux`)
* Termux Widget (linked `com.termux.widget` to `@drawable/termux`)
* Termux Api (linked `com.termux.api` to `@drawable/termux`)
* Termux Boot (linked `com.termux.boot` to `@drawable/termux`)
* Termux Tasker (linked `com.termux.tasker` to `@drawable/termux`)
