### PR TITLE
+14 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -792,6 +792,7 @@
   <item component="ComponentInfo{com.axis.net/com.axis.net.SplashScreenActivity}" drawable="axisnet" name="AXISnet" />
   <item component="ComponentInfo{com.axis.net/com.axis.net.ui.splashLogin.SplashActivity}" drawable="axisnet" name="AXISnet" />
   <item component="ComponentInfo{com.axis.net/com.axis.net.ui.splashscreen.SplashScreenAcitivity}" drawable="axisnet" name="AXISnet" />
+  <item component="ComponentInfo{org.telegram.messenger/com.exteragram.messenger.MonetIconExtera}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{com.radolyn.ayugram/com.exteragram.messenger.MonetIconExtera}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{com.radolyn.ayugram/com.exteragram.messenger.SapphireIcon}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{com.radolyn.ayugram/com.exteragram.messenger.AyuGramDiscord}" drawable="ayugram" name="AyuGram" />
@@ -1316,6 +1317,8 @@
   <item component="ComponentInfo{com.dwarfplanet.bundle/com.dwarfplanet.bundle.v2.ui.landing.views.SplashActivity}" drawable="bundle" name="Bundle" />
   <item component="ComponentInfo{com.xaviertobin.noted/com.xaviertobin.noted.activities.ActivitySignIn}" drawable="bundled_notes" name="Bundled Notes" />
   <item component="ComponentInfo{com.xaviertobin.noted/com.xaviertobin.noted.activities.ActivityBundles}" drawable="bundled_notes" name="Bundled Notes" />
+  <item component="ComponentInfo{io.github.pyoncord.app/com.discord.main.MainController}" drawable="discord" name="Bunny" />
+  <item component="ComponentInfo{io.github.pyoncord.app/com.discord.main.MainMidnightPrism}" drawable="discord" name="Bunny" />
   <item component="ComponentInfo{io.github.pyoncord.app/com.discord.main.MainDefault}" drawable="discord" name="Bunny" />
   <item component="ComponentInfo{io.github.pyoncord.manager/dev.beefers.vendetta.manager.ui.activity.MainActivity}" drawable="bunny_manager" name="Bunny Manager" />
   <item component="ComponentInfo{com.bunq.android/com.bunq.android.ui.activity.SplashScreenActivity}" drawable="bunq" name="bunq" />
@@ -1819,6 +1822,7 @@
   <item component="ComponentInfo{newway.open.chatgpt.ai.chat.bot.free/com.example.cca.views.Splash.SplashActivity}" drawable="chatbot_ai_4o" name="Chatbot AI 4o" />
   <item component="ComponentInfo{com.openai.chatgpt/md.elway.evo.screen.chat.ChatActivity}" drawable="chatgpt" name="ChatGPT" />
   <item component="ComponentInfo{com.openai.chatgpt/com.openai.chatgpt.MainActivity}" drawable="chatgpt" name="ChatGPT" />
+  <item component="ComponentInfo{dev.theolm.wwc/dev.theolm.wwc.presentation.ui.dialog.MainActivity}" drawable="chatlaunch_for_whatsapp" name="ChatLaunch for WhatsApp" />
   <item component="ComponentInfo{dev.theolm.wwc/dev.theolm.wwc.presentation.ui.main.MainActivity}" drawable="chatlaunch_for_whatsapp" name="ChatLaunch for WhatsApp" />
   <item component="ComponentInfo{dev.theolm.wwc/dev.theolm.wwc.ui.main.MainActivity}" drawable="chatlaunch_for_whatsapp" name="ChatLaunch for WhatsApp" />
   <item component="ComponentInfo{chatrandom.com/com.cr.MainActivity}" drawable="chatrandom" name="Chatrandom" />
@@ -2544,6 +2548,7 @@
   <item component="ComponentInfo{id.go.kominfo.digitalent/id.go.kominfo.digitalent.MainActivity}" drawable="digitalent" name="Digitalent" />
   <item component="ComponentInfo{giraffine.dimmer/giraffine.dimmer.Dimmer}" drawable="dimmer" name="Dimmer" />
   <item component="ComponentInfo{com.motorola.dimo/com.motorola.engageapp.ui.MotopayActivity}" drawable="dimo_essential" name="Dimo Essential" />
