### PR TITLE
Get rid of AppCompat

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,7 +136,6 @@ dependencies {
     val lifecycleVersion = "2.8.3"
     val hiltVersion = "2.51.1"
 
-    implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation(platform("androidx.compose:compose-bom:2024.06.00"))

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,6 +2,6 @@
 <resources>
     <style name="Theme.Lawnicons.SplashScreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/splashscreen</item>
-        <item name="postSplashScreenTheme">@style/Theme.AppCompat.DayNight.NoActionBar</item>
+        <item name="postSplashScreenTheme">@style/android:Theme.Material.Light.NoActionBar</item>
     </style>
 </resources>


### PR DESCRIPTION
We don't need it in a pure Compose app.

```diff
OLD: before.apk (signature: V2)
NEW: after.apk (signature: V2)

          │            compressed            │           uncompressed           
          ├──────────┬──────────┬────────────┼──────────┬──────────┬────────────
 APK      │ old      │ new      │ diff       │ old      │ new      │ diff       
──────────┼──────────┼──────────┼────────────┼──────────┼──────────┼────────────
      dex │  1.4 MiB │  1.4 MiB │  -89.6 KiB │  2.9 MiB │  2.8 MiB │ -174.1 KiB 
     arsc │    2 MiB │  1.5 MiB │ -479.5 KiB │    2 MiB │  1.5 MiB │ -479.5 KiB 
 manifest │  3.2 KiB │  3.2 KiB │       -1 B │ 14.3 KiB │ 14.3 KiB │        0 B 
      res │  7.6 MiB │  7.4 MiB │ -156.1 KiB │ 17.4 MiB │ 17.2 MiB │   -191 KiB 
   native │ 96.3 KiB │ 84.2 KiB │  -12.1 KiB │ 36.5 KiB │ 36.5 KiB │        0 B 
    asset │    9 KiB │  8.6 KiB │     -439 B │ 70.9 KiB │ 68.2 KiB │   -2.7 KiB 
    other │ 67.9 KiB │ 67.2 KiB │     -738 B │   73 KiB │   73 KiB │      -24 B 
──────────┼──────────┼──────────┼────────────┼──────────┼──────────┼────────────
    total │ 11.2 MiB │ 10.5 MiB │ -738.5 KiB │ 22.5 MiB │ 21.7 MiB │ -847.4 KiB 

 DEX     │ old   │ new   │ diff                  
─────────┼───────┼───────┼───────────────────────
   files │     1 │     1 │     0                 
 strings │ 14271 │ 13468 │  -803 (+2230 -3033)   
   types │  4836 │  4595 │  -241 (+2220 -2461)   
 classes │  3948 │  3783 │  -165 (+2127 -2292)   
 methods │ 21189 │ 19507 │ -1682 (+16085 -17767) 
  fields │ 13685 │ 12973 │  -712 (+12413 -13125) 

 ARSC    │ old   │ new   │ diff             
─────────┼───────┼───────┼──────────────────
 configs │   142 │   124 │   -18 (+0 -18)   
 entries │ 13419 │ 12339 │ -1080 (+0 -1080) 
```