### PR TITLE
Add SHA-256 verification to Gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=ed2c26eba7cfb93cc2b7785d05e534f07b5b48b5e7fc941921cd098628abca58
+distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=ed2c26eba7cfb93cc2b7785d05e534f07b5b48b5e7fc941921cd098628abca58
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description

Allows for verification for the downloaded binary using SHA-256 hash comparison. This increases security against targeted attacks by preventing a man-in-the-middle attacker from tampering with the downloaded Gradle and in rare case, attacker gets access to the Gradle servers.

Renovate should be able to bump the Gradle version and checksums.

> **Note**: SHA-256 hash come from https://gradle.org/release-checksums/

## Type of change

:x: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories like copyediting)
