### PR TITLE
Simplifying Contributor's checklist and instructions updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/general_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general_change.md
@@ -1,17 +1,10 @@
 ## Description
-
-<!-- 
-Please include a summary of the change. Please also include relevant motivation and context.
--->
+<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
 
 Fixes #(issue)
-
-<!--
-Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue.
--->
+<!-- Note: You can remove the "Fixes #(issue)" if you don't plan on making this PR close an issue. -->
 
 ## Type of change
-<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->
-
+<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
 :x: Bug fix (non-breaking change which fixes an issue)
 :x: General change (non-breaking change that doesn't fit the above categories, such as copyediting)

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -1,8 +1,8 @@
 # Description
-<!-- Please provide a short summary of your pull request -->
+<!-- Please provide a short summary of your pull request. -->
 
 ## Icons addition information
-<!--  Please specify the apps and packages for which you have added, linked, or updated icons. Unnecessary sections can be deleted -->
+<!--  Please specify the apps and packages for which you have added, linked, or updated icons. Unnecessary sections can be deleted. -->
 ### Added
 App Name (`com.package.app`)
 App Name (`com.package.app`)
@@ -16,5 +16,5 @@ App Name (`com.package.app`)
 App Name (`com.package.app`)
 
 ## Contributor's checklist
-<!-- Replace [ ] with [x] to check -->
+<!-- Replace [ ] with [x] to check. -->
 - [ ] I made the icons following [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (upd. Jan 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -18,4 +18,4 @@ App Name (`com.package.app`)
 
 ## Contributor's check
 <!-- Replace [ ] with [x] to check -->
-- [ ] I made the icons following [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (updated January 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.
+- [ ] I made the icons following [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (upd. Jan 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -16,6 +16,6 @@ App Name (`com.package.app` → `drawable.svg`)
 App Name (`com.package.app`)
 App Name (`com.package.app`)
 
-## Contributor's check
+## Contributor's checklist
 <!-- Replace [ ] with [x] to check -->
 - [ ] I made the icons following [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (upd. Jan 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -1,10 +1,9 @@
 # Description
-<!-- Please provide a short summary of what icons you added, changed, or linked -->
+<!-- Please provide a short summary of your pull request -->
 
 ## Icons addition information
-
+<!--  Please specify the apps and packages for which you have added, linked, or updated icons. Unnecessary sections can be deleted. -->
 ### Added
-App Name (`com.package.app`)
 App Name (`com.package.app`)
 App Name (`com.package.app`)
 

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -2,7 +2,7 @@
 <!-- Please provide a short summary of your pull request -->
 
 ## Icons addition information
-<!--  Please specify the apps and packages for which you have added, linked, or updated icons. Unnecessary sections can be deleted. -->
+<!--  Please specify the apps and packages for which you have added, linked, or updated icons. Unnecessary sections can be deleted -->
 ### Added
 App Name (`com.package.app`)
 App Name (`com.package.app`)

--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -16,8 +16,6 @@ App Name (`com.package.app` → `drawable.svg`)
 App Name (`com.package.app`)
 App Name (`com.package.app`)
 
-## Contributor's checklist
+## Contributor's check
 <!-- Replace [ ] with [x] to check -->
-- [ ] I have followed the [Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md)
-- [ ] I have ensured that Lawnicons builds correctly
-- [ ] I am willing to make changes to my icons if someone suggests changes
+- [ ] I made the icons following [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (updated January 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 <!-- Please open the `Preview` tab to select a template -->
+<!-- Note that we will ask you for a minimum description if there is none -->
 
 ## Click on the template that fits your PR
 * [**Icon addition**](?expand=1&template=icon_addition.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-<!-- Please open the `Preview` tab to select a template -->
-<!-- Note that we will ask you for a minimum description if there is none -->
+<!-- Please open the `Preview` tab to select a template. -->
+<!-- Note that we will ask you for a minimum description if there is none. -->
 
 ## Click on the template that fits your PR
 * [**Icon addition**](?expand=1&template=icon_addition.md)


### PR DESCRIPTION
## Description
I suggest leaving one checkbox. The main purpose of this list is to remind contributors about the Lawnicons Guidelines and what to expect next. It doesn't work, because judging by the reviews, many people put checkboxes just for fun. It's a mockery that checkboxes should be placed by keyboard, but I see the benefit of this section, it's better to keep it. So I minimize unnecessary actions.

**Changelog**
- three checkboxes became one.
- marked when the last guidelines update was, so old contributors would be aware.
- changed the wording about builds because it is inconvenient to first make a PR, then make sure that Lawnicons builds correctly, and then check that checkbox. Many contributors checked the checkbox first and then saw the result of the build. New contributors waited for approval of the build with the checkbox checked. 2-3 times I've seen contributors wait for the build result before checking the checkbox.

**Also, small changes to improve the quality of descriptions**
- clarified the instructions so that new contributors know exactly what is required, as some are filling out the template incorrectly.
- added a line to the pull request template stating that we will ask for a minimum description if there is none.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
