### PR TITLE
add workflow file to check SVGs in PR

### DIFF
--- a/.github/workflows/check_pr_svgs.yml
+++ b/.github/workflows/check_pr_svgs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create issue file
         run: |
-          echo "# Some of the svgs don't conform to the Lawnicon guidelines. Fix the svgs so that reviewers would have less to check and clarify deficiencies." > issues.json
+          echo "# Some of the svgs don't conform to the Lawnicon guidelines. Fix the svgs so that reviewers would have less to check and clarify deficiencies." > issues.txt
           echo "issue file created"
       
       - name: Check for issue(s)

--- a/.github/workflows/check_pr_svgs.yml
+++ b/.github/workflows/check_pr_svgs.yml
@@ -1,0 +1,156 @@
+name: PR SVG Check
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened]
+
+env:
+  viewbox: false
+  strokeColor: false
+  strokeWidth: false
+  fillColor: false
+  strokeLineJoin: false
+  issues: false
+
+jobs:
+  check-svg:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get added/changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+
+      - name: Create issue file
+        run: |
+          echo "# Some of the svgs don't conform to the Lawnicon guidelines. Fix the svgs so that reviewers would have less to check and clarify deficiencies." > issues.json
+          echo "issue file created"
+      
+      - name: Check for issue(s)
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            # check if file is an svg
+            if [[ $file == *.svg ]]; then
+              # read file content as xml
+              xml=$(cat $file)
+              
+              # check if xml has svg element with viewbox attribute equal to '0 0 192 192'
+              if [[ ! $xml == *"<svg"*"viewBox=\"0 0 192 192\""* ]]; then
+                echo "File $file is invalid"
+                if [[ $viewbox == false ]]; then
+                  echo "" >> issues.txt
+                  echo "### **Incorrect viewbox size**. Viewbox should be \`0 0 192 192\` in file(s):" >> issues.txt
+                  viewbox=true
+                fi
+                echo "- \`$file\`" >> issues.txt
+              fi
+            fi
+          done
+          
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            # check if file is an svg
+            if [[ $file == *.svg ]]; then
+              # read file content as xml
+              xml=$(cat $file)
+              
+              # check if xml contains "stroke" attrribute with value of "black, #000000, #000, rgb(0,0,0), rgb(0%,0%,0%)"
+              if [[ ! $xml == *"stroke=\"black\""* && ! $xml == *"stroke=\"#000000\""* && ! $xml == *"stroke=\"#000\""* && ! $xml == *"stroke=\"rgb(0,0,0)\""* && ! $xml == *"stroke=\"rgb(0%,0%,0%)\""* ]]; then
+                echo "File $file is invalid"
+                if [[ $strokeColor == false ]]; then
+                  echo "" >> issues.txt
+                  echo "### **Incorrect stroke color**. Stroke color should be black (\`black\`, \`#000000\`, \`#000\`, \`rgb(0,0,0)\`, or \`rgb(0%,0%,0%)\`) in file(s):" >> issues.txt
+                  strokeColor=true
+                fi
+                echo "- \`$file\`" >> issues.txt
+              fi
+            fi
+          done
+          
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            # check if file is an svg
+            if [[ $file == *.svg ]]; then
+              # read file content as xml
+              xml=$(cat $file)
+              
+              # check if xml contains "stroke-width" attrribute with value of "12"
+              if [[ ! $xml == *"stroke-width=\"12\""* ]]; then
+                echo "File $file is invalid"
+                if [[ $strokeWidth == false ]]; then
+                  echo "" >> issues.txt
+                  echo "### **Incorrect stroke width**. Standard stroke width should be \`12\`px in file(s):  " >> issues.txt
+                  echo "*Other width can be used but 12 should be the main width*" >> issues.txt
+                  strokeWidth=true
+                fi
+                echo "- \`$file\`" >> issues.txt
+              fi
+            fi
+          done
+          
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            # check if file is an svg
+            if [[ $file == *.svg ]]; then
+              # read file content as xml
+              xml=$(cat $file)
+              
+              # check if xml contains "fill" attrribute with value of "none"
+              if [[ ! $xml == *"fill=\"none\""* ]]; then
+                echo "File $file is invalid"
+                if [[ $fillColor == false ]]; then
+                  echo "" >> issues.txt
+                  echo "### **Incorrect fill value**. No attribute \`fill\` with value \`none\` was found in file(s):  " >> issues.txt
+                  echo "*Icons must be outlined (not filled)*  " >> issues.txt
+                  echo "*If your icon does not contain any \`<path>\` (only \`<circle>\` or \`<rect>\`), you can ignore this warning.*" >> issues.txt
+                  fillColor=true
+                fi
+                echo "- \`$file\`" >> issues.txt
+              fi
+            fi
+          done
+          
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            # check if file is an svg
+            if [[ $file == *.svg ]]; then
+              # read file content as xml
+              xml=$(cat $file)
+              
+              # check if xml contains "stroke-linejoin" attrribute with value of "round"
+              if [[ ! $xml == *"stroke-linejoin=\"round\""* ]]; then
+                echo "File $file is invalid"
+                if [[ $strokeLineJoin == false ]]; then
+                  echo "" >> issues.txt
+                  echo "### **Incorrect corner radius**. No attribute \`stroke-linejoin\` with value \`round\` was found. Icons must have a rounded corners in file(s):  " >> issues.txt
+                  echo "*If your icon does not contain any \`<path>\` (only \`<circle>\` or \`<rect>\`), you can ignore this warning.*" >> issues.txt
+                  strokeLineJoin=true
+                fi
+                echo "- \`$file\`" >> issues.txt
+              fi
+            fi
+          done
+          
+          # if any error were found, we add "see contributing.md for more details" at the end of the file
+          if [[ $viewbox == true || $strokeColor == true || $strokeWidth == true || $fillColor == true || $strokeLineJoin == true ]]; then
+            echo "" >> issues.txt
+            echo "See [CONTRIBUTING](https://github.com/LawnchairLauncher/lawnicons/blob/develop/.github/CONTRIBUTING.md) guide for more details" >> issues.txt
+          fi
+      
+      - name: Check for issue file
+        id: file_check
+        run: |
+          if [[ -f issues.txt ]]; then
+            echo "check_result=true" >> $GITHUB_OUTPUT
+          else
+            echo "check_result=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Create comment
+        if: steps.file_check.outputs.check_result == 'true'
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-path: issues.txt