+  <item component="ComponentInfo{com.dineout.book/in.swiggy.android.activities.HomeActivity}" drawable="dineout" name="Dineout" />
   <item component="ComponentInfo{com.dineout.book/com.dineout.book.splash.presentation.view.NewSplashActivity}" drawable="dineout" name="Dineout" />
   <item component="ComponentInfo{com.alibaba.android.rimet/com.alibaba.android.rimet.biz.SplashActivity}" drawable="dingtalk" name="DingTalk" />
   <item component="ComponentInfo{com.alibaba.android.rimet/com.alibaba.android.rimet.biz.LaunchHomeActivity}" drawable="dingtalk" name="DingTalk" />
@@ -3331,6 +3336,7 @@
   <item component="ComponentInfo{com.cyb3rko.flashdim/com.cyb3rko.flashdim.activities.MainActivity}" drawable="flashdim" name="FlashDim" />
   <item component="ComponentInfo{com.flashfoodapp.android/com.flashfoodapp.android.presentation.ui.splash.SplashScreenActivity}" drawable="flashfood" name="Flashfood" />
   <item component="ComponentInfo{com.flashfoodapp.android/com.flashfoodapp.android.v2.activities.SplashActivity}" drawable="flashfood" name="Flashfood" />
+  <item component="ComponentInfo{com.simplemobiletools.flashlight/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity.Orange}" drawable="flashlight" name="Flashlight" />
   <item component="ComponentInfo{com.simplemobiletools.flashlight/com.simplemobiletools.flashlight.activities.SplashActivity.Amber}" drawable="flashlight" name="Flashlight" />
   <item component="ComponentInfo{com.simplemobiletools.flashlight/com.simplemobiletools.flashlight.activities.SplashActivity.Blue_grey}" drawable="flashlight" name="Flashlight" />
   <item component="ComponentInfo{com.simplemobiletools.flashlight/com.simplemobiletools.flashlight.activities.SplashActivity.Brown}" drawable="flashlight" name="Flashlight" />
@@ -3750,6 +3756,7 @@
   <item component="ComponentInfo{com.robtopx.geometrydashworld/com.robtopx.geometrydashworld.GeometryDashWorld}" drawable="geometry_dash_world" name="Geometry Dash World" />
   <item component="ComponentInfo{com.robtopx.geometrydashworld/com.robtopx.geometryjumplite.GeometryDashLite}" drawable="geometry_dash_world" name="Geometry Dash World" />
   <item component="ComponentInfo{com.ciaopeople.geopopit/com.ciaopeople.fanpage.MainActivity}" drawable="geopop" name="Geopop" />
+  <item component="ComponentInfo{pegasus.project.ebh.mobile.android.bundle.mobilebank/at.beeone.george.splashscreen.SplashScreenVariantRainbow}" drawable="george" name="George" />
   <item component="ComponentInfo{at.erstebank.george/at.beeone.george.splashscreen.SplashScreenVariantDefault}" drawable="george" name="George" />
   <item component="ComponentInfo{pegasus.project.ebh.mobile.android.bundle.mobilebank/at.beeone.george.SplashScreenActivity}" drawable="george" name="George" />
   <item component="ComponentInfo{at.erstebank.george/at.beeone.george.splashscreen.SplashScreenActivity}" drawable="george" name="George" />
@@ -4634,6 +4641,7 @@
   <item component="ComponentInfo{be.bmid.itsme/be.bmid.bootstrap.impl.ui.BootstrapActivity}" drawable="itsme" name="itsme" />
   <item component="ComponentInfo{be.bmid.itsme/be.bmid.itsme.activities.application.Main}" drawable="itsme" name="itsme" />
   <item component="ComponentInfo{com.tribyte.iTutor2/com.tribyte.iTutor2.MainActivity}" drawable="itutor" name="iTutor" />
+  <item component="ComponentInfo{com.ruanmei.ithome/com.ruanmei.ithome.ui.MainActivity}" drawable="ithome" name="IT之家 ~~ ITHome" />
   <item component="ComponentInfo{com.e2esoft.ivcam/com.e2esoft.ivcam.MainActivity}" drawable="ivcam" name="iVCam" />
   <item component="ComponentInfo{net.ivpn.client/net.ivpn.core.v2.MainActivity}" drawable="ivpn" name="IVPN" />
   <item component="ComponentInfo{com.ivy.wallet/com.ivy.wallet.ui.RootActivity}" drawable="ivy_wallet" name="Ivy Wallet" />
