### PR TITLE
How to name drawables if the app name starts with a digit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,15 @@ Wrong
 Correct
 <item component="..." drawable="my_vodafone" name="My Vodafone ~~ MeinVodafone" />
 ```
+If the app name starts with a digit, then the drawable should start with `_`.
+```
+Wrong
+<item component="..." drawable="ninegag" name="9GAG" />
+```
+```
+Correct
+<item component="..." drawable="_9gag" name="9GAG" />
+```
 
 ## Adding an icon to Lawnicons
 Here's how to add an icon to Lawnicons:


### PR DESCRIPTION
## Description
It is impossible to start the name of the drawable with a digit and this is not obvious, as a result, contributors periodically correct the name after creating a PR. It is better to start the name of the drawable with the allowed symbol in order to reduce the likelihood of error and give contributors a simple solution to the issue. 

[Artcicons](https://github.com/Arcticons-Team/Arcticons) — thanks for the idea.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
