### PR TITLE
Fix list padding in About, Contributors, and Acknowledgement screens

### DIFF
--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/About.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/About.kt
@@ -3,7 +3,10 @@ package app.lawnchair.lawnicons.ui.destination
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -19,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.lawnchair.lawnicons.BuildConfig
@@ -87,7 +91,16 @@ fun About(
         onBack = onBack,
         isExpandedScreen = isExpandedScreen,
     ) { paddingValues ->
-        LazyColumn(modifier = Modifier.padding(paddingValues)) {
+        val layoutDirection = LocalLayoutDirection.current
+        val verticalListPadding = 8.dp
+        LazyColumn(
+            contentPadding = PaddingValues(
+                start = paddingValues.calculateStartPadding(layoutDirection),
+                top = paddingValues.calculateTopPadding() + verticalListPadding,
+                end = paddingValues.calculateEndPadding(layoutDirection),
+                bottom = paddingValues.calculateBottomPadding() + verticalListPadding,
+            ),
+        ) {
             item {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/Acknowledgements.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/Acknowledgements.kt
@@ -1,15 +1,16 @@
 package app.lawnchair.lawnicons.ui.destination
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -17,7 +18,6 @@ import app.lawnchair.lawnicons.R
 import app.lawnchair.lawnicons.ui.components.core.LawniconsScaffold
 import app.lawnchair.lawnicons.ui.components.core.SimpleListRow
 import app.lawnchair.lawnicons.ui.util.Destinations
-import app.lawnchair.lawnicons.ui.util.toPaddingValues
 import app.lawnchair.lawnicons.viewmodel.AcknowledgementsViewModel
 
 @Composable
@@ -35,16 +35,19 @@ fun Acknowledgements(
         title = stringResource(id = R.string.acknowledgements),
         onBack = onBack,
         isExpandedScreen = isExpandedScreen,
-    ) { innerPadding ->
+    ) { paddingValues ->
         Crossfade(
             targetState = ossLibraries,
-            modifier = Modifier.padding(innerPadding),
             label = "",
         ) { libraries ->
+            val layoutDirection = LocalLayoutDirection.current
+            val verticalListPadding = 8.dp
             LazyColumn(
-                contentPadding = WindowInsets.navigationBars.toPaddingValues(
-                    additionalTop = 8.dp,
-                    additionalBottom = 8.dp,
+                contentPadding = PaddingValues(
+                    start = paddingValues.calculateStartPadding(layoutDirection),
+                    top = paddingValues.calculateTopPadding() + verticalListPadding,
+                    end = paddingValues.calculateEndPadding(layoutDirection),
+                    bottom = paddingValues.calculateBottomPadding() + verticalListPadding,
                 ),
             ) {
                 itemsIndexed(libraries) { index, it ->

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/Contributors.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/Contributors.kt
@@ -3,11 +3,11 @@ package app.lawnchair.lawnicons.ui.destination
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
@@ -16,6 +16,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -27,7 +28,6 @@ import app.lawnchair.lawnicons.ui.components.ExternalLinkRow
 import app.lawnchair.lawnicons.ui.components.core.LawniconsScaffold
 import app.lawnchair.lawnicons.ui.theme.LawniconsTheme
 import app.lawnchair.lawnicons.ui.util.PreviewLawnicons
-import app.lawnchair.lawnicons.ui.util.toPaddingValues
 import app.lawnchair.lawnicons.viewmodel.ContributorsUiState
 import app.lawnchair.lawnicons.viewmodel.ContributorsViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -64,14 +64,28 @@ fun Contributors(
         onBack = onBack,
         isExpandedScreen = isExpandedScreen,
     ) { paddingValues ->
+        val layoutDirection = LocalLayoutDirection.current
+        val verticalListPadding = 8.dp
+        val innerPaddingValues = PaddingValues(
+            start = paddingValues.calculateStartPadding(layoutDirection),
+            top = paddingValues.calculateTopPadding() + verticalListPadding,
+            end = paddingValues.calculateEndPadding(layoutDirection),
+            bottom = paddingValues.calculateBottomPadding() + verticalListPadding,
+        )
         Crossfade(
             targetState = uiState,
-            modifier = Modifier.padding(paddingValues = paddingValues),
             label = "",
         ) {
             when (it) {
-                is ContributorsUiState.Success -> ContributorList(contributors = it.contributors)
-                is ContributorsUiState.Loading -> ContributorListPlaceholder()
+                is ContributorsUiState.Success -> ContributorList(
+                    contributors = it.contributors,
+                    contentPadding = innerPaddingValues,
+                )
+
+                is ContributorsUiState.Loading -> ContributorListPlaceholder(
+                    contentPadding = innerPaddingValues,
+                )
+
                 is ContributorsUiState.Error -> ContributorListError(onBack = onBack)
             }
         }
@@ -82,13 +96,11 @@ fun Contributors(
 private fun ContributorList(
     contributors: ImmutableList<GitHubContributor>,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     LazyColumn(
         modifier = modifier,
-        contentPadding = WindowInsets.navigationBars.toPaddingValues(
-            additionalTop = 8.dp,
-            additionalBottom = 8.dp,
-        ),
+        contentPadding = contentPadding,
     ) {
         item {
             ExternalLinkRow(
@@ -120,14 +132,12 @@ private fun ContributorList(
 @Composable
 private fun ContributorListPlaceholder(
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     val itemCount = 20
     LazyColumn(
         modifier = modifier,
-        contentPadding = WindowInsets.navigationBars.toPaddingValues(
-            additionalTop = 8.dp,
-            additionalBottom = 8.dp,
-        ),
+        contentPadding = contentPadding,
     ) {
         items(itemCount) {
             ContributorRowPlaceholder(


### PR DESCRIPTION
## Description
Fixes incorrect list padding cutting off content in the About, Contributors, and Acknowledgement screens.

<details>
<summary>Screenshots</summary>

### About
Before
![image](https://github.com/LawnchairLauncher/lawnicons/assets/14132249/fd907778-2f06-439b-a734-246da7deb927)

After
![image](https://github.com/LawnchairLauncher/lawnicons/assets/14132249/f35b33e7-0c76-4a63-a0b3-b2f410f89de1)

### Contributors
Before
![image](https://github.com/LawnchairLauncher/lawnicons/assets/14132249/12c04d08-c436-47a7-a580-ca9b00cf46d4)

After
![image](https://github.com/LawnchairLauncher/lawnicons/assets/14132249/fe84c784-9d74-4699-838b-bde4a6eabcce)

### Acknowledgements
Before
![image](https://github.com/LawnchairLauncher/lawnicons/assets/14132249/4d0ef6e7-fe98-4be9-9692-17405fcb1b60)

After
![image](https://github.com/LawnchairLauncher/lawnicons/assets/14132249/4a6335f1-fc1b-462c-b58b-5a402ccab586)
</details>

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
