### PR TITLE
Replacing links to the icon request form

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [Releases section](https://github.com/LawnchairLauncher/lawnicons/releas
 ## Contributing
 Please see the [contributing guide](CONTRIBUTING.md) for information on adding icons or contributing code. It will help you avoid mistakes and save time.
 
-Before you make the icons, you can check out the examples [in Figma](https://www.figma.com/community/file/1227718471680779613). In addition, you can see which icons users want in the [popular requests](https://docs.google.com/spreadsheets/d/10_o0DjhAGfP8ToDDNQ8M7eCZKtbzXLhIvxuF1XZEql0/edit#gid=327531090) or [raw requests](https://docs.google.com/spreadsheets/d/1h3eiJnG2nEdR1DbvemaF1lYthHkzYbXvVFPP0TEEt5k/edit?usp=sharing). If you make icons regularly or dozens at once, you can speed up contributing with [icontool.py](/docs/icontool_guide.md).
+Before you make the icons, you can check out the examples [in Figma](https://www.figma.com/community/file/1227718471680779613). In addition, you can see which icons users want in the [popular requests](https://docs.google.com/spreadsheets/d/1AXc9EDXA6udZeGROtB5nuABjM33VluGY_V24tIzHaKc/edit?resourcekey#gid=1923954573). If you make icons regularly or dozens at once, you can speed up contributing with [icontool.py](/docs/icontool_guide.md).
 
 If you are a developer, you may find the [contributing code section](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md#contributing-code) useful.
 

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/About.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/About.kt
@@ -41,7 +41,7 @@ private val externalLinks = listOf(
     ),
     ExternalLink(
         name = "Icon Request Form",
-        url = "https://forms.gle/Fx8vZAiWdW1Tyjo57",
+        url = "https://forms.gle/xt7sJhgWEasuo9TR9",
     ),
 )
 


### PR DESCRIPTION
Updated the links to the icon request form in the description and app, because the description of the old form was dragging out the icon creation process.

#1610

## Type of change
:x: Bug fix
:x: Icon addition
:white_check_mark: General change
