### PR TITLE
Naming guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Correct • Edited name: "Zoom"
 Names are separated via `~~`. If the app name is localized, then the first name should be the one most commonly spoken by the people who will be searching for the icon (if in doubt, in English). 
 ```
 Wrong
-<item component="..." drawable="hulu" name="Hulu" />
+<item component="..." drawable="hulu" name="フールー ~~ Hulu" />
 ```
 ```
 Correct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,47 @@ To avoid sharp contrast, you can follow either of these two methods:
 1. **Uniform Stroke:** Instead of jumping between stroke thicknesses, use the next immediate increment in width. For example, transition from *12px* to *10px*.
 2. **Gradual Transition:** Rather than making a large jump, introduce an intermediate thickness. By going from `12px` to `10px` and then to `8px` you create a gradual transition or gradation. This approach helps maintain visual balance in your icon design.
 
+## Naming
+To make it easier to find icons, you should keep the original names and supplement them with an English variant or transliteration. If you are adding a link to an existing icon, keep (or complement) the existing drawable and app names.
+### App name
+Should be the same as in Google Play, F-Droid or the official name. If the name in the source is too long, it's acceptable to remove the second part of the name without loss of recognition.
+```
+Wrong • Google Play name: "Zoom - One Platform to Connect"
+<item component="..." drawable="zoom" name="Zoom - One Platform to Connect" />
+```
+```
+Correct • Edited name: "Zoom"
+<item component="..." drawable="zoom" name="Zoom" />
+```
+If the app name is localized, then the first name should be the one most commonly spoken by the people who will be searching for the icon (if in doubt, in English).
+```
+Wrong
+<item component="..." drawable="hulu" name="Hulu" />
+```
+```
+Correct
+<item component="..." drawable="hulu" name="Hulu ~~ フールー" />
+```
+If the app name doesn't have an English localization, then you need to properly transliterate the name into English and add it after the original name via `~~`.
+```
+Wrong
+<item component="..." drawable="niconico" name="ニコニコ" />
+```
+```
+Correct
+<item component="..." drawable="niconico" name="ニコニコ ~~ Niconico" />
+```
+### Drawable
+Should be in English or transliterated from the original language. Should repeat the name of the app if possible.
+```
+Wrong
+<item component="..." drawable="meinvodafone" name="My Vodafone ~~ MeinVodafone" />
+```
+```
+Correct
+<item component="..." drawable="my_vodafone" name="My Vodafone ~~ MeinVodafone" />
+```
+
 ## Adding an icon to Lawnicons
 Here's how to add an icon to Lawnicons:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Wrong • Google Play name: "Zoom - One Platform to Connect"
 Correct • Edited name: "Zoom"
 <item component="..." drawable="zoom" name="Zoom" />
 ```
-If the app name is localized, then the first name should be the one most commonly spoken by the people who will be searching for the icon (if in doubt, in English).
+Names are separated via `~~`. If the app name is localized, then the first name should be the one most commonly spoken by the people who will be searching for the icon (if in doubt, in English). 
 ```
 Wrong
 <item component="..." drawable="hulu" name="Hulu" />
@@ -77,7 +77,7 @@ Wrong
 Correct
 <item component="..." drawable="hulu" name="Hulu ~~ フールー" />
 ```
-If the app name doesn't have an English localization, then you need to properly transliterate the name into English and add it after the original name via `~~`.
+If the app name doesn't have an English localization, then you need to properly transliterate the name into English.
 ```
 Wrong
 <item component="..." drawable="niconico" name="ニコニコ" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ To avoid sharp contrast, you can follow either of these two methods:
 2. **Gradual Transition:** Rather than making a large jump, introduce an intermediate thickness. By going from `12px` to `10px` and then to `8px` you create a gradual transition or gradation. This approach helps maintain visual balance in your icon design.
 
 ## Naming
-To make it easier to find icons, you should keep the original names and supplement them with an English variant or transliteration. If you are adding a link to an existing icon, keep (or complement) the existing drawable and app names.
+To make it easier to find icons, you should keep the original names and supplement them with an English variant or transliteration. If you are adding a link to an existing icon, keep (or complement) the existing app and drawable names.
 ### App name
 Should be the same as in Google Play, F-Droid or the official name. If the name in the source is too long, it's acceptable to remove the second part of the name without loss of recognition.
 ```


### PR DESCRIPTION
Since we have issues with naming, and out of a desire to simplify the search for different languages, I propose to describe the rules for naming apps and drawables. I suggest we stick to them.

If any wording is questionable, let's take that into consideration. I also used `~~` as a name separator, because `/` and `|` are sometimes found in app names, and `~` is sometimes found in Japanese part of Google Play. Any of these characters written twice would probably work, but tildes are neater in my opinion.

Fixes #1715

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)


