### PR TITLE
+13 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1195,6 +1195,7 @@
   <item component="ComponentInfo{digifit.virtuagym.foodtracker/digifit.virtuagym.foodtracker.presentation.screen.main.MainActivity}" drawable="calorie_carb_and_fat_counter" name="Calorie, Carb &amp; Fat Counter" />
   <item component="ComponentInfo{org.calyxinstitute.vpn/se.leap.bitmaskclient.StartActivity}" drawable="calyxvpn" name="CalyxVPN" />
   <item component="ComponentInfo{org.calyxinstitute.vpn/se.leap.bitmaskclient.base.StartActivity}" drawable="calyxvpn" name="CalyxVPN" />
+  <item component="ComponentInfo{com.samsung.agc.gcam84/com.android.camera.CameraLauncher}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.hihonor.camera/com.hihonor.camera}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.google.android.apps.cameraslite/com.google.android.apps.cameralite.capture.CaptureActivity}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.android.MGC_8_8_224/com.android.camera.CameraLauncher}" drawable="camera" name="Camera" />
@@ -1552,6 +1553,7 @@
   <item component="ComponentInfo{com.github.lamarios.clipious/com.ryanheise.audioservice.AudioServiceActivity}" drawable="clipious" name="Clipious" />
   <item component="ComponentInfo{com.github.lamarios.clipious/com.github.lamarios.clipious.MainActivity}" drawable="clipious" name="Clipious" />
   <item component="ComponentInfo{com.wb.clipboard.pro/clipto.AppContainer}" drawable="clipto" name="Clipto" />
+  <item component="ComponentInfo{com.android.BBKClock/com.android.BBKClock.Timer}" drawable="clock" name="Clock" />
   <item component="ComponentInfo{com.android.deskclock/com.android.deskclock.AlarmMainActivity}" drawable="clock" name="Clock" />
   <item drawableIgnore="true" component="ComponentInfo{com.coloros.alarmclock/com.coloros.alarmclock.AlarmClock}" drawable="clock" name="Clock" />
   <item drawableIgnore="true" component="ComponentInfo{com.coloros.alarmclock/com.oplus.alarmclock.AlarmClock}" drawable="clock" name="Clock" />
@@ -1668,6 +1670,7 @@
   <item component="ComponentInfo{asia.coins.mobile/com.coins.coinsapp.views.SplashActivity}" drawable="coins_ph" name="Coins.ph" />
   <item component="ComponentInfo{com.coinidentifyer.ai/com.glority.android.picturexx.splash.SplashActivity}" drawable="coinsnap" name="CoinSnap" />
   <item component="ComponentInfo{com.coinswitch.kuber/com.coinswitch.kuber.SplashActivity}" drawable="coinswitch" name="CoinSwitch" />
+  <item component="ComponentInfo{com.collabora.libreoffice.snapshot/org.libreoffice.androidapp.ui.LibreOfficeUIActivity}" drawable="collabora_office" name="Collabora Office" />
   <item component="ComponentInfo{com.collabora.libreoffice/com.collabora.libreoffice.LibreOfficeMainActivity}" drawable="collabora_office" name="Collabora Office" />
   <item component="ComponentInfo{com.collabora.libreoffice/com.collabora.libreoffice.ui.LibreOfficeUIActivity}" drawable="collabora_office" name="Collabora Office" />
   <item component="ComponentInfo{com.collabora.libreoffice/org.libreoffice.androidapp.ui.LibreOfficeUIActivity}" drawable="collabora_office" name="Collabora Office" />
@@ -1961,6 +1964,7 @@
   <item component="ComponentInfo{com.dealabs.apps.android/com.pepper.apps.android.presentation.MainActivity}" drawable="dealabs" name="Dealabs" />
   <item component="ComponentInfo{com.dealabs.apps.android/com.pepper.apps.android.presentation.MainActivityV2}" drawable="dealabs" name="Dealabs" />
   <item component="ComponentInfo{org.ebur.debitum/org.ebur.debitum.ui.MainActivity}" drawable="debitum" name="Debitum" />
+  <item component="ComponentInfo{com.decathlon.app/com.decathlon.app.splash.ActivitySplash}" drawable="decathlon" name="Decathlon" />
   <item component="ComponentInfo{com.decathlon.app/com.decathlon.app.BLUE}" drawable="decathlon" name="Decathlon" />
   <item component="ComponentInfo{com.deepl.mobiletranslator/com.deepl.mobiletranslator.MainActivity}" drawable="deepl" name="DeepL" />
   <item component="ComponentInfo{com.example.deeplviewer/com.example.deeplviewer.MainActivity}" drawable="deepl" name="DeepL" />