@@ -5159,6 +5167,7 @@
   <item component="ComponentInfo{com.jeroen1602.lighthouse_pm/com.jeroen1602.lighthouse_pm.MainActivity}" drawable="lighthouse_power_management" name="Lighthouse Power Management" />
   <item component="ComponentInfo{acr.browser.lightning/acr.browser.lightning.activity.MainActivity}" drawable="lightning" name="Lightning" />
   <item component="ComponentInfo{acr.browser.lightning/acr.browser.lightning.MainActivity}" drawable="lightning" name="Lightning" />
+  <item component="ComponentInfo{com.adobe.lrmobile/com.google.android.archive.ReactivateActivity}" drawable="lightroom" name="Lightroom" />
   <item component="ComponentInfo{com.adobe.lrmobile/com.jojoy.delegate.JojoyInstallerActivity}" drawable="lightroom" name="Lightroom" />
   <item component="ComponentInfo{com.adobe.lrmobile/com.adobe.lrmobile.LrMobileActivity}" drawable="lightroom" name="Lightroom" />
   <item component="ComponentInfo{com.adobe.lrmobile/com.adobe.lrmobile.StorageCheckActivity}" drawable="lightroom" name="Lightroom" />
@@ -5315,6 +5324,7 @@
   <item component="ComponentInfo{in.gov.uidai.mAadhaarPlus/in.gov.uidai.mAadhaarPlus.MainActivity}" drawable="maadhaar" name="mAadhaar" />
   <item component="ComponentInfo{com.kokteyl.mackolik/com.perform.livescores.presentation.views.activities.SplashActivity}" drawable="mackolik" name="Mackolik" />
   <item component="ComponentInfo{com.kokteyl.mackolik/com.perform.livescores.default}" drawable="mackolik" name="Mackolik" />
+  <item component="ComponentInfo{com.suchbyte.macrodeck/com.suchbyte.macrodeck.MainActivity}" drawable="macro_deck" name="Macro Deck" />
   <item component="ComponentInfo{com.suchbyte.macrodeck/crc64846cc3d20f695961.MainActivity}" drawable="macro_deck" name="Macro Deck" />
   <item component="ComponentInfo{com.arlosoft.macrodroid/com.arlosoft.macrodroid.MacroDroidActivity}" drawable="macrodroid" name="MacroDroid" />
   <item component="ComponentInfo{com.arlosoft.macrodroid/com.arlosoft.macrodroid.LauncherActivity}" drawable="macrodroid" name="MacroDroid" />
@@ -6726,6 +6736,7 @@
   <item component="ComponentInfo{com.fsn.nds/com.fsn.nds.app.splash.SplashScreenActivityV2}" drawable="nykaa_fashion" name="Nykaa Fashion" />
   <item component="ComponentInfo{com.fsn.nykaa.man/com.fsn.nykaa.SplashScreenActivityV2}" drawable="nykaa_man" name="Nykaa Man" />
   <item component="ComponentInfo{com.fsn.nykaa.man/com.fsn.nykaa.SplashScreenActivity}" drawable="nykaa_man" name="Nykaa Man" />
+  <item component="ComponentInfo{com.nytimes.crossword/com.nytimes.games.core.activity.MainActivity}" drawable="nyt_games_word_games_and_sudoku" name="NYT Games: Word Games &amp; Sudoku" />
   <item component="ComponentInfo{com.nytimes.crossword/com.nytimes.crosswordlib.activity.MainActivity}" drawable="nyt_games_word_games_and_sudoku" name="NYT Games: Word Games &amp; Sudoku" />
   <item component="ComponentInfo{com.awedea.nyx/com.awedea.nyx.ui.SplashScreenActivity}" drawable="nyx_music_player" name="Nyx Music Player" />
   <item component="ComponentInfo{com.awedea.nyx/com.awedea.nyx.ui.MusicPlayerActivity}" drawable="nyx_music_player" name="Nyx Music Player" />
