### PR TITLE
+12 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -617,6 +617,7 @@
   <item component="ComponentInfo{com.jlindemann.science/com.jlindemann.science.activities.SplashActivity}" drawable="atomic" name="Atomic" />
   <item component="ComponentInfo{com.jlindemann.science/com.jlindemann.science.activities.MainActivity}" drawable="atomic" name="Atomic" />
   <item component="ComponentInfo{atomic.black.icon.pack/atomic.black.icon.pack.activities.SplashActivity}" drawable="atomic_icons" name="ATOMIC Icons" />
+  <item component="ComponentInfo{com.requapp.requ/com.requapp.requ.features.splash.SplashActivity}" drawable="attapoll" name="AttaPoll" />
   <item component="ComponentInfo{com.requapp.requ/com.requapp.requ.SurveysActivity}" drawable="attapoll" name="AttaPoll" />
   <item component="ComponentInfo{com.audible.application/com.audible.application.SplashScreen}" drawable="audible" name="Audible" />
   <item component="ComponentInfo{com.mrsep.musicrecognizer/com.mrsep.musicrecognizer.presentation.MainActivity}" drawable="audile" name="Audile" />
@@ -672,6 +673,7 @@
   <item component="ComponentInfo{com.ttxapps.drivesync/com.ttxapps.sync.app.MainActivity}" drawable="autosync" name="Autosync for Google Drive" />
   <item component="ComponentInfo{com.serg.chuprin.tageditor/com.serg.chuprin.tageditor.app.main.view.MainActivity}" drawable="autotagger" name="AutoTagger" />
   <item component="ComponentInfo{com.joaomgcd.autotools/com.joaomgcd.autoapps.ActivityLaunchApp}" drawable="autotools" name="AutoTools" />
+  <item component="ComponentInfo{com.joaomgcd.autoweb/com.joaomgcd.autoapps.ActivityLaunchApp}" drawable="auto_web" name="AutoWeb" />
   <item component="ComponentInfo{com.joaomgcd.autoweb/com.joaomgcd.autoweb.activity.ActivityMain}" drawable="auto_web" name="AutoWeb" />
   <item component="ComponentInfo{org.oxycblt.auxio/org.oxycblt.auxio.MainActivity}" drawable="auxio" name="Auxio" />
   <item component="ComponentInfo{se.avanzabank.androidapplikation/se.avanzabank.androidapplikation.home.activity.MainActivity}" drawable="avanza" name="Avanza" />
@@ -1048,6 +1050,7 @@
   <item component="ComponentInfo{ee.mtakso.driver/ee.mtakso.driver.ui.screens.launch.LauncherActivity}" drawable="bolt_driver" name="Bolt Driver" />
   <item component="ComponentInfo{com.bolt.deliveryclient/com.boltdeliveryclientapp.LaunchActivity}" drawable="bolt_food" name="Bolt Food" />
   <item component="ComponentInfo{com.bolt.deliveryproviderapp/com.bolt.deliveryproviderapp.MainActivity}" drawable="bolt_restaurant" name="Bolt Restaurant" />
+  <item component="ComponentInfo{au.gov.bom.metview/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="bom_weather" name="BOM Weather" />
   <item component="ComponentInfo{au.gov.bom.metview/au.gov.bom.metview.MainActivity}" drawable="bom_weather" name="BOM Weather" />
   <item component="ComponentInfo{net.froemling.bombsquad/net.froemling.bombsquad.BombSquad}" drawable="bombsquad" name="BombSquad" />
   <item component="ComponentInfo{net.froemling.bombsquad/net.froemling.bombsquad.MainActivity}" drawable="bombsquad" name="BombSquad" />
@@ -1081,6 +1084,7 @@
   <item component="ComponentInfo{com.elektropepi.bootboi/com.elektropepi.bootboi.MainActivity}" drawable="bootboi" name="BootBoi" />
   <item component="ComponentInfo{com.unvoid.borealis/com.unvoid.borealis.activities.SplashActivity}" drawable="borealis_icons" name="Borealis Icons" />
   <item component="ComponentInfo{com.codepotro.borno.keyboard/com.codepotro.borno.keyboard.setup.SetupUI}" drawable="borno" name="Borno" />
