### PR TITLE
+35 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -792,6 +792,7 @@
   <item component="ComponentInfo{com.axis.net/com.axis.net.SplashScreenActivity}" drawable="axisnet" name="AXISnet" />
   <item component="ComponentInfo{com.axis.net/com.axis.net.ui.splashLogin.SplashActivity}" drawable="axisnet" name="AXISnet" />
   <item component="ComponentInfo{com.axis.net/com.axis.net.ui.splashscreen.SplashScreenAcitivity}" drawable="axisnet" name="AXISnet" />
+  <item component="ComponentInfo{com.radolyn.ayugram/com.exteragram.messenger.MonetIconExtera}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{com.radolyn.ayugram/com.exteragram.messenger.SapphireIcon}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{com.radolyn.ayugram/com.exteragram.messenger.AyuGramDiscord}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{org.telegram.messenger/com.exteragram.messenger.MonetIcon}" drawable="ayugram" name="AyuGram" />
@@ -1825,6 +1826,7 @@
   <item component="ComponentInfo{com.chegg/com.chegg.home.HomeActivity}" drawable="chegg_study" name="Chegg Study" />
   <item component="ComponentInfo{com.cheogram.android/eu.siacs.conversations.ui.ConversationActivity}" drawable="cheogram" name="Cheogram" />
   <item component="ComponentInfo{com.cheogram.android/eu.siacs.conversations.ui.ConversationsActivity}" drawable="cheogram" name="Cheogram" />
+  <item component="ComponentInfo{uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.CG_Icon_Dark_Bra}" drawable="cherrygram" name="Cherrygram" />
   <item component="ComponentInfo{uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.AquaIcon}" drawable="cherrygram" name="Cherrygram" />
   <item component="ComponentInfo{uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.CG_Icon_Aqua}" drawable="cherrygram" name="Cherrygram" />
   <item component="ComponentInfo{uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.CG_Icon_Cherry}" drawable="cherrygram" name="Cherrygram" />
@@ -2583,6 +2585,8 @@
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenAux$Main}" drawable="discord" name="Discord" />
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenLoading}" drawable="discord" name="Discord" />
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenMain}" drawable="discord" name="Discord" />
+  <item component="ComponentInfo{com.discoverfinancial.mobile/c6471e4fe.w09cf6196.n6c037710.o50da4a26}" drawable="discover" name="Discover" />
+  <item component="ComponentInfo{com.discoverfinancial.mobile/r13fa4bdb.rcd00874d.e8944d836.y0b26d82e}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/g6dffb2ad.xc5285670.rea5c867d.rcd1d7b0d}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/lf0af873a.e37dcd7f3.a55198c2f.x72a99b04}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/c4c5046ae.e2731a8f9.pd6fab278.pf47237c8}" drawable="discover" name="Discover" />
@@ -3065,6 +3069,7 @@
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.vpo.ui.SplashActivity}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.vpn.ui.SplashActivity}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.splash.SplashActivity}" drawable="expressvpn" name="ExpressVPN" />
+  <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.OriginsIcon}" drawable="exteragram" name="exteraGram" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.SusIcon}" drawable="exteragram" name="exteraGram" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.NeoIcon}" drawable="exteragram" name="exteraGram" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.SpaceIcon}" drawable="exteragram" name="exteraGram" />
@@ -3429,6 +3434,7 @@
   <item component="ComponentInfo{com.ebase.banking/com.ebase.app.banking.ebase_banking_app.MainActivity}" drawable="fnz_bank" name="FNZ Bank" />
   <item component="ComponentInfo{com.pomodoro.foca/com.example.focaNew.MainActivity}" drawable="foca" name="Foca" />
   <item component="ComponentInfo{com.pomodoro.foca/com.ryanheise.audioservice.AudioServiceActivity}" drawable="foca" name="Foca" />
+  <item component="ComponentInfo{com.franco.focus.lite/com.franco.focus.lite.compose.MainComposeActivity}" drawable="focus_go" name="Focus Go" />
   <item component="ComponentInfo{com.franco.focus.lite/com.franco.focus.lite.activities.Main}" drawable="focus_go" name="Focus Go" />
   <item component="ComponentInfo{com.franco.focus.lite/a.b}" drawable="focus_go" name="Focus Go" />
   <item component="ComponentInfo{com.superelement.pomodoro/com.superelement.project.LauncherActivity}" drawable="focus_todo" name="Focus To-Do" />
@@ -3731,6 +3737,7 @@
   <item component="ComponentInfo{wangdaye.com.geometricweather/wangdaye.com.geometricweather.ui.activity.MainActivity}" drawable="geometric_weather" name="Geometric Weather" />
   <item component="ComponentInfo{wangdaye.com.geometricweather/wangdaye.com.geometricweather.ui.activity.main.MainActivity}" drawable="geometric_weather" name="Geometric Weather" />
   <item component="ComponentInfo{wangdaye.com.geometricweather/wangdaye.com.geometricweather.view.activity.MainActivity}" drawable="geometric_weather" name="Geometric Weather" />