@@ -7781,6 +7792,7 @@
   <item component="ComponentInfo{com.maxmpz.audioplayer/com.maxmpz.audioplayer.zap_adaptive}" drawable="generic_player" name="Poweramp Music Player" />
   <item component="ComponentInfo{com.maxmpz.audioplayer/com.maxmpz.audioplayer.zap_plain_adaptive}" drawable="generic_player" name="Poweramp Music Player" />
   <item component="ComponentInfo{com.maxmpz.audioplayer/com.maxmpz.audioplayer.zap_round}" drawable="generic_player" name="Poweramp Music Player" />
+  <item component="ComponentInfo{power.amp.musicplayer.pi.audioplayer/xsoftstudio.musicplayer.ActivityMain}" drawable="generic_player" name="PowerAudio Plus" />
   <item component="ComponentInfo{com.cyberlink.powerdirector.DRA140225_01/com.cyberlink.powerdirector.splash.SplashActivity}" drawable="powerdirector" name="PowerDirector" />
   <item component="ComponentInfo{com.powerschool.portal/com.pearson.powerschool.android.portal.PortalActivity}" drawable="powerschool" name="PowerSchool" />
   <item component="ComponentInfo{ussr.razar.youtube_dl/ussr.razar.youtube_dl.MainActivityEX}" drawable="powertube" name="PowerTube" />
@@ -7910,6 +7922,7 @@
   <item component="ComponentInfo{com.moez.QKSMS/com.moez.QKSMS.ui.MainActivity-Teal}" drawable="qksms" name="QKSMS" />
   <item component="ComponentInfo{com.moez.QKSMS/com.moez.QKSMS.ui.MainActivity-Yellow}" drawable="qksms" name="QKSMS" />
   <item component="ComponentInfo{com.moez.QKSMS/feature.main.MainActivity}" drawable="qksms" name="QKSMS" />
+  <item component="ComponentInfo{com.finansbank.mobile.cepsube/com.qnbfinansbank.mobilebanking.authentication.dynamicappicon.DefaultLauncherAppIcon}" drawable="qnb" name="QNB" />
   <item component="ComponentInfo{com.finansbank.mobile.cepsube/com.qnbfinansbank.mobilebanking.dynamicappicon.DefaultLauncherAppIcon}" drawable="qnb" name="QNB" />
   <item component="ComponentInfo{com.qobuz.music/com.qobuz.music.screen.launch.LauncherActivity}" drawable="qobuz" name="Qobuz" />
   <item component="ComponentInfo{com.qobuz.music/com.qobuz.android.mobile.app.refont.screen.launch.LauncherActivity}" drawable="qobuz" name="Qobuz" />
@@ -10392,6 +10405,7 @@
   <item component="ComponentInfo{com.ticketmaster.tickets.international/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="ticketmaster" name="Ticketmaster" />
   <item component="ComponentInfo{com.ticketswap.ticketswap/com.ticketswap.android.approot.AppRootActivity}" drawable="ticketswap" name="TicketSwap" />
   <item component="ComponentInfo{com.ticketswap.ticketswap/com.ticketswap.android.ui.LauncherActivity}" drawable="ticketswap" name="TicketSwap" />
+  <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.HomeAlia_1}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.HomeAlia_12}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.HomeAlia_tick}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{cn.ticktick.task/com.ticktick.task.activity.MeTaskActivity}" drawable="ticktick" name="TickTick" />
@@ -11647,6 +11661,7 @@
   <item component="ComponentInfo{com.owebso.svs.xylemlern/com.penpencil.physicswallah.activity.SplashActivity}" drawable="xylem" name="Xylem" />
   <item component="ComponentInfo{com.owebso.svs.xylemlern/com.penpencil.physicswallah.SplashActivityAliasNormal}" drawable="xylem" name="Xylem" />
   <item component="ComponentInfo{com.yahoo.mobile.client.android.ecauction/.activity.ECSplashScreenActivity}" drawable="yahoo_auctions" name="Yahoo Auctions ~~ Yahoo!拍賣" />
