### PR TITLE
Link Aves gallery's icon to its libre counterpart of F-Droid

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -133,6 +133,7 @@
   <item component="ComponentInfo{com.authy.authy/.activities.InitializationActivity}" drawable="authy" name="Authy"/>
   <item component="ComponentInfo{org.oxycblt.auxio/org.oxycblt.auxio.MainActivity}" drawable="auxio" name="Auxio"/>
   <item component="ComponentInfo{deckers.thibault.aves/deckers.thibault.aves.MainActivity}" drawable="aves_gallery" name="Aves Gallery"/>
+  <item component="ComponentInfo{deckers.thibault.aves.libre/deckers.thibault.aves.libre.MainActivity}" drawable="aves_gallery" name="Aves Gallery"/>
   <item component="ComponentInfo{com.avito.android/com.avito.android.Launcher}" drawable="avito" name="Avito"/>
   <item component="ComponentInfo{com.avito.android/com.avito.android.ui.activity.SplashScreenActivity}" drawable="avito" name="Avito"/>
   <item component="ComponentInfo{com.avito.android/com.avito.android.view.splash.SplashScreenActivity}" drawable="avito" name="Avito"/>


### PR DESCRIPTION
## Description
This pull adds another `<item>` in the app/assets/appfilter.xml file, which adds the app `deckers.thibault.aves.libre`. It is the offical libre counterpart of `deckers.thibault.aves` made for F-Droid. It's drawable still links to `aves_gallery`, the one that its non-free counterpart (`deckers.thibault.aves` on Gplay) uses in lawnicons, because they are meant to be identical except the presence of non-free deps.
<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

Fixes #994 

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix
:white_check_mark: Icon addition
:x: General change

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information

### Icons linked
* App Name (linked `deckers.thibault.aves.libre` to `@drawable/aves_gallery`)
