### PR TITLE
Add find_missing.py

### DIFF
--- a/find_missing.py
+++ b/find_missing.py
@@ -1,0 +1,14 @@
+from xml.etree.ElementTree import parse
+import os
+
+root = parse("app/assets/appfilter.xml").getroot()
+svgs = os.listdir("svgs/")
+drawables = []
+for i in root:
+    drawable = str(i.attrib.get("drawable", None)) + ".svg"
+    drawables.append(drawable)
+
+for i in svgs:
+    if i not in drawables:
+        if not i.startswith("themed_icon_calendar_"):
+            print(i)


### PR DESCRIPTION
## Description

I added the find_missing.py tool, it is similar to the find_duplicates.py
When you run the tool (`python3 find_missing.py`) it prints list of icons that are in the svg directory but are not present in the appfilter.xml file (unlinked/unused icons)

the current output is:
```
securego_plus.svg
flashy.svg
movie_lab.svg
show_youtube_dislikes.svg
samsung_health_monitor.svg
animiru.svg
gramotnee.svg
mi_freeform.svg
russian_language_quiz.svg
calendar.svg
pixapencil.svg
tricount.svg
tinkoff_work.svg
camera_date_folders.svg
penta.svg
coinvero.svg
schulmanager.svg
z1.svg
russian_language.svg
nc_photos.svg
erste_hilfe.svg
xvii.svg
prognoza.svg
revanced_extended.svg
```

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories like copyediting)