### PR TITLE
Add nightly.link to download debug apks without GH account

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,10 +14,7 @@ This project is mostly supported by our community. If you wish to contribute, se
 ## Download
 See the [Releases section](https://github.com/LawnchairLauncher/lawnicons/releases) to download the latest stable build of Lawnicons.
 
-For the development versions with new icons, go to the [Actions tab](https://github.com/LawnchairLauncher/lawnicons/actions),
-click the first workflow run, and scroll to find the `Debug Apk`.
-
-**Note that you'll need to have a GitHub account to download the debug apk.**
+For the development versions with new icons, go to [nightly.link](https://nightly.link/LawnchairLauncher/lawnicons/workflows/build_debug_apk/develop/Debug%20APK).
 
 ## Contributing
 


### PR DESCRIPTION
## Description
Users will be able to download debug APKs from [nightly.link](https://nightly.link/) instead of Github actions which will eliminate the need to have an account. The nightly link is automatically updated.
<!-- 
Please include a summary of the change. Please also include relevant motivation and context.

If this PR is an icon addition one, please provide a short summary on what icons you added, changed, or linked
-->

Fixes #1251 

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
✅ : General change (non-breaking change that doesn't fit the above categories, such as copyediting)