+  <item component="ComponentInfo{com.robtopx.geometryjump/com.rainixdev.PreloadActivity}" drawable="geometry_dash" name="Geometry Dash" />
   <item component="ComponentInfo{com.robtopx.geometryjump/com.fiveplay.mod.RMS.Recovery}" drawable="geometry_dash" name="Geometry Dash" />
   <item component="ComponentInfo{com.robtopx.geometryjump/com.aiming.mdt.VdAd}" drawable="geometry_dash" name="Geometry Dash" />
   <item component="ComponentInfo{com.robtopx.geometryjump/com.robtopx.geometryjump.GeometryJump}" drawable="geometry_dash" name="Geometry Dash" />
@@ -4027,6 +4034,7 @@
   <item component="ComponentInfo{com.grammarly.android.keyboard/com.grammarly.host.SplashActivity}" drawable="grammarly" name="Grammarly" />
   <item component="ComponentInfo{org.akanework.gramophone/org.akanework.gramophone.MainActivity}" drawable="gramophone" name="Gramophone" />
   <item component="ComponentInfo{org.akanework.gramophone/org.akanework.gramophone.ui.MainActivity}" drawable="gramophone" name="Gramophone" />
+  <item component="ComponentInfo{ir.ilmili.telegraph/org.telegram.messenger.GraphIconRed}" drawable="graph_messenger" name="Graph Messenger" />
   <item component="ComponentInfo{ir.ilmili.telegraph/org.telegram.messenger.NoxIcon}" drawable="graph_messenger" name="Graph Messenger" />
   <item component="ComponentInfo{ir.ilmili.telegraph/org.telegram.messenger.AquaIcon}" drawable="graph_messenger" name="Graph Messenger" />
   <item component="ComponentInfo{ir.ilmili.telegraph/org.telegram.messenger.DefaultIcon}" drawable="graph_messenger" name="Graph Messenger" />
@@ -4245,6 +4253,7 @@
   <item component="ComponentInfo{com.toppr.toppr_ask/com.toppr.toppr_answr.splash.ui.activities.SplashActivity}" drawable="homework_help" name="Homework Help" />
   <item component="ComponentInfo{com.joinhoney.honeyandroid/com.joinhoney.honeyandroid.SplashActivity}" drawable="honey" name="Honey" />
   <item component="ComponentInfo{com.honeygain.make.money/com.honeygain.app.ui.splash.SplashActivity}" drawable="honeygain" name="Honeygain" />
+  <item component="ComponentInfo{cc.honista.app/com.app.launcher_4}" drawable="honista" name="Honista" />
   <item component="ComponentInfo{cc.honista.app/com.app.launcher_2}" drawable="honista" name="Honista" />
   <item component="ComponentInfo{cc.honista.app/com.app.launcher_25}" drawable="honista" name="Honista" />
   <item component="ComponentInfo{cc.honista.app/com.app.launcher_5}" drawable="honista" name="Honista" />
@@ -4818,6 +4827,7 @@
   <item component="ComponentInfo{com.yogeshpaliyal.keypass/com.yogeshpaliyal.keypass.ui.auth.AuthenticationActivity}" drawable="keypass" name="KeyPass" />
   <item component="ComponentInfo{com.yogeshpaliyal.keypass/com.yogeshpaliyal.keypass.ui.nav.DashboardComposeActivity}" drawable="keypass" name="KeyPass" />
   <item component="ComponentInfo{com.sie.kts/com.sie.kts.MainActivity}" drawable="keys_to_success" name="Keys to Success" />
+  <item component="ComponentInfo{com.kfc.nl.mobileapp/com.usemenu.MenuAndroidApplication.SplashActivity}" drawable="kfc" name="KFC" />
   <item component="ComponentInfo{com.kineticcafe.kfccolonelsclub/com.cognizantorderserv.kfcindiadroid.MainActivity}" drawable="kfc" name="KFC" />
   <item component="ComponentInfo{com.nanoequipment.kfc/com.nanoequipment.kfc.SplashActivity}" drawable="kfc" name="KFC" />
   <item component="ComponentInfo{es.kfc.spain/com.kfces.orderserv.SplashImageActivity}" drawable="kfc" name="KFC" />
@@ -5522,6 +5532,7 @@
   <item component="ComponentInfo{sh.ftp.rocketninelabs.meditationassistant.opensource/sh.ftp.rocketninelabs.meditationassistant.MainActivity}" drawable="meditation_assistant" name="Meditation Assistant" />
   <item component="ComponentInfo{meditofoundation.medito/com.ryanheise.audioservice.AudioServiceActivity}" drawable="medito" name="Medito" />
   <item component="ComponentInfo{meditofoundation.medito/meditofoundation.medito.MainActivity}" drawable="medito" name="Medito" />
+  <item component="ComponentInfo{com.medium.reader/com.medium.android.donkey.launcher.LauncherActivity}" drawable="medium" name="Medium" />
   <item component="ComponentInfo{com.medium.reader/android.support.main.a}" drawable="medium" name="Medium" />
   <item component="ComponentInfo{com.medium.reader/com.medium.android.donkey.start.SignInActivity}" drawable="medium" name="Medium" />
   <item component="ComponentInfo{com.medium.reader/com.medium.android.donkey.start.SplashActivity}" drawable="medium" name="Medium" />
@@ -6511,6 +6522,7 @@
   <item component="ComponentInfo{gov.pianzong.androidnga/com.qihoo.util.StartActivity}" drawable="nga" name="NGA" />
   <item component="ComponentInfo{gov.pianzong.androidnga/gov.pianzong.androidnga.Splash_0}" drawable="nga" name="NGA" />
   <item component="ComponentInfo{com.nglreactnative/com.nglreactnative.MainActivity}" drawable="ngl" name="NGL" />
