### PR TITLE
Try to fix icon checklist workflow

### DIFF
--- a/.github/workflows/icon_checklist.yml
+++ b/.github/workflows/icon_checklist.yml
@@ -7,6 +7,9 @@ on:
       paths:
         - svgs/*
 
+permissions:
+  issues: write
+
 jobs:
   comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

The icon checklist workflow [failed to run](https://github.com/LawnchairLauncher/lawnicons/actions/runs/9078779642/) on PR #2093 with error `Error: Unhandled error: HttpError: Resource not accessible by integration`, this seems to be a problem with the permissions, which is weird because it was running fine on my personal repo. Maybe there are restrictions set up on the Lawnicons repo?

I have specifically added in the permission to write a comment, so this may fix the problem. 

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
✅ Bug fix (non-breaking change which fixes an issue)
:x: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
