### PR TITLE
Downgrade material-motion-compose-core to 0.11.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,7 +132,7 @@ dependencies {
     implementation("com.google.accompanist:accompanist-systemuicontroller:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-placeholder-material:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-navigation-animation:$accompanistVersion")
-    implementation("io.github.fornewid:material-motion-compose-core:1.0.1")
+    implementation("io.github.fornewid:material-motion-compose-core:0.11.3")
     implementation("com.google.dagger:hilt-android:$hiltVersion")
     annotationProcessor("com.google.dagger:hilt-android-compiler:$hiltVersion")
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -3,7 +3,3 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
-
-# Please add these rules to your existing keep rules in order to suppress warnings.
-# This is generated automatically by the Android Gradle plugin.
--dontwarn androidx.compose.animation.AnimatedContentScope


### PR DESCRIPTION
Fix crash in release:

```
java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/compose/animation/AnimatedContentScope;
    at q1.i.Z(Unknown Source:0)
    at i.n.a(Unknown Source:676)
    at q1.q.a(Unknown Source:476)
    at q1.c.a(Unknown Source:80)
    at q1.c.M(Unknown Source:28)
    at A.K0.g(Unknown Source:14)
    at A.H.s0(Unknown Source:188)
    at A.H.I(Unknown Source:219)
    at A.H.q0(Unknown Source:32)
    at A.N.B(Unknown Source:18)
    at A.T0.E(Unknown Source:70)
    at A.R0.Z(Unknown Source:370)
    at androidx.compose.ui.platform.e0.doFrame(Unknown Source:6)
    at androidx.compose.ui.platform.d0.X(Unknown Source:33)
    at androidx.compose.ui.platform.c0.doFrame(Unknown Source:12)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1229)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1239)
    at android.view.Choreographer.doCallbacks(Choreographer.java:899)
    at android.view.Choreographer.doFrame(Choreographer.java:827)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1214)
    at android.os.Handler.handleCallback(Handler.java:984)
    at android.os.Handler.dispatchMessage(Handler.java:104)
    at android.os.Looper.loopOnce(Looper.java:238)
    at android.os.Looper.loop(Looper.java:357)
    at android.app.ActivityThread.main(ActivityThread.java:8118)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957)
    Suppressed: e2.J: [A.A0@37f56a4, androidx.compose.ui.platform.H0@760c0d, w0{Cancelling}@8fd47c2, d0@1c0d9d3]
```

It's the bad merge of #1179, see https://github.com/fornewid/material-motion-compose#compose-versions