### PR TITLE
New issue: Add a link to an existing icon

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Add new links via pull requests.
   - name: Icon Request
     url: https://forms.gle/xt7sJhgWEasuo9TR9
-    about: Please request your icons in this form.    
+    about: Please request your icons in this form.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Add a new link to an existing icon
+    url: https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md#adding-an-icon-to-lawnicons
+    about: Add new links via pull requests.
   - name: Icon Request
     url: https://forms.gle/xt7sJhgWEasuo9TR9
-    about: Please request your icons in this form.
+    about: Please request your icons in this form.    

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Add a new link to an existing icon
+  - name: Link apps to existing icons
     url: https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md#adding-an-icon-to-lawnicons
-    about: Add new links via pull requests.
+    about: Learn more about linking an app to an existing icon and making a PR to contribute to Lawnicons.
   - name: Icon Request
     url: https://forms.gle/xt7sJhgWEasuo9TR9
     about: Please request your icons in this form.


### PR DESCRIPTION
Although most of the new links are available in the icon request table, sometimes people want to speed up the process. I suggest making a link to the instructions for them.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
