### PR TITLE
Added a warning about using the sort command in icontool.py

### DIFF
--- a/docs/icontool_guide.md
+++ b/docs/icontool_guide.md
@@ -62,6 +62,8 @@ Note that the SVG file's name is based on the `drawable` attribute of the first 
 Some common utilities are described below.
 
 ### Sorting appfilter.xml
+> [!WARNING]  
+> At the moment, the sorting works with errors: duplicates and extra spaces are added. It is recommended not to use it.
 ```console
 python3 ./icontool.py sort
 ```


### PR DESCRIPTION
At the moment, 4 contributors have encountered errors when sorting through icontool.py, as a result, they needed to fix appfilter.xml to remove duplicates or pass the style check.

I added a warning about the current state of the command so that people avoid unnecessary work.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
