### PR TITLE
Optimized the wording in the description and added an invitation for devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,23 @@
 [![Discord](https://img.shields.io/discord/803299970169700402?label=server&logo=discord)](https://discord.gg/lawnchair-803299970169700402)
 [![License is Apache 2](https://img.shields.io/github/license/LawnchairLauncher/lawnicons)](LICENSE)
 
-**Lawnicons** is an icon pack developed by the Lawnchair team.
-Originally an addon for Lawnchair 12 Alpha 5 and above to implement themed icons, it can now be used on many launchers. Some launchers may also support Lawnicons for themed icons.
+**Lawnicons** is an icon pack developed by the Lawnchair team and supported by our community.
+Originally an addon for Lawnchair 12 Alpha 5 and above to implement themed icons, it can now be used on many launchers.
 
-Lawnicons is best used on [Lawnchair 12.1](https://github.com/LawnchairLauncher/lawnchair). You can enable themed icons on Lawnchair by going to `Home Settings > General > Icon Style > Themed Icons`, choosing "Home Screen" or "Home Screen and App Drawer".
-
-This project is mostly supported by our community. If you wish to contribute, check out the Contributing section below.
+Lawnicons is best used on [Lawnchair 12.1](https://github.com/LawnchairLauncher/lawnchair) or [Lawnchair 14 Beta 2](https://github.com/LawnchairLauncher/lawnchair/releases). You can enable themed icons on Lawnchair by going to `Home Settings → General → Icon Style → Themed Icons`, choosing "Home Screen" or "Home Screen and App Drawer".
 
 ## Download
 See [the Releases section](https://github.com/LawnchairLauncher/lawnicons/releases) for the latest stable build. For development builds with new icons, go to [nightly.link](https://nightly.link/LawnchairLauncher/lawnicons/workflows/build_debug_apk/develop/Debug%20APK).
 
 ## Contributing
-Please see [the contributing guide](CONTRIBUTING.md) for info on adding icons or contributing code. It will help you avoid mistakes and save time. Detailed examples are available [in Figma](https://www.figma.com/community/file/1227718471680779613). If you still have questions, join [Lawnchair on Discord](https://discord.gg/3x8qNWxgGZ).
+Please see [the guide](CONTRIBUTING.md) for info on contributing icons or code, it will save you time. If you have questions, join [Lawnchair on Discord](https://discord.gg/3x8qNWxgGZ).
 
-We keep [a list of popular requests for icons](https://docs.google.com/spreadsheets/d/1AXc9EDXA6udZeGROtB5nuABjM33VluGY_V24tIzHaKc/edit?resourcekey#gid=651079103). If you are interested in making icons or want some icons to appear quickly in Lawnicons, then we invite you to contribute.
+We keep [a list of popular requests for icons](https://docs.google.com/spreadsheets/d/1AXc9EDXA6udZeGROtB5nuABjM33VluGY_V24tIzHaKc/edit?resourcekey#gid=651079103). If you are interested in making icons or want some icons to appear quickly in Lawnicons, then we invite you to contribute. Detailed examples are available [in Figma](https://www.figma.com/community/file/1227718471680779613).
+
+If you are interested in mobile development, then pay attention [to our issues](https://github.com/LawnchairLauncher/lawnicons/issues).
 
 ## Requesting icons
 Please use the [icon request form](https://forms.gle/xt7sJhgWEasuo9TR9). If a previously added icon has a design change, create an [issue](https://github.com/LawnchairLauncher/lawnicons/issues).
+
+
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 **Lawnicons** is an icon pack developed by the Lawnchair team and supported by our community.
 Originally an addon for Lawnchair 12 Alpha 5 and above to implement themed icons, it can now be used on many launchers.
 
-Lawnicons is best used on [Lawnchair 12.1](https://github.com/LawnchairLauncher/lawnchair) or [Lawnchair 14 Beta 2](https://github.com/LawnchairLauncher/lawnchair/releases). You can enable themed icons on Lawnchair by going to `Home Settings → General → Icon Style → Themed Icons`, choosing "Home Screen" or "Home Screen and App Drawer".
+Lawnicons is best used [on Lawnchair 12.1 or Lawnchair 14 Beta 2](https://github.com/LawnchairLauncher/lawnchair/releases). You can enable themed icons on Lawnchair by going to `Home Settings → General → Icon Style → Themed Icons → "Home screen" or "Home screen and App Drawer"`.
 
 ## Download
 See [the Releases section](https://github.com/LawnchairLauncher/lawnicons/releases) for the latest stable build. For development builds with new icons, go to [nightly.link](https://nightly.link/LawnchairLauncher/lawnicons/workflows/build_debug_apk/develop/Debug%20APK).


### PR DESCRIPTION
## Changelog
- added a line for devs to highlight the tasks for their skills.
- slightly changed the first part of the description to shorten it without losing its meaning.
- mentioned Lawnchair 14 Beta 2 to highlight the new version. I have not removed the mention of the old one, because the new version works unstable when configuring icons on some systems.
- "Some launchers may also support Lawnicons for themed icons." — deleted because the previous sentence implies support for themed icons.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
