### PR TITLE
Updating the link to Lawnicons guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -19,6 +19,6 @@
 
 ## Contributor's checklist
 <!-- Replace [ ] with [x] to check -->
-- [ ] I have followed the [Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/.github/CONTRIBUTING.md)
+- [ ] I have followed the [Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md)
 - [ ] I have ensured that Lawnicons builds correctly
 - [ ] I am willing to make changes to my icons if someone suggests changes


### PR DESCRIPTION
Discovered another link that broke after moving docs.
