### PR TITLE
Clarified the process of filling out the icon request form

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Please check the [icon tool guide](/docs/icontool_guide.md) for more information
 
 1. Download the [IconRequest app](https://github.com/Kaiserdragon2/IconRequest/releases).
 2. Launch the app and click one of the options:
-- UPDATE EXISTING — to copy packages with activities. [How to request icons](https://kappa.lol/FL_Oh) • 25s video.
+- UPDATE EXISTING — to copy packages with activities. [How to request icons](https://kappa.lol/FL_Oh), 25s video.
 - REQUEST NEW — to save icon images and packages with activities. This option is better if you are creating icons.
 3. Select the apps for which youʼd like to request or make icons.
 4. Copy, save or share.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,12 +159,11 @@ Please check the [icon tool guide](/docs/icontool_guide.md) for more information
 
 ### Using 3rd-party apps
 #### IconRequest app
-[Video guide](https://kappa.lol/FL_Oh) • 11.6 MB, 25s
 
 1. Download the [IconRequest app](https://github.com/Kaiserdragon2/IconRequest/releases).
 2. Launch the app and click one of the options:
-- UPDATE EXISTING — to copy packages with activities.
-- REQUEST NEW — to save icon images and packages with activities.
+- UPDATE EXISTING — to copy packages with activities. [How to request icons](https://kappa.lol/FL_Oh) • 25s video.
+- REQUEST NEW — to save icon images and packages with activities. This option is better if you are creating icons.
 3. Select the apps for which youʼd like to request or make icons.
 4. Copy, save or share.
 


### PR DESCRIPTION
I have clarified the process for requesting icons to make it clearer which copy option is suitable for filling out the form.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