@@ -2125,6 +2129,7 @@
   <item component="ComponentInfo{com.candywriter.doglife/com.unity3d.player.UnityPlayerActivity}" drawable="doglife" name="DogLife" />
   <item component="ComponentInfo{app.dogo.com.dogo_android/app.dogo.com.dogo_android.splashscreen.SplashActivity}" drawable="dogo" name="Dogo" />
   <item component="ComponentInfo{com.dolap.android/com.dolap.android.splash.ui.SplashActivity}" drawable="dolap" name="Dolap" />
+  <item component="ComponentInfo{com.ontim.dolby/com.ontim.dolby.LauncherActivity}" drawable="dolby" name="Dolby" />
   <item component="ComponentInfo{com.dolby/com.dolby.ds1appUI.MainActivity}" drawable="dolby" name="Dolby" />
   <item component="ComponentInfo{com.dolby.dolby234/com.dolby.sessions.Launcher}" drawable="dolby" name="Dolby" />
   <item component="ComponentInfo{com.dolby.daxappui/com.dolby.daxappui.MainActivity}" drawable="dolby_atmos" name="Dolby Atmos" />
@@ -2760,6 +2765,7 @@
   <item component="ComponentInfo{io.flutter.demo.gallery/io.flutter.demo.gallery.MainActivity}" drawable="flutter_gallery" name="Flutter Gallery" />
   <item component="ComponentInfo{de.bendix.flux/de.bendix.flux.MainActivity}" drawable="flux" name="Flux" />
   <item component="ComponentInfo{com.caij.twiper/com.caij.twiper.activity.MainActivity}" drawable="flyy" name="Flyy" />
+  <item component="ComponentInfo{com.ontim.fmradio/com.ontim.fmradio.activities.MainActivity}" drawable="fm_radio" name="FM Radio" />
   <item component="ComponentInfo{com.miui.fm/fm.qingting.qtradio.WelcomeActivity}" drawable="fm_radio" name="FM Radio" />
   <item component="ComponentInfo{com.android.fmradio/com.android.fmradio.FmActivity}" drawable="fm_radio" name="FM Radio" />
   <item component="ComponentInfo{com.android.fmradio/com.android.fmradio.FmMainActivity}" drawable="fm_radio" name="FM Radio" />
@@ -2815,6 +2821,8 @@
   <item component="ComponentInfo{com.epicgames.fortnite/com.epicgames.ue4.SplashActivity}" drawable="fortnite" name="Fortnite" />
   <item component="ComponentInfo{com.epicgames.fortnite/com.epicgames.unreal.SplashActivity}" drawable="fortnite" name="Fortnite" />
   <item component="ComponentInfo{de.nucleus.foss_warn/de.nucleus.foss_warn.MainActivity}" drawable="foss_warn" name="FOSS Warn" />
+  <item component="ComponentInfo{com.mobilefootie.fotmobpro/com.mobilefootie.fotmob.gui.v2.MainActivityWrapper}" drawable="fotmob" name="FotMob" />
+  <item component="ComponentInfo{com.mobilefootie.fotmobpro/com.fotmob.android.ui.MainActivityWrapper}" drawable="fotmob" name="FotMob" />
   <item component="ComponentInfo{com.mobilefootie.wc2010/com.fotmob.android.ui.MainActivityWrapper}" drawable="fotmob" name="FotMob" />
   <item component="ComponentInfo{com.mobilefootie.wc2010/com.mobilefootie.fotmob.gui.v2.MainActivityWrapper}" drawable="fotmob" name="FotMob" />
   <item component="ComponentInfo{com.santaragione.fotonicaiOS/com.santaragione.fotonicaiOS.ExtendedUnityActivity}" drawable="fotonica" name="FOTONICA" />
@@ -3103,6 +3111,7 @@
   <item component="ComponentInfo{com.gojek.app/com.gojek.home.splash.GojekSplashActivity}" drawable="gojek" name="Gojek" />
   <item component="ComponentInfo{com.gojek.app/com.gojek.home.splash.GojekSplash}" drawable="gojek" name="Gojek" />
   <item component="ComponentInfo{com.simplaapliko.goldenhour/com.simplaapliko.goldenhour.ui.LauncherActivity}" drawable="golden_hour" name="Golden Hour" />
+  <item component="ComponentInfo{ph.gomo.gomoph/ph.gomo.gomoph.MainActivity}" drawable="gomo_ph" name="GOMO PH" />
   <item component="ComponentInfo{ph.com.globe.gomo/ph.com.globe.gomo.MainActivity}" drawable="gomo_ph" name="GOMO PH" />
   <item component="ComponentInfo{com.maidu.gkld/com.maidu.gkld.ui.splash.SplashActivity}" drawable="gkld" name="Gongkao Leida" />
   <item component="ComponentInfo{com.samsung.android.goodlock/com.samsung.android.goodlock.presentation.view.PluginListActivity}" drawable="good_lock" name="Good Lock" />