+  <item component="ComponentInfo{com.nhs.online.nhsonline/com.nhs.online.nhsonline.MainActivity}" drawable="nhs" name="NHS" />
   <item component="ComponentInfo{com.nhs.online.nhsonline/com.nhs.online.nhsonline.activities.MainActivity}" drawable="nhs" name="NHS" />
   <item component="ComponentInfo{com.nhs.online.nhsonline/crc64b7e535562fc6760f.SplashScreenActivity}" drawable="nhs" name="NHS" />
   <item component="ComponentInfo{bitpit.launcher/bitpit.launcher.Pro}" drawable="niagara_launcher" name="Niagara Launcher" />
@@ -6700,6 +6712,7 @@
   <item component="ComponentInfo{com.numworks.calculator/com.numworks.calculator.EpsilonActivity}" drawable="numworks" name="NumWorks" />
   <item component="ComponentInfo{com.nunti/com.nunti.MainActivity}" drawable="nunti" name="Nunti" />
   <item component="ComponentInfo{com.nuvempay/com.nuvempay.MainActivity}" drawable="nuvem" name="Nuvem" />
+  <item component="ComponentInfo{com.nvidia.geforcenow/com.nvidia.geforcenow.LauncherActivity}" drawable="nvidia_geforce_now" name="NVIDIA GeForce NOW" />
   <item component="ComponentInfo{com.nvidia.geforcenow/com.nvidia.tegrazone.MainActivity}" drawable="nvidia_geforce_now" name="NVIDIA GeForce NOW" />
   <item component="ComponentInfo{com.nvidia.geforcenow/com.nvidia.geforcenow.MallActivity}" drawable="nvidia_geforce_now" name="NVIDIA GeForce NOW" />
   <item component="ComponentInfo{com.nvidia.tegrazone3/com.nvidia.geforcenow.MallActivity}" drawable="nvidia_geforce_now" name="NVIDIA GeForce NOW for SHIELD TV" />
@@ -6756,6 +6769,7 @@
   <item component="ComponentInfo{com.okta.android.auth/com.okta.android.auth.activity.SplashActivity}" drawable="okta_verify" name="Okta Verify" />
   <item component="ComponentInfo{com.okinc.okex.gp/com.okinc.core.ok_app.homepage.ui.welcome.WelcomeActivity}" drawable="okx" name="OKX" />
   <item component="ComponentInfo{com.okinc.okex.gp/com.okinc.okex.welcome.WelcomeActivity}" drawable="okx" name="OKX" />
+  <item component="ComponentInfo{com.olacabs.customer/com.olacabs.customer.ui.NewSplashActivity}" drawable="ola" name="Ola" />
   <item component="ComponentInfo{com.olacabs.customer/com.olacabs.customer.ui.SplashActivity}" drawable="ola" name="Ola" />
   <item component="ComponentInfo{com.olaelectric.companion/com.olaelectric.presentationv3.views.splash.SplashActivity}" drawable="ola_electric" name="Ola Electric" />
   <item component="ComponentInfo{com.olacabs.lite/com.olacabs.lite.SplashActivity}" drawable="ola" name="Ola Lite" />
@@ -7120,6 +7134,7 @@
   <item component="ComponentInfo{com.ladsers.passtable.android/com.ladsers.passtable.android.activities.MainActivity}" drawable="passtable" name="Passtable" />
   <item component="ComponentInfo{com.reneph.passwordsafe/com.reneph.passwordsafe.login.Login_Activity}" drawable="password_safe_manager" name="Password Safe and Manager" />
   <item component="ComponentInfo{com.reneph.passwordsafe/com.reneph.passwordsafe.login.LoginActivity}" drawable="password_safe_manager" name="Password Safe and Manager" />
+  <item component="ComponentInfo{dev.msfjarvis.aps/dev.msfjarvis.aps.ui.main.LaunchActivity}" drawable="password_store" name="Password Store" />
   <item component="ComponentInfo{dev.msfjarvis.aps/com.zeapo.pwdstore.LaunchActivity}" drawable="password_store" name="Password Store" />
   <item component="ComponentInfo{dev.msfjarvis.aps/com.zeapo.pwdstore.PasswordStore}" drawable="password_store" name="Password Store" />
   <item component="ComponentInfo{com.arrow.wallpapers.pastelwall/com.arrow.wallpapers.pastelwall.activity.SplashScreen}" drawable="pastel_wallpapers" name="Pastel Wallpapers" />
@@ -7664,6 +7679,7 @@
   <item component="ComponentInfo{au.com.shiftyjelly.pocketcasts/au.com.shiftyjelly.pocketcasts.ui.MainActivity}" drawable="pocket_casts" name="Pocket Casts" />
   <item component="ComponentInfo{au.com.shiftyjelly.pocketcasts/au.com.shiftyjelly.pocketcasts.ui.TabWidget}" drawable="pocket_casts" name="Pocket Casts" />
   <item component="ComponentInfo{com.codebrewgames.pocketcitygame/com.codebrewgames.pocketcitygame.MainActivity}" drawable="pocket_city" name="Pocket City" />
