### PR TITLE
Add 2 icons and update 1

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -2731,6 +2731,7 @@
   <item component="ComponentInfo{com.nianticlabs.pokemongo/com.unity3d.player.UnityPlayerActivity}" drawable="pokemon_go" name="Pokémon GO" />
   <item component="ComponentInfo{com.nianticlabs.pokemongo/com.unity3d.player.UnityPlayerNativeActivity}" drawable="pokemon_go" name="Pokémon GO" />
   <item component="ComponentInfo{jp.pokemon.pokemonunite/com.nishiki.pgame.n.PGameActivity}" drawable="pokemon_unite" name="Pokémon UNITE" />
+  <item component="ComponentInfo{agersant.polaris/com.ryanheise.audioservice.AudioServiceActivity}" drawable="polaris" name="Polaris" />
   <item component="ComponentInfo{photo.editor.polarr/android.support.main.a}" drawable="photo_editor" name="Polarr" />
   <item component="ComponentInfo{photo.editor.polarr/co.polarr.polarrphotoeditor.EditorActivity}" drawable="photo_editor" name="Polarr" />
   <item component="ComponentInfo{com.pons.onlinedictionary/com.pons.onlinedictionary.splashscreen.SplashScreen}" drawable="pons_translate" name="Pons Translate" />
@@ -3956,6 +3957,7 @@
   <item component="ComponentInfo{com.viber.voip/com.viber.voip.ViberApplication}" drawable="viber" name="Viber" />
   <item component="ComponentInfo{com.viber.voip/com.viber.voip.WelcomeActivity}" drawable="viber" name="Viber" />
   <item component="ComponentInfo{net.petafuel.mobile.vimpay/net.petafuel.mobile.vimpay.StartActivity}" drawable="vimpay" name="Vimpay" />
+  <item component="ComponentInfo{it.vfsfitvnm.vimusic/it.vfsfitvnm.vimusic.MainActivity}" drawable="vimusic" name="ViMusic" />
   <item component="ComponentInfo{fr.vinted/com.vinted.activities.MDActivity}" drawable="vinted" name="Vinted" />
   <item component="ComponentInfo{com.poupa.vinylmusicplayer/com.poupa.vinylmusicplayer.ui.activities.MainActivity}" drawable="vinyl" name="Vinyl" />
   <item component="ComponentInfo{com.pittvandewitt.viperfx/com.audlabs.viperfx.main.MainActivity}" drawable="viper4android" name="ViPER4Android FX" />

--- a/svgs/auxio.svg
+++ b/svgs/auxio.svg
@@ -1,1 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 24 24"><path d="M18.622 1.987V6.48h-4.339v12.9l-2.607 2.607H7.989L5.38 19.38v-3.688l2.608-2.607h4.01V1.987Z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 192 192"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 78.309996,112.81378 -29.348234,29.34833 27.838025,27.83813 27.554923,-27.55505 V 21.999163 l 38.68292,38.683059"
+       id="path1165" />
+  </g>
+</svg>

--- a/svgs/polaris.svg
+++ b/svgs/polaris.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 192 192"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.015648,146.14458 c 10.463957,-2.84055 10.539716,-16.43731 21.583499,-16.19186 11.043782,0.24547 11.909588,16.55126 22.672843,16.42442 10.763255,-0.12689 12.401145,-16.55635 23.021653,-16.55635 10.620511,0 12.778497,16.55635 23.137937,16.55635 10.35941,0 12.51065,-16.48664 22.99157,-16.48664 10.48088,0 11.63899,13.46069 21.32143,16.25408"
+       id="path4395" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 57.883617,142.02348 c 0,0 -10.763567,-11.46674 -13.583517,-27.0053 -3.129114,-22.151643 10.563087,-35.213902 27.2367,-39.948741 26.936305,-7.706073 34.57093,-1.419876 56.67608,-13.907586 -2.63812,-12.06491 7.43734,-5.259644 7.43734,-5.259644 13.47092,-8.677579 14.28597,-8.743592 23.74431,-6.548335 l 9.76981,-3.732032 c 0,0 4.47905,9.734568 -7.00369,20.481142 -9.46679,9.200588 -17.33418,23.261199 -17.33418,23.261199 -10.2974,18.497077 -11.87101,29.784347 -18.80835,46.047627"
+       id="path6425" />
+    <ellipse
+       style="stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path9254"
+       cx="151.05992"
+       cy="59.938545"
+       rx="4.0104361"
+       ry="4.0104313" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 128.21288,61.161853 0.31372,1.108997"
+       id="path9502" />
+  </g>
+</svg>

--- a/svgs/vimusic.svg
+++ b/svgs/vimusic.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 192 192"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 59.98106,131.62187 c 11.859825,-5.85216 24.445745,12.28051 26.998347,22.04722 2.688798,11.09971 -11.764184,13.9848 -18.812021,7.60937 -6.678622,-6.31085 -20.046152,-23.80445 -8.186326,-29.65659 z"
+       id="path9462" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 111.4246,63.463232 c 0,0 27.89627,17.56222 55.48613,18.881393 V 40.881222 C 138.69331,39.488082 111.4246,21.999505 111.4246,21.999505 V 143.3862 c 0,0 0,26.6138 -28.525025,26.6138 -20.346949,0 -34.091704,-16.64255 -34.091704,-34.39533 0,-19.29253 11.356908,-34.54494 33.555541,-34.54494 29.061188,0 29.061188,30.40982 29.061188,30.40982 M 26.150652,41.105778 C 20.300309,38.414133 39.549623,19.864715 61.165844,29.061234 100.515,45.802153 111.4246,112.47617 111.4246,112.47617 c 0,0 -34.61848,-48.06465 -85.273948,-71.370392 z"
+       id="path859" />
+  </g>
+</svg>


### PR DESCRIPTION
## Description

This pull adds 2 new icons, namely:
1. [Polaris Android](https://play.google.com/store/apps/details?id=agersant.polaris) - official android client for the [Polaris music streaming server](https://github.com/agersant/polaris).
2. [ViMusic](https://f-droid.org/packages/it.vfsfitvnm.vimusic/) - an open source app to stream music from YouTube Music.

and updates 1, i.e., [Auxio](https://f-droid.org/app/org.oxycblt.auxio) to resemble it's [current icon](https://github.com/OxygenCobalt/Auxio/blob/dev/fastlane/metadata/android/en-US/images/icon.png) and [switch to an outlined design](https://github.com/LawnchairLauncher/lawnicons/blob/develop/.github/CONTRIBUTING.md#icon-guidelines).

<!-- Fixes no issue as of now -->

## Type of change

:x: Bug fix
:white_check_mark: Icon addition
:x: General change

## Icons addition information

### Icons added
* Polaris (`agersant.polaris`)
* ViMusic (`it.vfsfitvnm.vimusic`)

### Icons updated
* Auxio (`org.oxycbit.auxio`)