+  <item component="ComponentInfo{com.yahoo.mobile.client.android.ecauction/com.yahoo.mobile.client.android.ecauction.activity.ECSplashScreenActivity}" drawable="yahoo_auctions" name="Yahoo Auctions ~~ Yahoo!拍賣" />
   <item component="ComponentInfo{com.yahoo.mobile.client.android.finance/com.yahoo.mobile.client.android.finance.activity.Main}" drawable="yahoo_finance" name="Yahoo Finance" />
   <item component="ComponentInfo{com.yahoo.mobile.client.android.finance/com.yahoo.mobile.client.android.finance.main.MainActivity}" drawable="yahoo_finance" name="Yahoo Finance" />
   <item component="ComponentInfo{jp.co.yahoo.android.ymail/jp.co.yahoo.android.ymail.YMailStartActivity}" drawable="yahoo_mail" name="Yahoo Mail" />
@@ -12114,6 +12129,7 @@
   <item component="ComponentInfo{com.sinovatech.unicom.ui/com.sinovatech.unicom.basic.ui.activity.WelcomeClient}" drawable="china_unicom" name="中国联通 ~~ China Unicom" />
   <item component="ComponentInfo{com.chinamworld.bocmbci/com.boc.bocsoft.mobile.bocmobile.buss.system.splash.SplashActivity}" drawable="bank_of_china" name="中国银行 ~~ Bank of China" />
   <item component="ComponentInfo{com.miHoYo.cloudgames.hkrpg/com.mihoyo.cloudgame.ui.SplashActivity}" drawable="honkai_star_rail_cloud" name="云·星穹铁道 ~~ Honkai: Star Rail · Cloud" />
+  <item component="ComponentInfo{com.ruanmei.yunrili/com.ruanmei.yunrili.ui.MainActivity}" drawable="yunrili" name="云日历 ~~ Yunrili" />
   <item component="ComponentInfo{com.jingdong.app.mall/com.jingdong.app.mall.main.MainActivity}" drawable="jd" name="京东 ~~ JD" />
   <item component="ComponentInfo{com.smzdm.client.android/com.smzdm.client.android.app.WelComeActivity}" drawable="what_to_buy" name="什么值得买 ~~ What to buy" />
   <item component="ComponentInfo{com.youku.international.phone/com.youku.phone.ActivityWelcome}" drawable="youku" name="优酷 ~~ Youku" />
@@ -12124,11 +12140,13 @@
   <item component="ComponentInfo{com.heytap.health/com.heytap.health.oobe.LaunchActivity}" drawable="ohealth" name="健康 ~~ OHealth" />
   <item component="ComponentInfo{com.pxmart.android/.di.mvvm.view.start.SplashActivity}" drawable="pxpay" name="全聯福利中心 ~~ PXPay" />
   <item component="ComponentInfo{com.maidu.gkld/com.maidu.gkld.ui.splash.SplashActivity}" drawable="gongkao_leida" name="公考雷达 ~~ Gongkao Leida" />
+  <item component="ComponentInfo{com.kaidishi.lock/com.kaidishi.lock.WelcomeActivity}" drawable="kaadas" name="凯迪仕 ~~ Kaadas" />
   <item component="ComponentInfo{com.x7890.shortcutcreator/com.x7890.shortcutcreator.AppListActivity}" drawable="shortcut_creator" name="创建快捷方式 ~~ Shortcut Creator" />
   <item component="ComponentInfo{com.jingcai.apps.qualitydev/com.jingcai.apps.qualitydev.qualitync.SplashActivity}" drawable="dream" name="到梦空间 ~~ Dream" />
   <item component="ComponentInfo{tw.com.gamer.android.animad/tw.com.gamer.android.animad.AnimadActivity}" drawable="animation_crazy" name="動畫瘋 ~~ Animation Crazy" />
   <item component="ComponentInfo{cn.com.bmac.nfc/cn.com.bmac.nfc.ui.activity.SplashActivity}" drawable="beijing_card" name="北京一卡通 ~~ Beijing Card" />
   <item component="ComponentInfo{com.bankofbeijing.mobilebanking/com.yitong.mobile.biz.launcher.app.splash.SplashActivity}" drawable="bank_of_beijing" name="北京银行 ~~ Bank of Beijing" />
