### PR TITLE
Updating and simplifying templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_discussion.yml
+++ b/.github/ISSUE_TEMPLATE/general_discussion.yml
@@ -1,6 +1,5 @@
 name: General Discussion
 description: Discuss something related to Lawnicons.
-title: "[DISCUSSION] "
 labels: [discussion]
 body:
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -1,21 +1,20 @@
 # Description
-<!-- Please provide a short summary of what icons you added, changed, or linked
--->
+<!-- Please provide a short summary of what icons you added, changed, or linked -->
 
 ## Icons addition information
-<!-- Please specify if you added an icon that was requested in the icon request form, as seen below -->
-### Icons added
-* App Name (`package.name`) - added from icon request form
-* App Name (`package.name`)
-* App Name (`package.name`)
 
-### Icons updated
-* App Name (`package.name`)
-* App Name (`package.name`)
+### Added
+App Name (`com.package.app`)
+App Name (`com.package.app`)
+App Name (`com.package.app`)
 
-### Icons linked
-* App Name (linked `package.name` to `@drawable/package`)
-* App Name (linked `package.name` to `@drawable/package`)
+### Updated
+App Name (`com.package.app`)
+App Name (`com.package.app`)
+
+### Linked
+App Name (`com.package.app` → `drawable.svg`)
+App Name (`com.package.app` → `drawable.svg`)
 
 ## Contributor's checklist
 <!-- Replace [ ] with [x] to check -->

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -8,13 +8,13 @@ App Name (`com.package.app`)
 App Name (`com.package.app`)
 App Name (`com.package.app`)
 
-### Updated
-App Name (`com.package.app`)
-App Name (`com.package.app`)
-
 ### Linked
 App Name (`com.package.app` → `drawable.svg`)
 App Name (`com.package.app` → `drawable.svg`)
+
+### Updated
+App Name (`com.package.app`)
+App Name (`com.package.app`)
 
 ## Contributor's checklist
 <!-- Replace [ ] with [x] to check -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-<!-- Please select the the `Preview` tab -->
+<!-- Please open the the `Preview` tab to select a template  -->
 
-Select the appropriate sub-template:
+## Click on the template that fits your PR
 * [**Icon addition**](?expand=1&template=icon_addition.md&labels=needs+review,icon+change)
 * [General or miscellaneous change](?expand=1&template=general_change.md)
 * *[Blank](?expand=1&body=+) (not recommended)*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please open the the `Preview` tab to select a template  -->
+<!-- Please open the `Preview` tab to select a template  -->
 
 ## Click on the template that fits your PR
 * [**Icon addition**](?expand=1&template=icon_addition.md&labels=needs+review,icon+change)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please open the `Preview` tab to select a template  -->
+<!-- Please open the `Preview` tab to select a template -->
 
 ## Click on the template that fits your PR
 * [**Icon addition**](?expand=1&template=icon_addition.md&labels=needs+review,icon+change)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Please open the `Preview` tab to select a template -->
 
 ## Click on the template that fits your PR
-* [**Icon addition**](?expand=1&template=icon_addition.md&labels=needs+review,icon+change)
+* [**Icon addition**](?expand=1&template=icon_addition.md)
 * [General or miscellaneous change](?expand=1&template=general_change.md)
 * *[Blank](?expand=1&body=+) (not recommended)*


### PR DESCRIPTION
## Description
I suggest some changes to the templates to remove unnecessary information and clarify what is needed from the contributor.

## Type of change
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)

## Changelog
- Removed [DISCUSSION] from the issue template because it was duplicating the label.
- Shortened the subheadings in the icon addition template because they were duplicating the header.
- Removed the note about the icon being added from the request form, because that wasn't used and you can see in the current requests table what requests are fulfilled.
- Removed the indentation in the icon lists to make it easier to read.
- Renamed the package name example to make it closer to the real ones.
- Simplified the entry to add links because the `@drawable/package` part was unclear.
- Clarified in the PR template what actions to take. In particular it was not obvious that the template could be inserted into the description if you clicked on the link.