+  <item component="ComponentInfo{com.radio.pocketfm/com.radio.pocketfm.app.mobile.ui.routing.RoutingActivity}" drawable="pocket_fm" name="Pocket FM" />
   <item component="ComponentInfo{com.radio.pocketfm/com.radio.pocketfm.SplashActivity}" drawable="pocket_fm" name="Pocket FM" />
   <item component="ComponentInfo{com.radio.pocketfm/com.radio.pocketfm.app.mobile.ui.splash.SplashActivity}" drawable="pocket_fm" name="Pocket FM" />
   <item component="ComponentInfo{com.hyperbeard.pocketlove/com.google.firebase.MessagingUnityPlayerActivity}" drawable="pocket_love" name="Pocket Love" />
@@ -7824,6 +7840,7 @@
   <item component="ComponentInfo{ch.protonmail.android/ch.protonmail.android.mailbox.presentation.ui.MailboxActivity}" drawable="proton_mail" name="Proton Mail" />
   <item component="ComponentInfo{proton.android.pass.fdroid/proton.android.pass.ui.MainActivity}" drawable="proton_pass" name="Proton Pass" />
   <item component="ComponentInfo{proton.android.pass/proton.android.pass.ui.MainActivity}" drawable="proton_pass" name="Proton Pass" />
+  <item component="ComponentInfo{ch.protonvpn.android/ch.protonvpn.android.RoutingActivity}" drawable="proton_vpn" name="Proton VPN" />
   <item component="ComponentInfo{ch.protonvpn.android/com.protonvpn.android.ui.onboarding.SplashActivity}" drawable="proton_vpn" name="Proton VPN" />
   <item component="ComponentInfo{com.propel.ebenefits/com.propel.ebenefits.MainActivity}" drawable="providers" name="Providers" />
   <item component="ComponentInfo{com.proxmox.app.pve_flutter_frontend/com.proxmox.app.pve_flutter_frontend.MainActivity}" drawable="proxmox" name="Proxmox" />
@@ -8467,6 +8484,7 @@
   <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.ui.launch.LauncherActivity}" drawable="samsung_smart_switch" name="Samsung Smart Switch" />
   <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.DistributionActivity}" drawable="samsung_smart_switch" name="Samsung Smart Switch" />
   <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.DistributionNoIconActivity}" drawable="samsung_smart_switch" name="Samsung Smart Switch" />
+  <item component="ComponentInfo{com.samsung.android.soundassistant/com.samsung.android.soundassistant.activities.MainActivity}" drawable="samsung_sound_assistant" name="Samsung Sound Assistant" />
   <item component="ComponentInfo{com.samsung.android.soundassistant/com.sec.android.soundassistant.activities.MainActivity}" drawable="samsung_sound_assistant" name="Samsung Sound Assistant" />
   <item component="ComponentInfo{com.sec.android.app.vepreload/com.sec.android.app.vepreload.common.activity.ProjectShortcutActivity}" drawable="samsung_studio" name="Samsung Studio" />
   <item component="ComponentInfo{com.samsung.android.themedesigner/com.samsung.android.themedesigner.SplashActivity}" drawable="samsung_theme_park" name="Samsung Theme Park" />
@@ -8488,6 +8506,7 @@
   <item component="ComponentInfo{com.samsung.android.wonderland.wallpaper/com.samsung.android.wonderland.wallpaper.settings.StartupActivity}" drawable="samsung_wonderland" name="Samsung Wonderland" />
   <item component="ComponentInfo{smellymoo.sand/smellymoo.sand.Main}" drawable="sand_box" name="sand:box" />
   <item component="ComponentInfo{com.popcore.makesandwich/com.google.firebase.MessagingUnityPlayerActivity}" drawable="sandwich" name="Sandwich!" />
+  <item component="ComponentInfo{uk.co.santander.santanderUK/es.bancosantander.apps.mobile.android.activities.PublicActivity}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{com.santander.app/com.santander.app.splash.AppStartActivity}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{pl.bzwbk.bzwbk24/pl.bzwbk.bzwbk24.system.BzwbkSplashScreen}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{uk.co.santander.santanderUK/uk.co.santander.mobile.activities.SplashActivity}" drawable="santander" name="Santander" />
@@ -9363,6 +9382,7 @@
   <item component="ComponentInfo{com.kwai.bulldog/com.yxcorp.gifshow.tiny.TinyLaunchActivity}" drawable="snackvideo" name="SnackVideo" />
   <item component="ComponentInfo{com.kwai.bulldog/com.yxcorp.gifshow.homepage.HomeActivity}" drawable="snackvideo" name="SnackVideo" />
   <item component="ComponentInfo{com.bentostudio.ballsvsblocks/com.unity3d.player.UnityPlayerActivity}" drawable="snake_vs_block" name="Snake VS Block" />
+  <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.NeonAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.ColorRibbonsAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.SilkAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.NeonGhostAlias}" drawable="snapchat" name="Snapchat" />
@@ -9420,6 +9440,7 @@
   <item component="ComponentInfo{com.sofascore.results/com.sofascore.results.main.start.StartActivity}" drawable="sofascore" name="Sofascore" />
   <item component="ComponentInfo{com.sofascore.results/com.sofascore.results.activity.StartActivity}" drawable="sofascore" name="Sofascore" />
   <item component="ComponentInfo{com.sofascore.results/com.sofascore.results.main.StartActivity}" drawable="sofascore" name="Sofascore" />
