### PR TITLE
Fix first-interaction workflow

### DIFF
--- a/.github/workflows/first_pr_interaction.yml
+++ b/.github/workflows/first_pr_interaction.yml
@@ -14,18 +14,12 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-    # additional checks, might remove later
-    - name: Check if PR contains svg change
-      uses: JJ/github-pr-contains-action@releases/v10
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        diffContains: '<svg|</svg>'
     - name: Send message if first interaction
       if: steps.outcome != 'failure'
       uses: actions/first-interaction@v1.1.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: |
+        pr-message: |
           Thanks for your interest in contributing to Lawnicons!
           Ensure that the size of your icons, their line thicknesses, and their corner radius match the [Lawnicons guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/.github/CONTRIBUTING.md#icon-guidelines).
           If something is wrong with your icons, please correct them and update the PR.


### PR DESCRIPTION
## Description
Right now the action sometimes errors, this should make it not error

## Type of change

:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: Icon addition (non-breaking change that adds/modifies Lawnicons's icons)
:x: General change (non-breaking change that doesn't fit the above categories, such as copyediting)