### PR TITLE
Add 3 links, fix 1

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1983,6 +1983,7 @@
   <item component="ComponentInfo{com.dealabs.apps.android/com.pepper.apps.android.presentation.MainActivityV2}" drawable="dealabs" name="Dealabs" />
   <item component="ComponentInfo{org.ebur.debitum/org.ebur.debitum.ui.MainActivity}" drawable="debitum" name="Debitum" />
   <item component="ComponentInfo{com.decathlon.app/com.decathlon.app.splash.ActivitySplash}" drawable="decathlon" name="Decathlon" />
+  <item component="ComponentInfo{com.decathlon.app/com.decathlon.app.splash.SplashActivity}" drawable="decathlon" name="Decathlon" />
   <item component="ComponentInfo{com.decathlon.app/com.decathlon.app.BLUE}" drawable="decathlon" name="Decathlon" />
   <item component="ComponentInfo{com.deepl.mobiletranslator/com.deepl.mobiletranslator.MainActivity}" drawable="deepl" name="DeepL" />
   <item component="ComponentInfo{com.example.deeplviewer/com.example.deeplviewer.MainActivity}" drawable="deepl" name="DeepL" />
@@ -2986,7 +2987,7 @@
   <item component="ComponentInfo{com.sec.android.gallery3d/com.sec.android.gallery3d.app.GalleryOpaqueActivity launchParam=MultiScreenLaunchParams { mDisplayId=0 mFlags=0 }}" drawable="gallery" name="Gallery" />
   <item component="ComponentInfo{com.sec.android.gallery3d/com.sec.android.gallery3d.app.GalleryOpaqueActivity VirtualScreenParam=Params{mDisplayId=-1, null, mFlags=0x00000000)}}" drawable="gallery" name="Gallery" />
   <item component="ComponentInfo{com.vivo.gallery/com.android.gallery3d.vivo.GalleryTabActivity}" drawable="gallery" name="Gallery" />
-  <item component="ComponentInfo{org.lineageos.glimpse/org.lineageos.glimpse/.MainActivity}" drawable="gallery" name="Gallery" />
+  <item component="ComponentInfo{org.lineageos.glimpse/org.lineageos.glimpse.MainActivity}" drawable="gallery" name="Gallery" />
   <item component="ComponentInfo{org.fossify.gallery/org.fossify.gallery.activities.SplashActivity.Amber}" drawable="simple_gallery" name="Gallery" />
   <item component="ComponentInfo{org.fossify.gallery/org.fossify.gallery.activities.SplashActivity.Blue}" drawable="simple_gallery" name="Gallery" />
   <item component="ComponentInfo{org.fossify.gallery/org.fossify.gallery.activities.SplashActivity.Blue_grey}" drawable="simple_gallery" name="Gallery" />
@@ -4725,6 +4726,7 @@
   <item component="ComponentInfo{com.google.android.gms/org.microg.gms.ui.SettingsActivity}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{com.google.android.gms/org.microg.gms.ui.SettingsActivityLauncher}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{com.google.android.gms/org.microg.nlp.ui.SettingsLauncherActivity}" drawable="microg_settings" name="microG Settings" />
+  <item component="ComponentInfo{app.revanced.android.gms/org.microg.gms.ui.SettingsActivity}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{com.ms.office365admin/com.ms.office365admin.MainActivity}" drawable="microsoft365_admin" name="Microsoft 365 Admin" />
   <item component="ComponentInfo{com.ms.office365admin/com.ms.office365admin.SplashScreen}" drawable="microsoft365_admin" name="Microsoft 365 Admin" />
   <item component="ComponentInfo{com.azure.authenticator/com.azure.authenticator.ui.LaunchActivity}" drawable="microsoft_authenticator" name="Microsoft Authenticator" />
@@ -5190,6 +5192,7 @@
   <item component="ComponentInfo{com.aktifbank.nkolay/com.aktifbank.nkolay.feature.core.activity.MainActivity}" drawable="n_kolay" name="N Kolay" />
   <item component="ComponentInfo{com.rivuspurus.nbackchallenge/com.rivuspurus.nbackchallenge.MainActivity}" drawable="n_back_challenge" name="N-Back Challenge" />
   <item component="ComponentInfo{com.dmall.mfandroid/com.dmall.mfandroid.activity.base.NewSplash}" drawable="n11" name="n11" />
+  <item component="ComponentInfo{com.dmall.mfandroid/com.dmall.mfandroid.activity.base.NHomeActivity}" drawable="n11" name="n11" />
   <item component="ComponentInfo{de.number26.android/de.number26.machete.android.ui.landing.LandingActivity}" drawable="n26" name="N26" />
   <item component="ComponentInfo{de.number26.android/de.number26.machete.android.refactor.presentation.settings.customize_icon.launch_aliases.WheatActivityLauncher}" drawable="n26" name="N26" />
   <item component="ComponentInfo{com.n26brasil.app/io.flutter.embedding.android.FlutterFragmentActivity}" drawable="n26" name="N26" />


### PR DESCRIPTION
# Description
<!-- Please provide a short summary of your pull request. -->
Added links for Decathlon, MicroG Settings and n11. Fixed Glimpse link that I've made a mistake in my recent pull request.

## Icons addition information
<!--  Please specify the apps and packages for which you have added, linked, or updated icons. Unnecessary sections can be deleted. -->

### Linked
Decathlon (`com.decathlon.app` → `decathlon.svg`)
MicroG Settings (`app.revanced.android.gms` → `microg_settings`)
n11 (`com.dmall.mfandroid` → `n11`)

### Updated
Gallery (`org.lineageos.glimpse`)

## Contributor's checklist
<!-- Replace [ ] with [x] to check. -->
- [x] I made the icons following [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (upd. Jan 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.
