### PR TITLE
Updating the instructions for requesting icons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ Please check the [icon tool guide](/docs/icontool_guide.md) for more information
 2. Launch IconRequest and tap one of the options:
 - UPDATE EXISTING — to copy packages with activities.
 - REQUEST NEW — to save icon images and packages with activities. This option is better if you are creating icons.
-3. Select the apps for which youʼd like to request or make icons.
+3. Use the app toolbar to select the apps for which youʼd like to request or make icons.
 4. Copy, save or share.
 
 #### Icon Pusher app

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,12 @@ Please check the [icon tool guide](/docs/icontool_guide.md) for more information
 1. Done! You're ready to open a pull request. Please set `develop` as the base branch.
 
 ## Finding the package and activity name of an app
+
+### Using Lawnicons
+1. Install and open [Lawnicons 2.10+](https://github.com/LawnchairLauncher/lawnicons/releases).
+2. Tap "Request icons". The button appears when you are missing at least one icon. After that, our request form will open with a response ready to be submit. 
+3. Submit the response. You can copy the submitted activities [from our table](https://docs.google.com/spreadsheets/d/1AXc9EDXA6udZeGROtB5nuABjM33VluGY_V24tIzHaKc/edit?resourcekey=&gid=1039095616#gid=1039095616) (sorted by date).
+
 ### Using `adb`
 1. Connect your Android device or emulator to your laptop/desktop PC that has `adb` installed (see [this tutorial](https://www.xda-developers.com/install-adb-windows-macos-linux/) for more information) and open the app whose details you want to inspect, e.g. Telegram.
 1. Open a new Command Prompt or Terminal window and input `adb devices`.
@@ -171,11 +177,11 @@ Please check the [icon tool guide](/docs/icontool_guide.md) for more information
   The part before the `/` character in the above image, i.e. `org.telegram.messenger`, is the package name (`[PACKAGE_NAME]`). The part after it, i.e. `org.telegram.messenger.DefaultIcon`, is the activity name (`[APP_ACIVITY_NAME]`).
 
 ### Using 3rd-party apps
-#### IconRequest app
 
+#### IconRequest app
 1. Download IconRequest: [Google Play](https://play.google.com/store/apps/details?id=de.kaiserdragon.iconrequest) • [GitHub](https://github.com/Kaiserdragon2/IconRequest/releases).
 2. Launch IconRequest and tap one of the options:
-- UPDATE EXISTING — to copy packages with activities. [How to request icons](https://kappa.lol/u_MBz), 22s video.
+- UPDATE EXISTING — to copy packages with activities.
 - REQUEST NEW — to save icon images and packages with activities. This option is better if you are creating icons.
 3. Select the apps for which youʼd like to request or make icons.
 4. Copy, save or share.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ Lawnicons is best used [on Lawnchair 12.1 or Lawnchair 14 Beta 2](https://github
 See [the Releases section](https://github.com/LawnchairLauncher/lawnicons/releases) for the latest stable build. For development builds with new icons, go to [nightly.link](https://nightly.link/LawnchairLauncher/lawnicons/workflows/build_debug_apk/develop/Debug%20APK).
 
 ## Contributing
-Please see [the Lawnicons guidelines](CONTRIBUTING.md) for info on contributing icons or code, it will save you time. Android devs can find tasks [in our issues](https://github.com/LawnchairLauncher/lawnicons/issues).
+Please see [the Lawnicons guidelines](CONTRIBUTING.md) for information on contributing icons or code, it will save you time.
 
-If you are interested in creating icons, then we invite you to fulfill [popular icon requests](https://docs.google.com/spreadsheets/d/1AXc9EDXA6udZeGROtB5nuABjM33VluGY_V24tIzHaKc/edit?resourcekey#gid=651079103).
+Android developers can find tasks [in our issues](https://github.com/LawnchairLauncher/lawnicons/issues).
+Anyone who is interested in making icons can fulfill [the popular icon requests](https://docs.google.com/spreadsheets/d/1AXc9EDXA6udZeGROtB5nuABjM33VluGY_V24tIzHaKc/edit?resourcekey#gid=651079103).
 
 Need help? [Join us on Discord](https://discord.gg/3x8qNWxgGZ).
 
 ## Requesting icons
-Please use [the icon request form](https://forms.gle/xt7sJhgWEasuo9TR9). To wait for icons much less, you can take into account our guidelines and make the icons you need yourself. If a previously added icon has a design change, create [an issue](https://github.com/LawnchairLauncher/lawnicons/issues). 
+Please use **Lawnicons 2.10+**: `Open Lawnicons → Tap "Request icons" → Submit the response`.
+
+You can also use [the icon request form](https://forms.gle/xt7sJhgWEasuo9TR9). If a previously added icon has a design change, create [an issue](https://github.com/LawnchairLauncher/lawnicons/issues). 
 
 
 


### PR DESCRIPTION
Since the easiest way to request icons has changed, I'm updating the instructions.

I also delete the text that turned out to be useless and update the wording a little.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