@@ -3670,6 +3679,7 @@
   <item component="ComponentInfo{com.fusionmedia.investing/com.fusionmedia.investing.view.activities.SplashSplitter}" drawable="investing" name="Investing" />
   <item component="ComponentInfo{com.fusionmedia.investing/com.fusionmedia.investing.ui.activities.SplashSplitter}" drawable="investing" name="Investing" />
   <item component="ComponentInfo{com.fusionmedia.investing/com.fusionmedia.investing.features.splash.activity.SplashSplitter}" drawable="investing" name="Investing" />
+  <item component="ComponentInfo{pan.alexander.tordnscrypt.stable/pan.alexander.tordnscrypt.MainActivity}" drawable="invizible_pro" name="InviZible Pro" />
   <item component="ComponentInfo{pan.alexander.tordnscrypt/pan.alexander.tordnscrypt.MainActivity}" drawable="invizible_pro" name="InviZible Pro" />
   <item component="ComponentInfo{com.evo.inware/com.evo.inware.ui.activities.SplashActivity}" drawable="inware" name="Inware" />
   <item component="ComponentInfo{com.evo.inware/com.evo.inware.ui.activities.SweetHomeActivity}" drawable="inware" name="Inware" />
@@ -4653,7 +4663,9 @@
   <item component="ComponentInfo{com.mi.global.shop/com.mi.global.shop.activity.MainTabActivity}" drawable="mi_store" name="Mi Store" />
   <item component="ComponentInfo{com.mi.global.shop/com.mi.global.shop.activity.LaunchActivity}" drawable="mi_store" name="Mi Store" />
   <item component="ComponentInfo{com.mi.global.shop/com.mi.global.home.ui.LaunchActivity}" drawable="mi_store" name="Mi Store" />
-  <item component="ComponentInfo{com.xiaomi.shop/com.xiaomi.shop.activity.MainTabActivity}" drawable="mi_store" name="MI Store" />
+  <item component="ComponentInfo{com.xiaomi.shop/com.xiaomi.shop.activity.MainTabActivity}" drawable="mi_store" name="Mi Store" />
+  <item component="ComponentInfo{com.miui.video/com.miui.video.Launcher1}" drawable="mi_video" name="Mi Video" />
+  <item component="ComponentInfo{com.miui.video/com.miui.video.HomeActivity}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{com.miui.videoplayer/com.mb.android.MainActivity}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.LauncherActivity}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{com.xiaomi.router/com.xiaomi.router.module.splash.SplashActivity}" drawable="mi_wifi" name="Mi WiFi" />
@@ -9233,6 +9245,7 @@
   <item component="ComponentInfo{com.mkarpenko.worldbox/com.unity3d.player.UnityPlayerActivity}" drawable="worldbox" name="WorldBox" />
   <item component="ComponentInfo{com.funbase.xradio/com.funbase.xradio.activity.SplashActivity}" drawable="fm_radio" name="Wow FM" />
   <item component="ComponentInfo{com.funbase.xradio/com.funbase.xradio.home.activity.MainActivity}" drawable="fm_radio" name="Wow FM" />
+  <item component="ComponentInfo{com.kingsoft.moffice_pro/cn.wps.moffice.documentmanager.PreStartActivity}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice.documentmanager.PreStartActivity}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice_eng.documentmanager.DocumentManager}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice_eng.documentmanager.PreStartActivity}" drawable="wps_office" name="WPS Office" />


### PR DESCRIPTION
Fulfilling requests.

## Linked
Camera (`com.samsung.agc.gcam84/com.android.camera.CameraLauncher` → `camera.svg`)
Clock (`com.android.BBKClock/com.android.BBKClock.Timer` → `clock.svg`)
Collabora Office (`com.collabora.libreoffice.snapshot/org.libreoffice.androidapp.ui.LibreOfficeUIActivity` → `collabora_office.svg`)
Decathlon (`com.decathlon.app/com.decathlon.app.splash.ActivitySplash` → `decathlon.svg`)
Dolby (`com.ontim.dolby/com.ontim.dolby.LauncherActivity` → `dolby.svg`)
FM Radio (`com.ontim.fmradio/com.ontim.fmradio.activities.MainActivity` → `fm_radio.svg`)
FotMob (`com.mobilefootie.fotmobpro/com.fotmob.android.ui.MainActivityWrapper` → `fotmob.svg`)
FotMob (`com.mobilefootie.fotmobpro/com.mobilefootie.fotmob.gui.v2.MainActivityWrapper` → `fotmob.svg`)
GOMO PH (`ph.gomo.gomoph/ph.gomo.gomoph.MainActivity` → `gomo_ph.svg`)
InviZible Pro (`pan.alexander.tordnscrypt.stable/pan.alexander.tordnscrypt.MainActivity` → `invizible_pro.svg`)
Mi Video (`com.miui.video/com.miui.video.HomeActivity` → `mi_video.svg`)
Mi Video (`com.miui.video/com.miui.video.Launcher1` → `mi_video.svg`)
WPS Office (`com.kingsoft.moffice_pro/cn.wps.moffice.documentmanager.PreStartActivity` → `wps_office.svg`)