### PR TITLE
Clarified how to name apps w/o a name localization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,14 +77,14 @@ Wrong
 Correct
 <item component="..." drawable="hulu" name="Hulu ~~ フールー" />
 ```
-If the app name doesn't have an English localization, then you need to properly transliterate the name into English.
+If the app name has letters that aren't in English and it doesn't have an English localization, then you need to properly transliterate the name into English.
 ```
 Wrong
-<item component="..." drawable="niconico" name="ニコニコ" />
+<item component="..." drawable="otp_szep_card" name="OTP SZÉP Card" />
 ```
 ```
 Correct
-<item component="..." drawable="niconico" name="ニコニコ ~~ Niconico" />
+<item component="..." drawable="otp_szep_card" name="OTP SZÉP Card ~~ OTP SZEP Card" />
 ```
 ### Drawable
 Should be in English or transliterated from the original language. Should repeat the name of the app if possible.


### PR DESCRIPTION
It happens that only English letters are used in the name of the app, although the app may be, say, Turkish. Often there is no point in translating such a name, as it's convenient to search for it by its original name.

At the same time, if the name contains characters from other languages, it can make the search more difficult for people who don't have a suitable keyboard layout.

Clarified what to do about such cases.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark:  General change (non-breaking change that doesn't fit the above categories, such as copyediting)
