### PR TITLE
Clarifying the icon update template

### DIFF
--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -20,3 +20,4 @@ body:
     id: additional-info
     attributes:
       label: Additional information
+      placeholder: Specify what else is worth considering. For example, the application has a new activity.

--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -20,4 +20,4 @@ body:
     id: additional-info
     attributes:
       label: Additional information
-      placeholder: Specify what else is worth considering. For example, the application has a new activity.
+      placeholder: Specify what else is worth considering. For example, the application has a new activity

--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -12,6 +12,11 @@ body:
         - [the link to the icon](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs) in Lawnicons;
         - the new application name, if changed;
         - the image of the new icon.
+
+        Example:
+        Twitter, [twitter.svg](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs/)
+        ↓
+        X, [the X logo](https://commons.wikimedia.org/wiki/File:X_logo_2023_original.svg)
         
       placeholder: Tell us what should be changed and how
     validations:

--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -9,7 +9,7 @@ body:
       description: |
         Please specify for each icon:
         - the current application name in Lawnicons (search in [the appfilter.xml](https://github.com/LawnchairLauncher/lawnicons/blob/develop/app/assets/appfilter.xml));
-        - [the link to the icon](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs) in Lawnicons.
+        - [the link to the icon](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs) in Lawnicons;
         - the new application name, if changed;
         - the image of the new icon.
         

--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -7,13 +7,13 @@ body:
     attributes:
       label: Icons
       description: |
-        Please specify for each icon:
+        **Please specify for each icon**
         - the current application name in Lawnicons (search in [the appfilter.xml](https://github.com/LawnchairLauncher/lawnicons/blob/develop/app/assets/appfilter.xml));
         - [the link to the icon](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs) in Lawnicons;
         - the new application name, if changed;
         - the image of the new icon.
 
-        Example:
+        **Example**
         Twitter, [twitter.svg](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs/)
         ↓
         X, [the X logo](https://commons.wikimedia.org/wiki/File:X_logo_2023_original.svg)

--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -1,24 +1,20 @@
-name: Request icon design change
-description: Request changing the design of an existing icon in Lawnicons
-title: "[Icon Rebrand] "
-labels: ["icon rebrand"]
+name: Change an outdated icon
+description: Request updating an icon if it is outdated or applied incorrectly.
+labels: ["icon change"]
 body:
   - type: textarea
     id: outdated-icon-list
     attributes:
-      label: List of outdated icons
+      label: Outdated icons
       description: |
-        Please follow the following format regarding the outdated icons:
-
-        ```
-        App Name
-        (image to new icon)
+        Please specify what will change:
         
-        App Name
-        (image to new icon)
-        ```
-
-        It is more preferable to link to the outdated icon in [the svgs/ folder](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs)
+        **Old App Name**
+        The [link to the outdated icon](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs).
+        ↓
+        **New App Name**
+        The image of the new icon.
+        
       placeholder: 
     validations:
       required: true
@@ -26,6 +22,3 @@ body:
     id: additional-info
     attributes:
       label: Additional information
-      description: Place additional context here.
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -1,21 +1,19 @@
-name: Change an outdated icon
-description: Request updating an icon if it is outdated or applied incorrectly.
+name: Update an existing icon
+description: Request changing an icon if it is outdated or applied incorrectly.
 labels: ["icon change"]
 body:
   - type: textarea
     id: outdated-icon-list
     attributes:
-      label: Outdated icons
+      label: Icons
       description: |
-        Please specify what will change:
+        Please specify for each icon:
+        - the current application name in Lawnicons (search in [the appfilter.xml](https://github.com/LawnchairLauncher/lawnicons/blob/develop/app/assets/appfilter.xml));
+        - [the link to the icon](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs) in Lawnicons.
+        - the new application name, if changed;
+        - the image of the new icon.
         
-        **Old App Name**
-        The [link to the outdated icon](https://github.com/LawnchairLauncher/lawnicons/tree/develop/svgs).
-        ↓
-        **New App Name**
-        The image of the new icon.
-        
-      placeholder: 
+      placeholder: Tell us what should be changed and how
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/icon_rebrand.yml
+++ b/.github/ISSUE_TEMPLATE/icon_rebrand.yml
@@ -1,6 +1,6 @@
 name: Update an existing icon
 description: Request changing an icon if it is outdated or applied incorrectly.
-labels: ["icon change"]
+labels: ["icon update"]
 body:
   - type: textarea
     id: outdated-icon-list


### PR DESCRIPTION
I deleted unnecessary info, clarified the terms and expanded the template a little. This way, we could see what needs to be changed, as well as catch activities that have been assigned to the wrong icons.

Most likely the preview is not quite accurate in the order of the blocks.
## Preview
![Screenshot 2024-07-30 at 10 26 16](https://github.com/user-attachments/assets/cb52428e-9c94-48cb-9de0-555357431c44)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
