### PR TITLE
fix checklist rendering in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -18,6 +18,6 @@
 * App Name (linked `package.name` to `@drawable/package`)
 
 ## Contributor's checklist
-[ ] I have followed the [Lawnicons Guidelines](./github/CONTRIBUTING.md)
-[ ] I have ensured that Lawnicons builds correctly
-[ ] I am willing to make changes to my icons if someone suggests changes
+- [ ] I have followed the [Lawnicons Guidelines](./github/CONTRIBUTING.md)
+- [ ] I have ensured that Lawnicons builds correctly
+- [ ] I am willing to make changes to my icons if someone suggests changes


### PR DESCRIPTION
## Description
Previously the checklist in the pr template used `[x] ...`

![image](https://github.com/LawnchairLauncher/lawnicons/assets/104420015/2222b1b4-9435-4be9-98b4-2c1c979a6f7e)

<!-- 
Please include a summary of the change. Please also include relevant motivation and context.
-->

<!--
Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
-->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark:  General change (non-breaking change that doesn't fit the above categories, such as copyediting)