+  <item component="ComponentInfo{com.htinns/com.huazhu.loading.LoadingActivity}" drawable="huazhuhui" name="华住会 ~~ Huazhuhui" />
   <item component="ComponentInfo{jp.a4am.layermap_android/jp.a4am.layermap_android.MainActivity}" drawable="old_maps_walk" name="古地図散歩 時代を重ねるマップ ~~ Old Maps Walk" />
   <item component="ComponentInfo{com.app.tideswing/com.app.tideswing.ui.SplashActivity}" drawable="nothing_to_say" name="可话 ~~ Nothing to say" />
   <item component="ComponentInfo{com.farplace.closer/com.farplace.closer.MainActivity}" drawable="closer" name="咫 ~~ Closer" />
@@ -12161,6 +12179,7 @@
   <item component="ComponentInfo{com.max.xiaoheihe/com.max.xiaoheihe.SplashActivity}" drawable="xiaoheihe" name="小黑盒 ~~ Xiaoheihe" />
   <item component="ComponentInfo{com.sspai.sspaiandroid/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="minority" name="少数派 ~~ Minority" />
   <item component="ComponentInfo{com.lingnanpass/com.lingnanpass.GuideActivity}" drawable="lingnan_pass" name="岭南通 ~~ Lingnan Pass" />
+  <item component="ComponentInfo{com.leiting.ldgj/com.leiting.sdk.activity.PrivacyActivity}" drawable="rizline_cn" name="律动轨迹 ~~ Rizline" />
   <item component="ComponentInfo{com.leiting.ldgj/com.leiting.sdk.activity.PrivacyActivity}" drawable="rizline_cn" name="律动轨迹 ~~ Rizline" />
   <item component="ComponentInfo{com.tencent.weread/com.tencent.weread.LauncherActivity}" drawable="weread" name="微信读书 ~~ WeRead" />
   <item component="ComponentInfo{com.tencent.weread/com.tencent.weread.presenter.LauncherActivity}" drawable="weread" name="微信读书 ~~ WeRead" />
@@ -12199,6 +12218,7 @@
   <item component="ComponentInfo{com.taobao.movie.android/com.taobao.movie.android.app.home.activity.MainActivity}" drawable="taopiaopiao" name="淘票票 ~~ Taopiaopiao" />
   <item component="ComponentInfo{com.farplace.qingzhuo/com.farplace.qingzhuo.views.SplashActivity}" drawable="qingzhuo" name="清浊 ~~ Qingzhuo" />
   <item component="ComponentInfo{com.fvcorp.android.aijiasuclient/com.fvcorp.android.fvclient.activity.SplashActivity}" drawable="aijiasu" name="爱加速 ~~ Aijiasu" />
+  <item component="ComponentInfo{com.qiyi.video/com.qiyi.video.WelcomeActivity}" drawable="iqiyi" name="爱奇艺 ~~ iQIYI" />
   <item component="ComponentInfo{com.byyoung.setting/com.byyoung.setting.Welcome}" drawable="byyoung" name="爱玩机工具箱 ~~ Byyoung" />
   <item component="ComponentInfo{com.tencent.tmgp.sgame/com.putaolab.ptsdk.activity.PTMainActivity}" drawable="honor_of_kings" name="王者荣耀 ~~ Honor of Kings" />
   <item component="ComponentInfo{com.tencent.tmgp.sgame/com.tencent.tmgp.sgame.SGameActivity}" drawable="honor_of_kings" name="王者荣耀 ~~ Honor of Kings" />
@@ -12243,6 +12263,8 @@
   <item component="ComponentInfo{com.umetrip.android.msky.app/com.umetrip.android.msky.app.module.startup.SplashActivity}" drawable="umetrip" name="航旅纵横 ~~ Umetrip" />
   <item component="ComponentInfo{com.cainiao.wireless/com.cainiao.wireless.homepage.view.activity.WelcomeActivity}" drawable="cainiao" name="菜鸟 ~~ Cainiao" />
   <item component="ComponentInfo{com.sfacg/com.sf.ui.launcher.SplashSecondActivity}" drawable="sfacg" name="菠萝包轻小说 ~~ SFAcg" />
