### PR TITLE
Clarified the guidelines for transliteration of names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,14 +91,14 @@ Wrong
 Correct
 <item component="..." drawable="hulu" name="Hulu ~~ フールー" />
 ```
-If there are letters at the beginning of the app name that aren't in English, then it's worth adding the name transliterated into English.
+If there are letters in the first `3` characters of the app name that aren't in English, then it's worth adding the name transliterated into English.
 ```
 Wrong
-<item component="..." drawable="otp_szep_card" name="OTP SZÉP Card" />
+<item component="..." drawable="lansforsakringar" name="Länsförsäkringar" />
 ```
 ```
 Correct
-<item component="..." drawable="otp_szep_card" name="OTP SZÉP Card ~~ OTP SZEP Card" />
+<item component="..." drawable="lansforsakringar" name="Länsförsäkringar ~~ Lansforsakringar" />
 ```
 ### Drawable
 Should be in English or transliterated from the original language. Should repeat the name of the app if possible.


### PR DESCRIPTION
I clarified the transliteration guidelines so that it would become clearer when it should be done. This eliminates the addition of far-fetched and actually useless transliterations.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
