### PR TITLE
Make self-review checklist collapsible

### DIFF
--- a/.github/icon_checklist.md
+++ b/.github/icon_checklist.md
@@ -2,6 +2,9 @@ Thanks for your contribution!
 
 While waiting for a review from our team, you can do a self-review to ensure that your icons are suitable for Lawnicons.
 
+<details>
+<summary><i>Click to expand self-review checklist</i></summary>
+
 ### Canvas and sizes
 1. Canvas: `192×192px`.
 2. Non-square icons: the long side of the icons should be `160px`.
@@ -24,3 +27,5 @@ Example: `京东 ~~ JD`.
 3. Avoid noticable black spots by reducing the stroke width or simplifying the icons.
 4. Avoid close distances between strokes. The icons on the phone screen will be smaller, so the small distances between the strokes will stick together.
 5. Avoid drastic changes in stroke widths. When the strokes next to each other differ in width by 4px or more, the icon will look sloppy.
+
+</details>


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

The self-review icon checklist takes up quite a bit of space on the screen, so I've made it collapsible so that it takes up considerably less space. The checklist itself is what's collapsible, not the short piece of text before it.

https://github.com/LawnchairLauncher/lawnicons/assets/133548095/6b679c87-951e-4052-ad5e-221f57ed369b



## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