+  <item component="ComponentInfo{com.bolindadigital.BorrowBoxLibrary/com.bolinda.digital.library.mobile.android.startup.StartUpActivity}" drawable="borrowbox" name="BorrowBox" />
   <item component="ComponentInfo{com.bolindadigital.BorrowBoxLibrary/com.bolinda.digital.library.mobile.android.gui.BorrowBoxMainActivity}" drawable="borrowbox" name="BorrowBox" />
   <item component="ComponentInfo{com.bose.monet/com.bose.monet.activity.discovery.SplashSearchingActivity}" drawable="bose_connect" name="Bose Connect" />
   <item component="ComponentInfo{com.bose.bosemusic/com.bose.bosemusic.SplashScreenActivity}" drawable="bose_music" name="Bose Music" />
@@ -1267,6 +1271,7 @@
   <item component="ComponentInfo{com.cakewallet.cake_wallet/com.cakewallet.cake_wallet.MainActivity}" drawable="cake_wallet" name="Cake Wallet" />
   <item component="ComponentInfo{me.mycake/me.mycake.MainActivity}" drawable="cake_learn" name="Cake — Learn English &amp; Korean" />
   <item component="ComponentInfo{com.cakeresume.app/com.cakeresume.app.MainActivity}" drawable="cakeresume" name="CakeResume" />
+  <item component="ComponentInfo{advanced.scientific.calculator.calc991.plus/advanced.scientific.calculator.calc991.plus.splash.ytivitcAneercShsalpS_ksvLWSZxEDOdvwaxbGtYQvBnIcAGr_}" drawable="calces" name="CalcES" />
   <item component="ComponentInfo{advanced.scientific.calculator.calc991.plus/advanced.scientific.calculator.calc991.plus.main.ytivitcArotaluclaCecneicS_kLCneODahnPWsyfdoUSygLOxHQLt_e}" drawable="calces" name="CalcES" />
   <item component="ComponentInfo{advanced.scientific.calculator.calc991.plus/advanced.scientific.calculator.calc991.plus.splash.SplashScreenActivity}" drawable="calces" name="CalcES" />
   <item component="ComponentInfo{com.huawei.calculator/com.huawei.calculator.Calculator}" drawable="calculator" name="Calculator" />
@@ -2676,6 +2681,7 @@
   <item component="ComponentInfo{com.easilydo.mail/com.easilydo.mail.ui.SplashActivity}" drawable="edison_mail" name="Email" />
   <item component="ComponentInfo{com.mb.android/com.mb.android.MainActivity}" drawable="emby" name="Emby" />
   <item component="ComponentInfo{ru.henridellal.emerald/ru.henridellal.emerald.Apps}" drawable="emerald_launcher" name="Emerald Launcher" />
+  <item component="ComponentInfo{com.threesixtyentertainment.nesn/com.threesixtyentertainment.nesn.SplashActivity}" drawable="emergency_plus" name="Emergency Plus" />
   <item component="ComponentInfo{com.threesixtyentertainment.nesn/com.threesixtyentertainment.nesn.MainActivity}" drawable="emergency_plus" name="Emergency Plus" />
   <item component="ComponentInfo{com.emeritus.mobile/com.rootstrap.android.ui.activity.main.SplashActivity}" drawable="emeritus" name="Emeritus" />
   <item component="ComponentInfo{com.ecology.view/com.ecology.view.WelcomeActivity}" drawable="emobile" name="emobile" />
@@ -3051,6 +3057,7 @@
   <item component="ComponentInfo{com.flightradar24free/com.flightradar24free.FreeSplashActivity}" drawable="flightradar24" name="Flightradar24" />
   <item component="ComponentInfo{com.flightradar24free/com.flightradar24free.MainActivity}" drawable="flightradar24" name="Flightradar24" />
   <item component="ComponentInfo{com.flightradar24free/com.flightradar24free.SplashActivity}" drawable="flightradar24" name="Flightradar24" />