+  <item component="ComponentInfo{com.sofi.mobile/com.sofi.mobile.MainActivity}" drawable="sofi" name="SoFi" />
   <item component="ComponentInfo{com.sofi.mobile/com.sofi.mobile.login.splashscreen.SplashScreenActivity}" drawable="sofi" name="SoFi" />
   <item component="ComponentInfo{pl.solidexplorer2/pl.solidexplorer.SolidExplorer}" drawable="solid_explorer" name="Solid Explorer" />
   <item component="ComponentInfo{ee.dustland.android.solitaire/ee.dustland.android.solitaire.SolitaireHostActivity}" drawable="solitaire" name="Solitaire — The Clean One" />
@@ -9472,6 +9493,7 @@
   <item component="ComponentInfo{com.sonymobile.support/com.sonymobile.support.InAppSupportLauncher}" drawable="sony_support" name="Sony Support" />
   <item component="ComponentInfo{jp.co.sony.mc.videopro/jp.co.sony.mc.videopro.VideoProActivity}" drawable="sony_videography_pro" name="Sony Videography Pro" />
   <item component="ComponentInfo{com.mycompany.app.soulbrowser/com.mycompany.app.web.WebViewActivity}" drawable="soul" name="Soul" />
+  <item component="ComponentInfo{com.ChillyRoom.DungeonShooter/com.chillyroomsdk.sdkbridge.privacy.BasePrivacyActivity}" drawable="soul_knight" name="Soul Knight" />
   <item component="ComponentInfo{com.ChillyRoom.DungeonShooter/com.chillyroomsdk.sdkbridge.BasePlayerActivity}" drawable="soul_knight" name="Soul Knight" />
   <item component="ComponentInfo{com.google.android.accessibility.soundamplifier/com.google.android.accessibility.soundamplifier.ui.SoundAmplifierSettingActivity}" drawable="sound_amplifier" name="Sound Amplifier" />
   <item component="ComponentInfo{com.google.android.accessibility.soundamplifier/com.google.android.accessibility.soundamplifier.LauncherActivity}" drawable="sound_amplifier" name="Sound Amplifier" />
@@ -9723,6 +9745,8 @@
   <item component="ComponentInfo{com.subway.mobile.subwayapp03/com.subway.mobile.subwayapp03.ui.SplashActivity}" drawable="subway" name="Subway" />
   <item component="ComponentInfo{com.wahalla.subwaybr/com.wahalla.subwaybr.MainActivity}" drawable="subway" name="Subway" />
   <item component="ComponentInfo{com.subway.subway/com.subway.subway.SplashActivity}" drawable="subway" name="Subway" />
+  <item component="ComponentInfo{com.kiloo.subwaysurf/com.releasedata.ReleaseDataActivity.SplashActivityKing}" drawable="subway_surfers" name="Subway Surfers" />
+  <item component="ComponentInfo{com.kiloo.subwaysurf/io.unity.sdk.android.UnityLauncher}" drawable="subway_surfers" name="Subway Surfers" />
   <item component="ComponentInfo{com.kiloo.subwaysurf/cn.releasedata.ReleaseDataActivity.SplashActivityKing}" drawable="subway_surfers" name="Subway Surfers" />
   <item component="ComponentInfo{com.kiloo.subwaysurf/com.google.android.archive.ReactivateActivity}" drawable="subway_surfers" name="Subway Surfers" />
   <item component="ComponentInfo{com.kiloo.subwaysurf/com.ms.sdk.plugin.explain.ExplainActivity}" drawable="subway_surfers" name="Subway Surfers" />
@@ -10363,6 +10387,7 @@
   <item component="ComponentInfo{com.ticketmaster.tickets.international/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="ticketmaster" name="Ticketmaster" />
   <item component="ComponentInfo{com.ticketswap.ticketswap/com.ticketswap.android.approot.AppRootActivity}" drawable="ticketswap" name="TicketSwap" />
   <item component="ComponentInfo{com.ticketswap.ticketswap/com.ticketswap.android.ui.LauncherActivity}" drawable="ticketswap" name="TicketSwap" />
+  <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.HomeAlia_12}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.HomeAlia_tick}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{cn.ticktick.task/com.ticktick.task.activity.MeTaskActivity}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{cn.ticktick.task/cn.ticktick.task.HomeAlia_springFestive}" drawable="ticktick" name="TickTick" />
@@ -10961,6 +10986,7 @@
   <item component="ComponentInfo{instagram.video.downloader.story.saver/instasaver.instagram.video.downloader.photo.ui.startup.StartupActivity}" drawable="video_downloader_story_saver" name="Video downloader — Story Saver" />
   <item component="ComponentInfo{instasaver.videodownloader.photodownloader.repost/instasaver.videodownloader.photodownloader.repost.view.activity.SplashMainActivity}" drawable="video_downloader_story_saver" name="Video downloader — Story Saver" />
   <item component="ComponentInfo{com.movisoftnew.videoeditor/com.freevideomaker.videoeditor.slideshow.activity.SplashActivity}" drawable="video_editor_video_maker" name="Video Editor" />
