### PR TITLE
Link `com.android.email` to samsung_email icon

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1936,6 +1936,7 @@
   <item component="ComponentInfo{com.topjohnwu.magisk/QLa.I}" drawable="magisk" name="Magisk" />
   <item component="ComponentInfo{com.topjohnwu.magisk/V.T}" drawable="magisk" name="Magisk" />
   <item component="ComponentInfo{io.github.huskydg.magisk/com.topjohnwu.magisk.ui.MainActivity}" drawable="magisk" name="Magisk" />
+  <item component="ComponentInfo{com.android.email/com.android.email.login.activity.WelcomeActivity}" drawable="samsung_email" name="Mail" />
   <item component="ComponentInfo{ru.yandex.mail/ru.yandex.mail.im.RosterActivity}" drawable="yandex_mail" name="Mail" />
   <item component="ComponentInfo{ru.yandex.mail/ru.yandex.mail.ui.LoginActivity}" drawable="yandex_mail" name="Mail" />
   <item component="ComponentInfo{ru.yandex.mail/ru.yandex.mail.ui.MailListActivity}" drawable="yandex_mail" name="Mail" />


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

Link `com.android.email` to samsung_email icon. It has the same icon on ColorOS

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)

<!-- Erase the below text if you are not making an icon addition -->
## Icons addition information
<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->

### Icons linked
* Mail (linked `com.android.email` to `@drawable/samsung_email`)