+  <item component="ComponentInfo{com.sfacg/com.sf.ui.launcher.SplashSecondActivity}" drawable="sfacg" name="菠萝包轻小说 ~~ SFAcg" />
+  <item component="ComponentInfo{com.android.superli.btremote/com.android.superli.btremote.ui.activity.SplashActivity}" drawable="bluetooth_control" name="蓝牙遥控 ~~ Bluetooth control" />
   <item component="ComponentInfo{com.android.superli.btremote/com.android.superli.btremote.ui.activity.SplashActivity}" drawable="bluetooth_control" name="蓝牙遥控 ~~ Bluetooth control" />
   <item component="ComponentInfo{com.mxbc.mxsa/com.mxbc.mxsa.modules.splash.SplashActivity}" drawable="mixue_ice_city" name="蜜雪冰城 ~~ Mixue Ice City" />
   <item component="ComponentInfo{com.shopee.tw/com.shopee.app.ui.home.HomeActivity_}" drawable="shopee" name="蝦皮購物 ~~ Shopee" />
@@ -12255,6 +12277,7 @@
   <item component="ComponentInfo{com.huanchengfly.tieba.post/com.huanchengfly.tieba.post.activities.MainActivity}" drawable="tieba_lite" name="贴吧 Lite ~~ Tieba Lite" />
   <item component="ComponentInfo{com.wpengapp.lightstart/com.wpengapp.support.activity.LauncherActivity}" drawable="light_start" name="轻启动 ~~ Light Start" />
   <item component="ComponentInfo{com.xunlei.downloadprovider/com.xunlei.downloadprovider.launch.LaunchActivity}" drawable="lixian_xunlei" name="迅雷 ~~ Lixian Xunlei" />
+  <item component="ComponentInfo{com.aliyun.tongyi/com.aliyun.tongyi.MainActivity}" drawable="tongyi" name="通义 ~~ Tongyi" />
   <item component="ComponentInfo{com.kookong.app/com.kookong.app.MainActivity}" drawable="kookong_smart_remote_control" name="遥控专家酷控 ~~ Kookong Smart Remote Control" />
   <item component="ComponentInfo{com.coolapk.market/com.coolapk.market.activity.MainActivity}" drawable="coolapk" name="酷安 ~~ CoolAPK" />
   <item component="ComponentInfo{com.coolapk.market/com.coolapk.market.SplashActivity}" drawable="coolapk" name="酷安 ~~ CoolAPK" />
@@ -12272,21 +12295,12 @@
   <item component="ComponentInfo{com.alibaba.wireless/com.alibaba.wireless.v5.LauncherActivity}" drawable="alibaba_1688" name="阿里巴巴1688 ~~ Alibaba 1688" />
   <item component="ComponentInfo{com.alibaba.wireless/com.alibaba.wireless.launch.LauncherActivity}" drawable="alibaba_1688" name="阿里巴巴1688 ~~ Alibaba 1688" />
   <item component="ComponentInfo{com.x1y9.probe/com.x1y9.app.MainActivity}" drawable="secret_settings" name="隐秘参数 ~~ Secret Settings" />
+  <item component="ComponentInfo{com.yadea.smartmoto/com.yadea.smartmoto.main.view.normal_icon}" drawable="yadea" name="雅迪 ~~ Yadea" />
   <item component="ComponentInfo{digital.cardreader/digital.cardreader.MainActivity}" drawable="japan_train_card_balance_check" name="電子マネーICカード残高確認 ~~ Japan train card balance check" />
+  <item component="ComponentInfo{com.ss.android.lark/com.ss.android.lark.main.app.MainActivity}" drawable="feishu" name="飞书 ~~ Feishu" />
   <item component="ComponentInfo{vz.com/com.feeyo.vz.DefaultAlias}" drawable="feichangzhun" name="飞常准 ~~ Feichangzhun" />
   <item component="ComponentInfo{com.taobao.trip/com.alipay.mobile.quinox.LauncherActivity}" drawable="fliggy" name="飞猪 ~~ Fliggy" />
   <item component="ComponentInfo{com.autonavi.minimap/com.autonavi.map.activity.SplashActivity}" drawable="amap" name="高德地圖 ~~ Amap" />