--- a/.github/workflows/check_pr_svgs.yml
+++ b/.github/workflows/check_pr_svgs.yml
@@ -1,156 +1,44 @@
-name: PR SVG Check
+name: SVG Validation
 
 on:
   pull_request:
     branches: [develop]
     types: [opened]
-
-env:
-  viewbox: false
-  strokeColor: false
-  strokeWidth: false
-  fillColor: false
-  strokeLineJoin: false
-  issues: false
+    paths:
+      - '**.svg'
 
 jobs:
-  check-svg:
+  validate:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Get added/changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v37
-
-      - name: Create issue file
-        run: |
-          echo "# Some of the svgs don't conform to the Lawnicon guidelines. Fix the svgs so that reviewers would have less to check and clarify deficiencies." > issues.txt
-          echo "issue file created"
-      
-      - name: Check for issue(s)
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            # check if file is an svg
-            if [[ $file == *.svg ]]; then
-              # read file content as xml
-              xml=$(cat $file)
-              
-              # check if xml has svg element with viewbox attribute equal to '0 0 192 192'
-              if [[ ! $xml == *"<svg"*"viewBox=\"0 0 192 192\""* ]]; then
-                echo "File $file is invalid"
-                if [[ $viewbox == false ]]; then
-                  echo "" >> issues.txt
-                  echo "### **Incorrect viewbox size**. Viewbox should be \`0 0 192 192\` in file(s):" >> issues.txt
-                  viewbox=true
-                fi
-                echo "- \`$file\`" >> issues.txt
-              fi
-            fi
-          done
-          
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            # check if file is an svg
-            if [[ $file == *.svg ]]; then
-              # read file content as xml
-              xml=$(cat $file)
-              
-              # check if xml contains "stroke" attrribute with value of "black, #000000, #000, rgb(0,0,0), rgb(0%,0%,0%)"
-              if [[ ! $xml == *"stroke=\"black\""* && ! $xml == *"stroke=\"#000000\""* && ! $xml == *"stroke=\"#000\""* && ! $xml == *"stroke=\"rgb(0,0,0)\""* && ! $xml == *"stroke=\"rgb(0%,0%,0%)\""* ]]; then
-                echo "File $file is invalid"
-                if [[ $strokeColor == false ]]; then
-                  echo "" >> issues.txt
-                  echo "### **Incorrect stroke color**. Stroke color should be black (\`black\`, \`#000000\`, \`#000\`, \`rgb(0,0,0)\`, or \`rgb(0%,0%,0%)\`) in file(s):" >> issues.txt
-                  strokeColor=true
-                fi
-                echo "- \`$file\`" >> issues.txt
-              fi
-            fi
-          done
-          
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            # check if file is an svg
-            if [[ $file == *.svg ]]; then
-              # read file content as xml
-              xml=$(cat $file)
-              
-              # check if xml contains "stroke-width" attrribute with value of "12"
-              if [[ ! $xml == *"stroke-width=\"12\""* ]]; then
-                echo "File $file is invalid"
-                if [[ $strokeWidth == false ]]; then
-                  echo "" >> issues.txt
-                  echo "### **Incorrect stroke width**. Standard stroke width should be \`12\`px in file(s):  " >> issues.txt
-                  echo "*Other width can be used but 12 should be the main width*" >> issues.txt
-                  strokeWidth=true
-                fi
-                echo "- \`$file\`" >> issues.txt
-              fi
-            fi
-          done
-          
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            # check if file is an svg
-            if [[ $file == *.svg ]]; then
-              # read file content as xml
-              xml=$(cat $file)
-              
-              # check if xml contains "fill" attrribute with value of "none"
-              if [[ ! $xml == *"fill=\"none\""* ]]; then
-                echo "File $file is invalid"
-                if [[ $fillColor == false ]]; then
-                  echo "" >> issues.txt
-                  echo "### **Incorrect fill value**. No attribute \`fill\` with value \`none\` was found in file(s):  " >> issues.txt
-                  echo "*Icons must be outlined (not filled)*  " >> issues.txt
-                  echo "*If your icon does not contain any \`<path>\` (only \`<circle>\` or \`<rect>\`), you can ignore this warning.*" >> issues.txt
-                  fillColor=true
-                fi
-                echo "- \`$file\`" >> issues.txt
-              fi
-            fi
-          done
-          
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            # check if file is an svg
-            if [[ $file == *.svg ]]; then
-              # read file content as xml
-              xml=$(cat $file)
-              
-              # check if xml contains "stroke-linejoin" attrribute with value of "round"
-              if [[ ! $xml == *"stroke-linejoin=\"round\""* ]]; then
-                echo "File $file is invalid"
-                if [[ $strokeLineJoin == false ]]; then
-                  echo "" >> issues.txt
-                  echo "### **Incorrect corner radius**. No attribute \`stroke-linejoin\` with value \`round\` was found. Icons must have a rounded corners in file(s):  " >> issues.txt
-                  echo "*If your icon does not contain any \`<path>\` (only \`<circle>\` or \`<rect>\`), you can ignore this warning.*" >> issues.txt
-                  strokeLineJoin=true
-                fi
-                echo "- \`$file\`" >> issues.txt
-              fi
-            fi
-          done
-          
-          # if any error were found, we add "see contributing.md for more details" at the end of the file
-          if [[ $viewbox == true || $strokeColor == true || $strokeWidth == true || $fillColor == true || $strokeLineJoin == true ]]; then
-            echo "" >> issues.txt
-            echo "See [CONTRIBUTING](https://github.com/LawnchairLauncher/lawnicons/blob/develop/.github/CONTRIBUTING.md) guide for more details" >> issues.txt
-          fi
-      
-      - name: Check for issue file
-        id: file_check
-        run: |
-          if [[ -f issues.txt ]]; then
-            echo "check_result=true" >> $GITHUB_OUTPUT
-          else
-            echo "check_result=false" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Create comment
-        if: steps.file_check.outputs.check_result == 'true'
-        uses: mshick/add-pr-comment@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          message-path: issues.txt
+          node-version: '18'
+      
+      - name: Run JS action on SVG files
+        run: |
+          node svg-check.js $(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep .svg$ | xargs)
+
+      - name: Post comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs');
+            const errorFile = 'errors.md';
+            if (fs.existsSync(errorFile)) {
+              const errors = fs.readFileSync(errorFile, 'utf8');
+              const issue_number = context.issue.number;
+              github.rest.issues.createComment({
+                issue_number: issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: errors
+              });
+            }