+  <item component="ComponentInfo{com.xvideostudio.videoeditor/com.xvideostudio.videoeditor.activity.SplashRCActivity}" drawable="video_editor_and_maker" name="Video Editor &amp; Maker" />
   <item component="ComponentInfo{com.xvideostudio.videoeditor/com.xvideostudio.videoeditor.activity.SplashSubActivity}" drawable="video_editor_and_maker" name="Video Editor &amp; Maker" />
   <item component="ComponentInfo{com.video.fun.app/com.nemo.vidmate.host.WelcomeActivity}" drawable="video_fun" name="Video Fun" />
   <item component="ComponentInfo{com.fundevs.app.mediaconverter/com.fundevs.app.mediaconverter.SplashActivity}" drawable="video_mp3_converter" name="Video MP3 Converter" />
@@ -11049,6 +11075,7 @@
   <item component="ComponentInfo{org.videolan.vlc/org.videolan.vlc.StartActivity}" drawable="vlc" name="VLC" />
   <item component="ComponentInfo{org.videolan.vlc/.StartActivity}" drawable="vlc" name="VLC" />
   <item component="ComponentInfo{org.videolan.vlc.debug/org.videolan.vlc.StartActivity}" drawable="vlc" name="VLC Debug" />
+  <item component="ComponentInfo{com.vmos.pro/com.vmos.pro.activities.PureSplashActivity}" drawable="vmos" name="VMOS" />
   <item component="ComponentInfo{com.vmos.pro/com.vmos.pro.activities.splash.SplashActivity}" drawable="vmos" name="VMOS" />
   <item component="ComponentInfo{com.frontrow.vlog/com.frontrow.vlog.ui.splash.SplashActivity}" drawable="vn" name="VN" />
   <item component="ComponentInfo{com.vnid/com.vnid.MainActivity}" drawable="vneid" name="VNeID" />
@@ -11255,6 +11282,7 @@
   <item component="ComponentInfo{com.webank.wemoney/com.webank.wemoney.EmptyActivity}" drawable="wemoney" name="WeMoney" />
   <item component="ComponentInfo{com.webank.wemoney/com.webank.wemoney.LauncherActivity}" drawable="wemoney" name="WeMoney" />
   <item component="ComponentInfo{de.wse.werstreamt.es/crc640c17457b81fa6cc4.SplashActivity}" drawable="werstreamt_es" name="WerStreamt.es?" />
+  <item component="ComponentInfo{com.wetherspoon.orderandpay/com.wetherspoon.orderandpay.MainActivity}" drawable="wetherspoon" name="Wetherspoon" />
   <item component="ComponentInfo{com.wetherspoon.orderandpay/com.wetherspoon.orderandpay.base.StartupActivity}" drawable="wetherspoon" name="Wetherspoon" />
   <item component="ComponentInfo{com.wetherspoon.orderandpay/com.xibis.txdvenues.StartActivity}" drawable="wetherspoon" name="Wetherspoon" />
   <item component="ComponentInfo{de.beowulf.wetter/de.beowulf.wetter.activities.LaunchActivity}" drawable="wetter" name="Wetter ~~ Weather" />
@@ -11442,6 +11470,7 @@
   <item component="ComponentInfo{at.willhaben/at.willhaben.MainActivity}" drawable="willhaben" name="willhaben" />
   <item component="ComponentInfo{nl.deckeron.apps.innerfire/nl.deckeron.apps.innerfire.ui.entry.ActivityEntry}" drawable="wim_hof_method" name="Wim Hof Method" />
   <item component="ComponentInfo{nl.windesheim.studentsapp/crc6456a163bb30e67f4b.SplashActivity}" drawable="windesheim" name="Windesheim" />
+  <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.tv.splash.SplashActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.splash.SplashActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.vpn.splash.SplashActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.vpn.ui.activities.EntryPointActivity}" drawable="windscribe" name="Windscribe" />
@@ -11502,6 +11531,7 @@
   <item component="ComponentInfo{com.worldcoin/com.worldcoin.app.main.MainActivity}" drawable="worldcoin_wallet" name="Worldcoin Wallet" />
   <item component="ComponentInfo{com.funbase.xradio/com.funbase.xradio.activity.SplashActivity}" drawable="wow_fm" name="WOW FM" />
   <item component="ComponentInfo{com.funbase.xradio/com.funbase.xradio.home.activity.MainActivity}" drawable="wow_fm" name="WOW FM" />
+  <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice.documentmanager.ab.proxy.a}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice.documentmanager.ab.proxy.main}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.shell.MainActivity}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{com.kingsoft.moffice_pro/cn.wps.moffice.documentmanager.PreStartActivity}" drawable="wps_office" name="WPS Office" />
@@ -11585,6 +11615,7 @@
   <item component="ComponentInfo{com.xiaomi.vipaccount/com.xiaomi.mi.launch.LaunchActivity}" drawable="xiaomi_community" name="Xiaomi Community" />
   <item component="ComponentInfo{com.xiaomi.vipaccount/com.xiaomi.vipaccount.ui.VipAccountActivity}" drawable="xiaomi_community" name="Xiaomi Community" />
   <item component="ComponentInfo{com.mi.earphone/com.xiaomi.fitness.login.SplashActivity}" drawable="xiaomi_earbuds" name="Xiaomi Earbuds" />
