### PR TITLE
Let lintVitalAnalyzeAppRelease depend on copyAppReleaseArtifactList

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,11 @@ android {
         tasks.named("merge${capitalizedName}Assets").configure {
             dependsOn(copyArtifactList)
         }
+        if (buildType.name == "release") {
+            tasks.named("lintVitalAnalyze${capitalizedName}").configure {
+                dependsOn(copyArtifactList)
+            }
+        }
 
         outputs.all {
             (this as? ApkVariantOutputImpl)?.outputFileName =


### PR DESCRIPTION
Fix build error from https://github.com/LawnchairLauncher/lawnicons/actions/runs/5262850812/jobs/9512426343

```
A problem was found with the configuration of task ':app:lintVitalAnalyzeAppRelease' (type 'AndroidLintAnalysisTask').
  - Gradle detected a problem with the following location: '/home/runner/work/lawnicons/lawnicons/app/build/generated/dependencyAssets'.
    
    Reason: Task ':app:lintVitalAnalyzeAppRelease' uses this output of task ':app:copyAppReleaseArtifactList' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':app:copyAppReleaseArtifactList' as an input of ':app:lintVitalAnalyzeAppRelease'.
      2. Declare an explicit dependency on ':app:copyAppReleaseArtifactList' from ':app:lintVitalAnalyzeAppRelease' using Task#dependsOn.
      3. Declare an explicit dependency on ':app:copyAppReleaseArtifactList' from ':app:lintVitalAnalyzeAppRelease' using Task#mustRunAfter.
```

Follow up #1288