--- a/svg-check.js
+++ b/svg-check.js
@@ -1,0 +1,109 @@
+const fs = require('fs');
+const path = require('path');
+
+const rules = [
+    {
+        name: "viewBox",
+        rule: "viewBox=\"0 0 192 192\"",
+        error: "Incorrect viewbox size",
+        description: "Viewbox should be \`0 0 192 192\`",
+        protip: null
+    },
+    {
+        name: "fillValue",
+        rule: "fill=\"none\"",
+        error: "Incorrect fill value",
+        description: "Fill should be set to \`none\` and be outlined",
+        protip: "If your icon does not contain any \`<path>\` (only \`<circle>\` or \`<rect>\`), you can ignore this warning"
+    },
+    {
+        name: "strokeColor",
+        rule: [
+            "stroke=\"black\"",
+            "stroke=\"#000000\"",
+            "stroke=\"#000\"",
+            "stroke=\"rgb(0,0,0)\"",
+            "stroke=\"rgb(0%,0%,0%)\""
+        ],
+        error: "Incorrect stroke value",
+        description: "Stroke should be set to **black** *(\`black\`, \`#000000\`, \`#000\`, \`rgb(0,0,0)\`, or \`rgb(0%,0%,0%)\`)*",
+        protip: null
+    },
+    {
+        name: "strokeWidth",
+        rule: "stroke-width=\"12\"",
+        error: "Incorrect stroke-width value",
+        description: "Standard stroke width should be \`12\`px",
+        protip: "Other width can be used for finer details but 12 should be the main width"
+    },
+    {
+        name: "strokeLinejoin",
+        rule: "stroke-linejoin=\"round\"",
+        error: "Incorrect stroke-linejoin value",
+        description: "Stroke-linejoin should be set to \`round\`",
+        protip: "If your icon does not contain any \`<path>\` (only \`<circle>\` or \`<rect>\`), you can ignore this warning"
+    }
+];
+
+function validateSvg(file) {
+    let hasError = false;
+    let errors = [];
+
+    try {
+        const svg = fs.readFileSync(file, 'utf8');
+
+        rules.forEach(rule => {
+            rule.rule = Array.isArray(rule.rule)? rule.rule : [rule.rule];
+            if(!rule.rule.some(r => svg.includes(r))) {
+                rule.affectedFiles = rule.affectedFiles || [];
+                rule.affectedFiles.push(file);
+            }
+        });
+    } catch (err) {
+        console.error(`File ${file} does not exist or is not readable`);
+        return [];
+    }
+    console.log(`${file} tested`);
+}
+
+// files should be process.argv minus 0 and 1
+const files = process.argv.slice(2);
+console.log(`${files}`)
+
+if (files.length === 0) {
+    console.log('No file path provided');
+    process.exit(0);
+}
+
+files.forEach(file => {
+    const errors = validateSvg(file);
+});
+
+// get each rules with affected files
+const rulesWithAffectedFiles = rules.filter(rule => rule.affectedFiles);
+if (rulesWithAffectedFiles.length > 0) {
+    const errorFile = path.join(process.cwd(), 'errors.md');
+    // for each rule, write the rule name and the affected files
+    try {
+        fs.appendFileSync(errorFile, `# Thanks for contributing! Some of the svgs don't conform to the [Lawnicon guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/.github/CONTRIBUTING.md):\n`);
+        rulesWithAffectedFiles.forEach(rule => {
+            fs.appendFileSync(errorFile, `- ## ${rule.name}:\n`);
+            fs.appendFileSync(errorFile, `\t${rule.description}.  \n`);
+            fs.appendFileSync(errorFile, `\tAffected files:\n`);
+            rule.affectedFiles.forEach(affectedFile => {
+                fs.appendFileSync(errorFile, `\t- ${affectedFile}\n`);
+            });
+            if (rule.protip) fs.appendFileSync(errorFile, `\n\t*${rule.protip}.*\n`);
+        });
+        fs.appendFileSync(errorFile, `\n### Please fix these mistakes and update your pull request, thank you! See the [Contributing guide](https://github.com/LawnchairLauncher/lawnicons/blob/develop/.github/CONTRIBUTING.md) for more details.`);
+    } catch (err) {
+        console.log(`Error while writing errors to ${errorFile}`);
+    }
+} else {
+    try {
+        const errorFile = path.join(process.cwd(), 'errors.md');
+        fs.appendFileSync(errorFile, `# Thanks for contributing! No mistakes have been found in your pull request. Kindly wait for a reviewer to validate your contribution.`);
+    } catch (err) {
+        console.log(`Error while writing errors to ${errorFile}`);
+    }
+}


### PR DESCRIPTION
## Description

As discused in #1318, I tried to create a PoC of a workflow that could help reviewers quickly see common mistakes made by contributors as well as helping said contributors find out what need to be changed.

You can test the workflow on a repo I made [here](https://github.com/lorrding/workflow-test). I already made 2 PRs with and without issues. Feel free to create any PR with .svg files to test out and see if everything works as intended.
Also, feel free to suggest modifications that could be made to the comment building part or suggest other rules I forgot to include.

This is my first time digging into workflows so this version is far from optimized.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
✅  General change (non-breaking change that doesn't fit the above categories, such as copyediting)