+  <item component="ComponentInfo{com.xiaomi.glgm/com.mig.play.Icon0}" drawable="xiaomi_games" name="Xiaomi Games" />
   <item component="ComponentInfo{com.xiaomi.glgm/com.xiaomi.glgm.home.ui.category}" drawable="xiaomi_games" name="Xiaomi Games" />
   <item component="ComponentInfo{com.xiaomi.glgm/com.xiaomi.glgm.home.ui.SplashActivity}" drawable="xiaomi_games" name="Xiaomi Games" />
   <item component="ComponentInfo{com.xiaomi.xmsf/top.trumeet.mipushframework.wizard.WelcomeActivity}" drawable="xiaomi_service_framework" name="Xiaomi Service Framework" />
@@ -11655,6 +11686,7 @@
   <item component="ComponentInfo{com.sbi.SBIFreedomPlus/com.sbi.SBIFreedomPlus.sbunifiedcug}" drawable="yono_lite_sbi" name="Yono Lite SBI" />
   <item component="ComponentInfo{com.sbi.SBIFreedomPlus/com.sbi.SBIFreedomPlus.SBIYonoLite}" drawable="yono_lite_sbi" name="Yono Lite SBI" />
   <item component="ComponentInfo{com.sbi.lotusintouch/com.sbi.lotusintouch.MainActivity}" drawable="yono_sbi" name="YONO SBI" />
+  <item component="ComponentInfo{com.celcom.yoodo/com.tripica.MainActivity}" drawable="yoodo" name="Yoodo" />
   <item component="ComponentInfo{com.celcom.yoodo/com.celcom.yoodo.MainActivityyoodo}" drawable="yoodo" name="Yoodo" />
   <item component="ComponentInfo{com.celcom.yoodo/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="yoodo" name="Yoodo" />
   <item component="ComponentInfo{ru.yota.android/ru.yota.android.presentation.view.splash.SplashActivity}" drawable="yota" name="Yota" />
@@ -12100,6 +12132,7 @@
   <item component="ComponentInfo{com.guotai.dazhihui/com.gtja.home.InitScreen}" drawable="guotai_junan" name="国泰君安君弘 ~~ Guotai Junan" />
   <item component="ComponentInfo{com.duokan.reader/com.duokan.reader.DkReaderActivity}" drawable="duokan" name="多看阅读 ~~ Duokan" />
   <item component="ComponentInfo{com.dianping.v1/com.dianping.v1.NovaMainActivity}" drawable="dianping" name="大众点评 ~~ Dianping" />
+  <item component="ComponentInfo{com.zmzx.college.search/com.tencent.a.SetupInfoActivity}" drawable="college_search" name="大学搜题酱 ~~ College Search" />
   <item component="ComponentInfo{com.zmzx.college.search/com.zmzx.college.search.activity.init.InitActivity}" drawable="college_search" name="大学搜题酱 ~~ College Search" />
   <item component="ComponentInfo{com.cn21.ecloud/com.cn21.ecloud.vip}" drawable="ecloud" name="天翼云 ~~ ecloud" />
   <item component="ComponentInfo{com.cn21.ecloud/com.cn21.ecloud.activity.login.StartActivity}" drawable="ecloud" name="天翼云 ~~ ecloud" />
@@ -12184,6 +12217,7 @@
   <item component="ComponentInfo{com.fenbi.android.servant/com.fenbi.android.module.welcome.WelcomeActivity}" drawable="fenbi" name="粉笔 ~~ Fenbi" />
   <item component="ComponentInfo{com.mystyle.purelive/com.mystyle.purelive.MainActivity}" drawable="purelive" name="纯粹直播 ~~ PureLive" />
   <item component="ComponentInfo{com.mybank.android.phone/com.mybank.android.phone.MainActivity}" drawable="mybank" name="网商银行 ~~ MYBank" />
+  <item component="ComponentInfo{com.sankuai.meituan/com.sankuai.meituan.MPMainActivity}" drawable="meituan" name="美团 ~~ Meituan" />
   <item component="ComponentInfo{com.sankuai.meituan/com.meituan.android.pt.homepage.activity.MainActivity}" drawable="meituan" name="美团 ~~ Meituan" />
   <item component="ComponentInfo{com.sankuai.meituan/com.sankuai.meituan.activity.Welcome}" drawable="meituan" name="美团 ~~ Meituan" />
   <item component="ComponentInfo{com.sankuai.meituan/com.sankuai.meituan.activity.PreloadedWelcome}" drawable="meituan" name="美团 ~~ Meituan" />
@@ -12224,6 +12258,7 @@
   <item component="ComponentInfo{com.taobao.idlefish/com.taobao.fleamarket.home.activity.InitActivity}" drawable="idle_fish" name="闲鱼 ~~ Idle Fish" />
   <item component="ComponentInfo{io.legado.app.release/io.legado.app.ui.welcome.WelcomeActivity}" drawable="legado" name="阅读 ~~ Legado" />
   <item component="ComponentInfo{io.legado.play.release/io.legado.app.ui.welcome.WelcomeActivity}" drawable="legado" name="阅读 ~~ Legado" />
+  <item component="ComponentInfo{com.alicloud.databox/com.alicloud.databox.launcher.splash.SplashIconPixelActivity}" drawable="aliyundrive" name="阿里云盘 ~~ AliyunDrive" />
   <item component="ComponentInfo{com.alicloud.databox/com.alicloud.databox.launcher.splash.SplashActivity}" drawable="aliyundrive" name="阿里云盘 ~~ AliyunDrive" />
   <item component="ComponentInfo{com.goyal.fip888/com.goyal.fip888.MainActivity}" drawable="alibaba_1688" name="阿里巴巴1688 ~~ Alibaba 1688" />
   <item component="ComponentInfo{com.alibaba.wireless/com.alibaba.wireless.welcome.Welcome}" drawable="alibaba_1688" name="阿里巴巴1688 ~~ Alibaba 1688" />


