### PR TITLE
Link official M3 Catalog

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4595,6 +4595,7 @@
   <item component="ComponentInfo{se.lf.mobile.android/se.lf.mobile.android.module.outside.ProxyActivity}" drawable="lansforsakringar" name="Länsförsäkringar ~~ Lansforsakringar" />
   <item component="ComponentInfo{lds.cinema21/lds.cinema21.MainActivity}" drawable="mtix" name="m.tix" />
   <item component="ComponentInfo{lds.cinema21/ldsboks.cinema.MainActivity}" drawable="mtix" name="m.tix" />
+  <item component="ComponentInfo{io.material.catalog/io.material.catalog.main.MainActivity}" drawable="material_catalog" name="M3 Catalog" />
   <item component="ComponentInfo{io.materialdesign.catalog/io.materialdesign.catalog.main.MainActivity}" drawable="material_catalog" name="M3 Catalog" />
   <item component="ComponentInfo{app.peretti.m365tools/app.peretti.m365tools.MainActivity}" drawable="m365_tools" name="m365 Tools" />
   <item component="ComponentInfo{org.mupen64plusae.v3.fzurita/paulscode.android.mupen64plusae.SplashActivity}" drawable="m64plus_fz" name="M64Plus FZ" />


### PR DESCRIPTION
# Description
https://github.com/material-components/material-components-android

## Icons addition information

### Linked
M3 Catalog (`io.material.catalog/io.material.catalog.main.MainActivity` → `material_catalog.svg`)

## Contributor's checklist
- [x] I followed [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (upd. Jan 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.