+  <item component="ComponentInfo{com.conducivetech.android.traveler/com.conducivetech.android.traveler.app.SplashScreenActivity}" drawable="flightstats" name="FlightStats" />
   <item component="ComponentInfo{com.conducivetech.android.traveler/com.conducivetech.android.traveler.app.flights.MainSearchActivity}" drawable="flightstats" name="FlightStats" />
   <item component="ComponentInfo{com.vidku.app.flipgrid/com.flipgrid.core.home.HomeActivity}" drawable="flip" name="Flip" />
   <item component="ComponentInfo{id.flip/id.flip.MainActivity}" drawable="flip_id" name="Flip" />
@@ -4497,6 +4504,7 @@
   <item component="ComponentInfo{com.kmplayer/com.kmplayer.SplashActivity}" drawable="kmplayer" name="KMPlayer" />
   <item component="ComponentInfo{com.ketchapp.knifehit/org.cocos2dx.cpp.AppActivity}" drawable="knife_hit" name="Knife Hit" />
   <item component="ComponentInfo{nl.lecreditsportif.knip/nl.lecreditsportif.lcs.Activities.LoaderActivity}" drawable="knip" name="KNIP" />
+  <item component="ComponentInfo{com.kobobooks.android/com.kobobooks.android.screens.AppLoading}" drawable="kobo_books" name="Kobo Books" />
   <item component="ComponentInfo{com.kobobooks.android/com.kobobooks.android.screens.MainNavActivity}" drawable="kobo_books" name="Kobo Books" />
   <item component="ComponentInfo{org.xbmc.kodi/org.xbmc.kodi.Splash}" drawable="kodi" name="Kodi" />
   <item component="ComponentInfo{org.xbmc.kodi/org.xbmc.kodi.Main}" drawable="kodi" name="Kodi" />
@@ -7180,6 +7188,7 @@
   <item component="ComponentInfo{com.yourdelivery.pyszne/com.yopeso.lieferando.SplashActivity}" drawable="just_eat" name="Pyszhne" />
   <item component="ComponentInfo{com.pyypl/com.pyypl.MainActivityDefault}" drawable="pyypl" name="Pyypl" />
   <item component="ComponentInfo{com.pyypl/com.pyypl.MainActivity}" drawable="pyypl" name="Pyypl" />
+  <item component="ComponentInfo{au.com.qantas.qantas/au.com.qantas.qantas.AppIconRedActivityAlias}" drawable="qantas" name="Qantas" />
   <item component="ComponentInfo{au.com.qantas.qantas/au.com.qantas.ui.presentation.main.sd.MainSDActivity}" drawable="qantas" name="Qantas" />
   <item component="ComponentInfo{au.com.qantas.qstreaming/au.com.qantas.qstreaming.home.presentation.SplashActivity}" drawable="qantas_entertainment" name="Qantas Entertainment" />
   <item component="ComponentInfo{io.github.qauxv/io.github.qauxv.activity.ConfigV2ActivityAlias}" drawable="qauxiliary" name="QAuxiliary" />
@@ -8419,6 +8428,7 @@
   <item component="ComponentInfo{com.tuya.smartlife/com.smart.TuyaSplashActivity}" drawable="smart_life" name="Smart Life" />
   <item component="ComponentInfo{com.transsion.scanningrecharger/com.transsion.scanningrecharger.view.activity.SplashActivity}" drawable="scanner" name="Smart Scanner" />
   <item component="ComponentInfo{com.transsion.scanningrecharger/com.transsion.scanningrecharger.view.activity.textrecognized.TextRecognizedActivity}" drawable="scanner" name="Smart Scanner" />
+  <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.ui.launch.LauncherActivity}" drawable="smart_switch" name="Smart Switch" />
   <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.DistributionActivity}" drawable="smart_switch" name="Smart Switch" />
   <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.DistributionNoIconActivity}" drawable="smart_switch" name="Smart Switch" />
   <item component="ComponentInfo{app.smart.timetable/app.smart.timetable.MainActivity}" drawable="smart_timetable" name="Smart Timetable" />