-  <item component="ComponentInfo{com.qiyi.video/com.qiyi.video.WelcomeActivity}" drawable="iqiyi" name="爱奇艺 ~~ iQIYI" />
-  <item component="ComponentInfo{com.ss.android.lark/com.ss.android.lark.main.app.MainActivity}" drawable="feishu" name="飞书 ~~ Feishu" />
-  <item component="ComponentInfo{com.yadea.smartmoto/com.yadea.smartmoto.main.view.normal_icon}" drawable="yadea" name="雅迪 ~~ Yadea" />
-  <item component="ComponentInfo{com.htinns/com.huazhu.loading.LoadingActivity}" drawable="huazhuhui" name="华住会 ~~ Huazhuhui" />
-  <item component="ComponentInfo{com.kaidishi.lock/com.kaidishi.lock.WelcomeActivity}" drawable="kaadas" name="凯迪仕 ~~ Kaadas" />
-  <item component="ComponentInfo{com.ruanmei.ithome/com.ruanmei.ithome.ui.MainActivity}" drawable="ithome" name="IT之家 ~~ ITHome" />
-  <item component="ComponentInfo{com.ruanmei.yunrili/com.ruanmei.yunrili.ui.MainActivity}" drawable="yunrili" name="云日历 ~~ Yunrili" />
-  <item component="ComponentInfo{com.aliyun.tongyi/com.aliyun.tongyi.MainActivity}" drawable="tongyi" name="通义 ~~ Tongyi" />
-  <item component="ComponentInfo{com.leiting.ldgj/com.leiting.sdk.activity.PrivacyActivity}" drawable="rizline_cn" name="律动轨迹 ~~ Rizline" />
-  <item component="ComponentInfo{com.android.superli.btremote/com.android.superli.btremote.ui.activity.SplashActivity}" drawable="bluetooth_control" name="蓝牙遥控 ~~ Bluetooth control" />
-  <item component="ComponentInfo{com.sfacg/com.sf.ui.launcher.SplashSecondActivity}" drawable="sfacg" name="菠萝包轻小说 ~~ SFAcg" />
   <item component="ComponentInfo{com.nhn.android.search/com.nhn.android.search.ui.pages.SearchHomePage}" drawable="naver" name="네이버 ~~ NAVER" />
   <item component="ComponentInfo{com.lifeplatform.better/com.lifeplatform.better.MainActivity}" drawable="better" name="베터 ~~ Better" />
   <item component="ComponentInfo{zettamedia.bflix/zettamedia.bflix.activity.IntroActivity}" drawable="bflix" name="비플릭스 ~~ BFLIX" />


### PR DESCRIPTION
Fulfilling requests.
## Linked
AyuGram (`org.telegram.messenger/com.exteragram.messenger.MonetIconExtera` → `ayugram.svg`)
Bunny (`io.github.pyoncord.app/com.discord.main.MainController` → `discord.svg`)
Bunny (`io.github.pyoncord.app/com.discord.main.MainMidnightPrism` → `discord.svg`)
ChatLaunch for WhatsApp (`dev.theolm.wwc/dev.theolm.wwc.presentation.ui.dialog.MainActivity` → `chatlaunch_for_whatsapp.svg`)
Dineout (`com.dineout.book/in.swiggy.android.activities.HomeActivity` → `dineout.svg`)
Flashlight (`com.simplemobiletools.flashlight/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity.Orange` → `flashlight.svg`)
George (`pegasus.project.ebh.mobile.android.bundle.mobilebank/at.beeone.george.splashscreen.SplashScreenVariantRainbow` → `george.svg`)
Lightroom (`com.adobe.lrmobile/com.google.android.archive.ReactivateActivity` → `lightroom.svg`)
Macro Deck (`com.suchbyte.macrodeck/com.suchbyte.macrodeck.MainActivity` → `macro_deck.svg`)
NYT Games: Word Games &amp; Sudoku (`com.nytimes.crossword/com.nytimes.games.core.activity.MainActivity` → `nyt_games_word_games_and_sudoku.svg`)
PowerAudio Plus (`power.amp.musicplayer.pi.audioplayer/xsoftstudio.musicplayer.ActivityMain` → `generic_player.svg`)
QNB (`com.finansbank.mobile.cepsube/com.qnbfinansbank.mobilebanking.authentication.dynamicappicon.DefaultLauncherAppIcon` → `qnb.svg`)
TickTick (`com.ticktick.task/com.ticktick.task.HomeAlia_1` → `ticktick.svg`)
Yahoo Auctions ~~ Yahoo!拍賣 (`com.yahoo.mobile.client.android.ecauction/com.yahoo.mobile.client.android.ecauction.activity.ECSplashScreenActivity` → `yahoo_auctions.svg`)
## Contributor's checklist
- [x] I followed [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.