### PR TITLE
+12 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -5373,6 +5373,7 @@
   <item component="ComponentInfo{com.github.ashutoshgngwr.noice/com.github.ashutoshgngwr.noice.activity.MainActivity}" drawable="noice" name="Noice" />
   <item component="ComponentInfo{com.github.ashutoshgngwr.noice/com.github.ashutoshgngwr.noice.MainActivity}" drawable="noice" name="Noice" />
   <item component="ComponentInfo{com.noisefit/com.noisefit.ui.SplashActivity}" drawable="noisefit" name="NoiseFit" />
+  <item component="ComponentInfo{com.hmdglobal.app.fmradio/com.hmdglobal.app.fmradio.FMRadio}" drawable="nokia_fm_radio" name="Nokia FM Radio" />
   <item component="ComponentInfo{com.hmdglobal.app.fmradio/com.hmdglobal.app.fmradio.FmMainActivity}" drawable="nokia_fm_radio" name="Nokia FM Radio" />
   <item component="ComponentInfo{com.hmdglobal.support/com.hmdglobal.support.ui.welcome.WelcomeActivity}" drawable="nokia_my_device" name="Nokia My Device" />
   <item component="ComponentInfo{com.hmdglobal.support/com.hmdglobal.support.MainActivity}" drawable="nokia_my_device" name="Nokia My Device" />
@@ -7036,6 +7037,16 @@
   <item component="ComponentInfo{com.samsung.android.scloud/com.samsung.android.scloud.app.ui.splash.launcher}" drawable="samsung_cloud" name="samsung_cloud" />
   <item component="ComponentInfo{com.samsung.android.forest/com.samsung.android.forest.launcher.LauncherActivity}" drawable="samsung_digital_wellbeing" name="samsung_digital_wellbeing" />
   <item component="ComponentInfo{smellymoo.sand/smellymoo.sand.Main}" drawable="sand_box" name="Sand : box" />
+  <item component="ComponentInfo{uk.co.santander.santanderUK/uk.co.santander.mobile.activities.SplashActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{pt.santander.oneappparticulares/es.bancosantander.apps.mobile.android.activities.SplashActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{pt.santander.oneappparticulares/es.bancosantander.apps.mobile.android.activities.PublicActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{pl.bzwbk.bzwbk24/es.bancosantander.apps.mobile.android.activities.PublicActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{mx.bancosantander.supermovil/mx.bancosantander.supermovil.activities.SplashActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{mx.bancosantander.supermovil/mx.bancosantander.supermovil.activities.splash.SplashActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{com.santander.app/com.santander.app.splash.SplashScreenActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{com.santander.app/com.santander.app.homenaologada.presentation.HomeActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{br.com.santander.way/br.com.santander.ewallet.feature.splash.activity.SplashActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{uk.co.santander.santanderUK/uk.co.santander.santanderuk.logon.SplashActivity}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{ar.com.santander.rio.mbanking/ar.com.santander.rio.mbanking.app.ui.activities.SplashScreenActivity}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{com.saq.android/com.saq.android.splash.SplashActivity}" drawable="saq" name="SAQ" />
   <item component="ComponentInfo{com.satispay.customer/com.satispay.customer.home.HomeActivity}" drawable="satispay" name="Satispay" />
@@ -8629,6 +8640,7 @@
   <item component="ComponentInfo{tk.hack5.treblecheck/tk.hack5.treblecheck.ui.MainActivity}" drawable="treble_info" name="Treble Info" />
   <item component="ComponentInfo{com.trello/com.trello.authentication.AuthLoginActivity}" drawable="trello" name="Trello" />
   <item component="ComponentInfo{com.trello/com.trello.home.HomeActivity}" drawable="trello" name="Trello" />
+  <item component="ComponentInfo{org.equeim.tremotesf/org.equeim.tremotesf.mainactivity.MainActivity}" drawable="tremotesf" name="Tremotesf" />
   <item component="ComponentInfo{org.equeim.tremotesf/org.equeim.tremotesf.ui.NavigationActivity}" drawable="tremotesf" name="Tremotesf" />
   <item component="ComponentInfo{trendyol.com/com.trendyol.ui.splash.SplashActivity}" drawable="trendyol" name="Trendyol" />
   <item component="ComponentInfo{trendyol.com/com.trendyol.common.splash.impl.ui.SplashActivity}" drawable="trendyol" name="Trendyol" />


### PR DESCRIPTION
Fulfilling requests.
## Linked
Nokia FM Radio (`com.hmdglobal.app.fmradio/com.hmdglobal.app.fmradio.FMRadio` → `nokia_fm_radio.svg`)
Santander (`br.com.santander.way/br.com.santander.ewallet.feature.splash.activity.SplashActivity` → `santander.svg`)
Santander (`com.santander.app/com.santander.app.homenaologada.presentation.HomeActivity` → `santander.svg`)
Santander (`com.santander.app/com.santander.app.splash.SplashScreenActivity` → `santander.svg`)
Santander (`mx.bancosantander.supermovil/mx.bancosantander.supermovil.activities.splash.SplashActivity` → `santander.svg`)
Santander (`mx.bancosantander.supermovil/mx.bancosantander.supermovil.activities.SplashActivity` → `santander.svg`)
Santander (`pl.bzwbk.bzwbk24/es.bancosantander.apps.mobile.android.activities.PublicActivity` → `santander.svg`)
Santander (`pt.santander.oneappparticulares/es.bancosantander.apps.mobile.android.activities.PublicActivity` → `santander.svg`)
Santander (`pt.santander.oneappparticulares/es.bancosantander.apps.mobile.android.activities.SplashActivity` → `santander.svg`)
Santander (`uk.co.santander.santanderUK/uk.co.santander.mobile.activities.SplashActivity` → `santander.svg`)
Santander (`uk.co.santander.santanderUK/uk.co.santander.santanderuk.logon.SplashActivity` → `santander.svg`)
Tremotesf (`org.equeim.tremotesf/org.equeim.tremotesf.mainactivity.MainActivity` → `tremotesf.svg`)

## Contributor's checklist
- [x] I followed [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (upd. Jan 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.