@@ -10251,6 +10261,7 @@
   <item component="ComponentInfo{com.punicapp.whoosh/com.punicapp.whoosh.activities.SplashActivity}" drawable="whoosh" name="Whoosh" />
   <item component="ComponentInfo{com.punicapp.whoosh/com.punicapp.whoosh.activities.ClientSplashActivity}" drawable="whoosh" name="Whoosh" />
   <item component="ComponentInfo{com.punicapp.whoosh/bike.whoosh.client.splash.ui.ClientSplashActivity}" drawable="whoosh" name="Whoosh" />
+  <item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.ui.MainActivity}" drawable="wi_fi_info" name="Wi-Fi Info" />
   <item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.SplashActivity}" drawable="wi_fi_info" name="Wi-Fi Info" />
   <item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.MainActivity}" drawable="wi_fi_info" name="Wi-Fi Info" />
   <item component="ComponentInfo{ru.andr7e.wifimonitor/ru.andr7e.deviceinfohw.DeviceInfoActivity}" drawable="wifianalyzer" name="Wi-Fi Monitor" />
@@ -10502,6 +10513,7 @@
   <item component="ComponentInfo{app.revanced.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube_revanced" name="YouTube ReVanced" />
   <item component="ComponentInfo{app.revanced.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube_revanced" name="YouTube ReVanced" />
   <item component="ComponentInfo{app.revanced.android.youtube/com.google.android.youtube.app.honeycomb.ShellHomeActivity}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.rvx.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="revanced_extended" name="YouTube ReVanced Extended" />
   <item component="ComponentInfo{app.rvx.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="revanced_extended" name="YouTube ReVanced Extended" />
   <item component="ComponentInfo{app.rvx.android.youtube/com.google.android.youtube.app.honeycomb.ShellHomeActivity}" drawable="revanced_extended" name="YouTube ReVanced Extended" />
   <item component="ComponentInfo{com.google.android.apps.youtube.creator/com.google.android.apps.youtube.creator.activities.SplashActivity}" drawable="ytstudio" name="YouTube Studio" />


### PR DESCRIPTION
Fulfilling requests.
## Linked
AttaPoll (`com.requapp.requ/com.requapp.requ.features.splash.SplashActivity` → `attapoll.svg`)
AutoWeb (`com.joaomgcd.autoweb/com.joaomgcd.autoapps.ActivityLaunchApp` → `auto_web.svg`)
BOM Weather (`au.gov.bom.metview/com.zoontek.rnbootsplash.RNBootSplashActivity` → `bom_weather.svg`)
BorrowBox (`com.bolindadigital.BorrowBoxLibrary/com.bolinda.digital.library.mobile.android.startup.StartUpActivity` → `borrowbox.svg`)
CalcES (`advanced.scientific.calculator.calc991.plus/advanced.scientific.calculator.calc991.plus.splash.ytivitcAneercShsalpS_ksvLWSZxEDOdvwaxbGtYQvBnIcAGr_` → `calces.svg`)
Emergency Plus (`com.threesixtyentertainment.nesn/com.threesixtyentertainment.nesn.SplashActivity` → `emergency_plus.svg`)
FlightStats (`com.conducivetech.android.traveler/com.conducivetech.android.traveler.app.SplashScreenActivity` → `flightstats.svg`)
Kobo Books (`com.kobobooks.android/com.kobobooks.android.screens.AppLoading` → `kobo_books.svg`)
Qantas (`au.com.qantas.qantas/au.com.qantas.qantas.AppIconRedActivityAlias` → `qantas.svg`)
Smart Switch (`com.sec.android.easyMover/com.sec.android.easyMover.ui.launch.LauncherActivity` → `smart_switch.svg`)
Wi-Fi Info (`com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.ui.MainActivity` → `wi_fi_info.svg`)
YouTube ReVanced Extended (`app.rvx.android.youtube/com.google.android.youtube.app.honeycomb.Shell` → `revanced_extended.svg`)
## Contributor's checklist
- [x] I followed [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) (upd. Jan 2024) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.