### PR DESCRIPTION
Fulfilling requests.
## Linked
AyuGram (`com.radolyn.ayugram/com.exteragram.messenger.MonetIconExtera` → `ayugram.svg`)
Cherrygram (`uz.unnarsx.cherrygram/uz.unnarsx.cherrygram.CG_Icon_Dark_Bra` → `cherrygram.svg`)
Discover (`com.discoverfinancial.mobile/c6471e4fe.w09cf6196.n6c037710.o50da4a26` → `discover.svg`)
Discover (`com.discoverfinancial.mobile/r13fa4bdb.rcd00874d.e8944d836.y0b26d82e` → `discover.svg`)
exteraGram (`com.exteragram.messenger/com.exteragram.messenger.OriginsIcon` → `exteragram.svg`)
Focus Go (`com.franco.focus.lite/com.franco.focus.lite.compose.MainComposeActivity` → `focus_go.svg`)
Geometry Dash (`com.robtopx.geometryjump/com.rainixdev.PreloadActivity` → `geometry_dash.svg`)
Graph Messenger (`ir.ilmili.telegraph/org.telegram.messenger.GraphIconRed` → `graph_messenger.svg`)
Honista (`cc.honista.app/com.app.launcher_4` → `honista.svg`)
KFC (`com.kfc.nl.mobileapp/com.usemenu.MenuAndroidApplication.SplashActivity` → `kfc.svg`)
Medium (`com.medium.reader/com.medium.android.donkey.launcher.LauncherActivity` → `medium.svg`)
NHS (`com.nhs.online.nhsonline/com.nhs.online.nhsonline.MainActivity` → `nhs.svg`)
NVIDIA GeForce NOW (`com.nvidia.geforcenow/com.nvidia.geforcenow.LauncherActivity` → `nvidia_geforce_now.svg`)
Ola (`com.olacabs.customer/com.olacabs.customer.ui.NewSplashActivity` → `ola.svg`)
Password Store (`dev.msfjarvis.aps/dev.msfjarvis.aps.ui.main.LaunchActivity` → `password_store.svg`)
Pocket FM (`com.radio.pocketfm/com.radio.pocketfm.app.mobile.ui.routing.RoutingActivity` → `pocket_fm.svg`)
Proton VPN (`ch.protonvpn.android/ch.protonvpn.android.RoutingActivity` → `proton_vpn.svg`)
Samsung Sound Assistant (`com.samsung.android.soundassistant/com.samsung.android.soundassistant.activities.MainActivity` → `samsung_sound_assistant.svg`)
Santander (`uk.co.santander.santanderUK/es.bancosantander.apps.mobile.android.activities.PublicActivity` → `santander.svg`)
Snapchat (`com.snapchat.android/com.snapchat.android.NeonAlias` → `snapchat.svg`)
SoFi (`com.sofi.mobile/com.sofi.mobile.MainActivity` → `sofi.svg`)
Soul Knight (`com.ChillyRoom.DungeonShooter/com.chillyroomsdk.sdkbridge.privacy.BasePrivacyActivity` → `soul_knight.svg`)
Subway Surfers (`com.kiloo.subwaysurf/com.releasedata.ReleaseDataActivity.SplashActivityKing` → `subway_surfers.svg`)
Subway Surfers (`com.kiloo.subwaysurf/io.unity.sdk.android.UnityLauncher` → `subway_surfers.svg`)
TickTick (`com.ticktick.task/com.ticktick.task.HomeAlia_12` → `ticktick.svg`)
Video Editor &amp; Maker (`com.xvideostudio.videoeditor/com.xvideostudio.videoeditor.activity.SplashRCActivity` → `video_editor_and_maker.svg`)
VMOS (`com.vmos.pro/com.vmos.pro.activities.PureSplashActivity` → `vmos.svg`)
Wetherspoon (`com.wetherspoon.orderandpay/com.wetherspoon.orderandpay.MainActivity` → `wetherspoon.svg`)
Windscribe (`com.windscribe.vpn/com.windscribe.tv.splash.SplashActivity` → `windscribe.svg`)
WPS Office (`cn.wps.moffice_eng/cn.wps.moffice.documentmanager.ab.proxy.a` → `wps_office.svg`)
Xiaomi Games (`com.xiaomi.glgm/com.mig.play.Icon0` → `xiaomi_games.svg`)
Yoodo (`com.celcom.yoodo/com.tripica.MainActivity` → `yoodo.svg`)
大学搜题酱 ~~ College Search (`com.zmzx.college.search/com.tencent.a.SetupInfoActivity` → `college_search.svg`)
美团 ~~ Meituan (`com.sankuai.meituan/com.sankuai.meituan.MPMainActivity` → `meituan.svg`)
阿里云盘 ~~ AliyunDrive (`com.alicloud.databox/com.alicloud.databox.launcher.splash.SplashIconPixelActivity` → `aliyundrive.svg`)
## Contributor's checklist
- [x] I followed [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.