### PR TITLE
+11 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -3255,6 +3255,7 @@
   <item component="ComponentInfo{com.nextbillion.groww/com.nextbillion.groww.MainActivity}" drawable="groww" name="Groww" />
   <item component="ComponentInfo{com.nextbillion.groww/com.nextbillion.groww.genesys.loginsignup.activities.LoginActivity}" drawable="groww" name="Groww" />
   <item component="ComponentInfo{de.bpb.grundgesetz/com.example.lfranken.grundgesetzapp.MainActivity}" drawable="grundgesetz" name="Grundgesetz" />
+  <item component="ComponentInfo{com.netflix.NGP.GTASanAndreasDefinitiveEdition/com.fiveplay.mod.RMS.Recovery}" drawable="gta_sa" name="GTA: San Andreas" />
   <item component="ComponentInfo{com.netflix.NGP.GTASanAndreasDefinitiveEdition/com.epicgames.ue4.GameActivity}" drawable="gta_sa" name="GTA: San Andreas" />
   <item component="ComponentInfo{com.rockstargames.gtasa/com.fiveplay.mod.RMS.Recovery}" drawable="gta_sa" name="GTA: San Andreas" />
   <item component="ComponentInfo{com.rockstargames.gtasa/com.rockstargames.gtasa.Downloader}" drawable="gta_sa" name="GTA: San Andreas" />
@@ -3478,6 +3479,7 @@
   <item component="ComponentInfo{pl.pkobp.iko/pl.pkobp.iko.startup.activity.StartupActivity}" drawable="iko" name="IKO" />
   <item component="ComponentInfo{com.jwtian.smartbt/com.jwtian.smartbt.ActivityWelcome}" drawable="ilink" name="iLink" />
   <item component="ComponentInfo{com.imageresizer.imagecompressor/com.imageresizer.imagecompressor.activity.SplashActivity}" drawable="image_compressor_and_resizer" name="Image Compressor and Resizer" />
+  <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.presentation.AppActivity}" drawable="image_toolbox" name="Image Toolbox (Resizer)" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.presentation.MainActivity}" drawable="image_toolbox" name="Image Toolbox (Resizer)" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.presentation.main_screen.MainActivity}" drawable="image_toolbox" name="Image Toolbox (Resizer)" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.MainActivity}" drawable="image_toolbox" name="Image Toolbox (Resizer)" />
@@ -4320,6 +4322,7 @@
   <item component="ComponentInfo{com.mbta.mobileapp/io.ionic.starter.MainActivity}" drawable="mbta_mticket" name="MBTA mTicket" />
   <item component="ComponentInfo{com.wsandroid.suite/com.mcafee.app.LauncherDelegateActivity}" drawable="mcafee_security" name="McAfee Security" />
   <item component="ComponentInfo{com.wsandroid.suite/com.android.mcafee.ui.framework.BaseActivity}" drawable="mcafee_security" name="McAfee Security" />
+  <item component="ComponentInfo{com.mcdo.mcdonalds/com.gigigo.mcdonaldsbr.modules.splash.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdo.mcdonalds/com.gigigo.mcdonaldsbr.ui.activities.splash.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdonalds.gma.cn/com.mcdonalds.mcdcoreapp.common.activity.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdonalds.au.gma/com.mcdonalds.mcdcoreapp.common.activity.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
@@ -4351,6 +4354,8 @@
   <item component="ComponentInfo{org.telegram.mdgram/org.telegram.mdgram.VintageIcon.SplashActivity}" drawable="mdgram" name="MDGram" />
   <item component="ComponentInfo{org.telegram.mdgram/org.telegram.mdgram.MaterialYou}" drawable="mdgram" name="MDGram" />
   <item component="ComponentInfo{org.telegram.mdgram/org.telegram.ui.LaunchActivityBlueIcon}" drawable="mdgram" name="MDGram" />
+  <item component="ComponentInfo{com.google.tango.measure/com.google.tango.measure.MainActivity}" drawable="measure" name="Measure" />
+  <item component="ComponentInfo{com.google.tango.measure/com.google.tango.measure.android.LaunchScreenActivity}" drawable="measure" name="Measure" />
   <item component="ComponentInfo{com.google.tango.measure/com.google.vr.apps.ornament.measure.MeasureMainActivity}" drawable="measure" name="Measure" />
   <item component="ComponentInfo{net.mediaarea.mediainfo/net.mediaarea.mediainfo.ReportListActivity}" drawable="mediainfo" name="MediaInfo" />
   <item component="ComponentInfo{it.fabbricadigitale.android.videomediaset/com.mediaset.mediasetplay.ui.main.MainActivity}" drawable="mediaset_infinity" name="Mediaset Infinity" />
@@ -9068,6 +9073,7 @@
   <item component="ComponentInfo{pl.xkom/pl.xkom.ui.MainActivity}" drawable="xkom" name="x-kom" />
   <item component="ComponentInfo{com.lonelycatgames.Xplore/com.lonelycatgames.Xplore.Browser}" drawable="xplore_file_manager" name="X-plore" />
   <item component="ComponentInfo{com.gsm.customer/com.emddicustomer.MainActivity}" drawable="xanh_sm" name="Xanh SM" />
+  <item component="ComponentInfo{com.transsion.smartpanel/com.transsion.gamespace.activity.GameSpaceActivity}" drawable="xarena" name="XArena" />
   <item component="ComponentInfo{com.transsion.smartpanel/com.transsion.gamemode.activity.GameSpaceActivity}" drawable="xarena" name="XArena" />
   <item component="ComponentInfo{com.microsoft.xboxone.smartglass/com.microsoft.xbox.MainActivity}" drawable="xbox" name="Xbox" />
   <item component="ComponentInfo{com.microsoft.xboxone.smartglass/com.microsoft.xbox.xle.app.MainActivity}" drawable="xbox" name="Xbox" />
@@ -9232,6 +9238,7 @@
   <item component="ComponentInfo{com.graymatrix.did/com.graymatrix.did.splash.SplashActivity}" drawable="zee5" name="ZEE5" />
   <item component="ComponentInfo{com.graymatrix.did/com.applicaster.componentsapp.IntroActivity}" drawable="zee5" name="ZEE5" />
   <item component="ComponentInfo{com.graymatrix.did/com.zee5.splash.SplashActivity}" drawable="zee5" name="ZEE5" />
+  <item component="ComponentInfo{com.mad.zenflipclock/com.mad.zenflipclock.ui.MainActivity}" drawable="zen_flip_clock" name="Zen Flip Clock" />
   <item component="ComponentInfo{com.mad.zenflipclock/com.mad.zenflipclock.compose.MainComposeActivity}" drawable="zen_flip_clock" name="Zen Flip Clock" />
   <item component="ComponentInfo{com.oneplus.brickmode/com.oneplus.brickmode.activity.MainControlActivity}" drawable="zen_space" name="Zen Space" />
   <item component="ComponentInfo{com.huami.watch.hmwatchmanager/com.xiaomi.hm.health.activity.StartUpActivity}" drawable="zepp" name="Zepp" />
@@ -9387,6 +9394,10 @@
   <item component="ComponentInfo{com.easycard.wallet/com.easycard.wallet.nonfc.activity.WelcomePageActivity}" drawable="easy_wallet" name="悠遊付 ~~ Easy Wallet" />
   <item component="ComponentInfo{com.tencent.tmgp.sgame/com.putaolab.ptsdk.activity.PTMainActivity}" drawable="honor_of_kings" name="王者荣耀 ~~ Honor of Kings" />
   <item component="ComponentInfo{com.tencent.tmgp.sgame/com.tencent.tmgp.sgame.SGameActivity}" drawable="honor_of_kings" name="王者荣耀 ~~ Honor of Kings" />
+  <item component="ComponentInfo{me.gfuil.bmap/me.gfuil.bmap.StartActivity6}" drawable="bmap" name="白马地图 ~~ Bmap" />
+  <item component="ComponentInfo{me.gfuil.bmap/me.gfuil.bmap.StartActivity3}" drawable="bmap" name="白马地图 ~~ Bmap" />
+  <item component="ComponentInfo{me.gfuil.bmap/me.gfuil.bmap.activity.StartActivity}" drawable="bmap" name="白马地图 ~~ Bmap" />
+  <item component="ComponentInfo{me.gfuil.bmap/me.gfuil.bmap.activity.MainActivity}" drawable="bmap" name="白马地图 ~~ Bmap" />
   <item component="ComponentInfo{me.gfuil.bmap/me.gfuil.bmap.StartActivity}" drawable="bmap" name="白马地图 ~~ Bmap" />
   <item component="ComponentInfo{com.mybank.android.phone/com.mybank.android.phone.MainActivity}" drawable="mybank" name="网商银行 ~~ MYBank" />
   <item component="ComponentInfo{com.sankuai.meituan/com.sankuai.meituan.activity.Welcome}" drawable="meituan" name="美团 ~~ Meituan" />


### PR DESCRIPTION
Fulfilling requests.

## Linked
GTA: San Andreas (`com.netflix.NGP.GTASanAndreasDefinitiveEdition/com.fiveplay.mod.RMS.Recovery` → `gta_sa.svg`)
Image Toolbox (Resizer) (`ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.presentation.AppActivity` → `image_toolbox.svg`)
McDonald's (`com.mcdo.mcdonalds/com.gigigo.mcdonaldsbr.modules.splash.SplashActivity` → `mcdonalds.svg`)
Measure (`com.google.tango.measure/com.google.tango.measure.android.LaunchScreenActivity` → `measure.svg`)
Measure (`com.google.tango.measure/com.google.tango.measure.MainActivity` → `measure.svg`)
XArena (`com.transsion.smartpanel/com.transsion.gamespace.activity.GameSpaceActivity` → `xarena.svg`)
Zen Flip Clock (`com.mad.zenflipclock/com.mad.zenflipclock.ui.MainActivity` → `zen_flip_clock.svg`)
白马地图 ~~ Bmap (`me.gfuil.bmap/me.gfuil.bmap.activity.MainActivity` → `bmap.svg`)
白马地图 ~~ Bmap (`me.gfuil.bmap/me.gfuil.bmap.activity.StartActivity` → `bmap.svg`)
白马地图 ~~ Bmap (`me.gfuil.bmap/me.gfuil.bmap.StartActivity3` → `bmap.svg`)
白马地图 ~~ Bmap (`me.gfuil.bmap/me.gfuil.bmap.StartActivity6` → `bmap.svg`)

