### PR TITLE
+37 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -512,6 +512,7 @@
   <item component="ComponentInfo{de.danoeh.antennapod/de.danoeh.antennapod.activity.SplashActivity}" drawable="antennapod" name="AntennaPod" />
   <item component="ComponentInfo{dev.lucanlm.antimine/dev.lucasnlm.antimine.main.MainActivity}" drawable="antimine" name="Antimine" />
   <item component="ComponentInfo{dev.lucanlm.antimine/dev.lucasnlm.antimine.splash.SplashActivity}" drawable="antimine" name="Antimine" />
+  <item component="ComponentInfo{com.antutu.ABenchMark/org.uzuy.uzuy_emu.ui.main.MainActivity}" drawable="antutu_benchmark" name="AnTuTu Benchmark" />
   <item component="ComponentInfo{com.antutu.ABenchMark/com.antutu.ABenchMark.MainActivity}" drawable="antutu_benchmark" name="AnTuTu Benchmark" />
   <item component="ComponentInfo{com.antutu.benchmark.full/com.android.module.graphics.app.MainActivity}" drawable="antutu_benchmark" name="AnTuTu Benchmark" />
   <item component="ComponentInfo{com.antutu.benchmark.full.lite/com.android.module.graphics.app.MainActivity}" drawable="antutu_benchmark" name="AnTuTu Benchmark" />
@@ -681,6 +682,7 @@
   <item component="ComponentInfo{in.hridayan.ashell/in.hridayan.ashell.activities.StartActivity}" drawable="ladb" name="aShell You" />
   <item component="ComponentInfo{in.hridayan.ashell/in.hridayan.ashell.activities.MainActivity}" drawable="ladb" name="aShell You" />
   <item component="ComponentInfo{com.asos.app/com.asos.app.ui.activities.ConfigActivity}" drawable="asos" name="ASOS" />
+  <item component="ComponentInfo{com.gameloft.android.ANMP.GloftA8HM/com.byfen.archiver.MainActivity}" drawable="asphalt_8_airborne" name="Asphalt 8: Airborne" />
   <item component="ComponentInfo{com.gameloft.android.ANMP.GloftA8HM/com.gameloft.android.ANMP.GloftA8HM.MainActivity}" drawable="asphalt_8_airborne" name="Asphalt 8: Airborne" />
   <item component="ComponentInfo{com.gameloft.android.SAMS.GloftA9SS/com.gameloft.android.SAMS.GloftA9SS.MainActivity}" drawable="asphalt_legends_unite" name="Asphalt Legends Unite" />
   <item component="ComponentInfo{com.gameloft.android.ANMP.GloftA9HM/com.gameloft.android.ANMP.GloftA9HM.MainActivity}" drawable="asphalt_legends_unite" name="Asphalt Legends Unite" />
@@ -796,6 +798,7 @@
   <item component="ComponentInfo{com.axis.net/com.axis.net.SplashScreenActivity}" drawable="axisnet" name="AXISnet" />
   <item component="ComponentInfo{com.axis.net/com.axis.net.ui.splashLogin.SplashActivity}" drawable="axisnet" name="AXISnet" />
   <item component="ComponentInfo{com.axis.net/com.axis.net.ui.splashscreen.SplashScreenAcitivity}" drawable="axisnet" name="AXISnet" />
+  <item component="ComponentInfo{org.telegram.messenger.web/com.exteragram.messenger.MonetIconExtera}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{com.radolyn.ayugram/com.exteragram.messenger.AyuGramExtera}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{org.telegram.messenger/com.exteragram.messenger.SusIcon}" drawable="ayugram" name="AyuGram" />
   <item component="ComponentInfo{org.telegram.messenger/com.exteragram.messenger.MonetIconExtera}" drawable="ayugram" name="AyuGram" />
@@ -956,6 +959,7 @@
   <item component="ComponentInfo{com.apple.bnd/com.apple.vienna.v3.presentation.welcome.WelcomeActivity}" drawable="beats" name="Beats" />
   <item component="ComponentInfo{com.beatstars.mobile/com.beatstars.mobile.activities.MainActivity}" drawable="beatstars" name="BeatStars" />
   <item component="ComponentInfo{sk.maniacs.bm/sk.maniacs.bm.DirectFileActivityIAP}" drawable="beatx" name="BeatX" />
+  <item component="ComponentInfo{com.meitu.meiyancamera/com.android.camera.CameraLauncher}" drawable="beautycam" name="BeautyCam" />
   <item component="ComponentInfo{com.meitu.meiyancamera/com.meitu.myxj.home.activity.NewHomeActivity}" drawable="beautycam" name="BeautyCam" />
   <item component="ComponentInfo{com.meitu.meiyancamera/com.qihoo.util.StartActivity}" drawable="beautycam" name="BeautyCam" />
   <item component="ComponentInfo{com.meitu.meiyancamera/com.meitu.meiyancamera.HomeActivity}" drawable="beautycam" name="BeautyCam" />
@@ -988,9 +992,11 @@
   <item component="ComponentInfo{org.kde.bettercounter/org.kde.bettercounter.ui.MainActivity}" drawable="bettercounter" name="BetterCounter" />
   <item component="ComponentInfo{com.sapuseven.untis/com.sapuseven.untis.activities.MainActivity}" drawable="better_untis" name="BetterUntis" />
   <item component="ComponentInfo{com.bewakoof.bewakoof/com.bewakoof.bewakoof.MainActivity}" drawable="bewakoof" name="Bewakoof" />
+  <item component="ComponentInfo{org.telegram.BifToGram/org.telegram.messenger.DefaultIcon}" drawable="bgram" name="BGram" />
   <item component="ComponentInfo{org.telegram.BifToGram/org.telegram.ui.LaunchActivity}" drawable="bgram" name="BGram" />
   <item component="ComponentInfo{com.wirelessalien.android.bhagavadgita/com.wirelessalien.android.bhagavadgita.activity.SplashActivity}" drawable="bhagavad_gita" name="Bhagavad Gita" />
   <item component="ComponentInfo{com.wirelessalien.android.bhagavadgita/com.wirelessalien.android.bhagavadgita.MainActivity}" drawable="bhagavad_gita" name="Bhagavad Gita" />
+  <item component="ComponentInfo{in.org.npci.upiapp/pqzfrpu.ae}" drawable="bhim" name="BHIM" />
   <item component="ComponentInfo{in.org.npci.upiapp/uuqkxbixh.J}" drawable="bhim" name="BHIM" />
   <item component="ComponentInfo{in.org.npci.upiapp/butqc.l}" drawable="bhim" name="BHIM" />
   <item component="ComponentInfo{in.org.npci.upiapp/bnbcpjyhd.ac}" drawable="bhim" name="BHIM" />
@@ -1115,6 +1121,7 @@
   <item component="ComponentInfo{com.immediasemi.android.blink/com.immediasemi.blink.activities.MainActivity}" drawable="blink_home_monitor" name="Blink Home Monitor" />
   <item component="ComponentInfo{com.blinkslabs.blinkist.android/com.blinkslabs.blinkist.android.ui.activities.LauncherActivity}" drawable="blinkist" name="Blinkist" />
   <item component="ComponentInfo{com.blinkslabs.blinkist.android/com.blinkslabs.blinkist.android.uicore.activities.LauncherActivity}" drawable="blinkist" name="Blinkist" />
+  <item component="ComponentInfo{com.grofers.customerapp/com.grofers.customerapp.RAKHI}" drawable="blinkit" name="Blinkit" />
   <item component="ComponentInfo{com.grofers.customerapp/com.grofers.customerapp.INDEPENDENCE_DAY}" drawable="blinkit" name="Blinkit" />
   <item component="ComponentInfo{com.grofers.customerapp/com.grofers.customerapp.activities.ActivitySplashScreen}" drawable="blinkit" name="Blinkit" />
   <item component="ComponentInfo{com.grofers.customerapp/com.grofers.customerapp.DIWALI}" drawable="blinkit" name="Blinkit" />
@@ -1330,6 +1337,7 @@
   <item component="ComponentInfo{com.dwarfplanet.bundle/com.dwarfplanet.bundle.v2.ui.landing.views.SplashActivity}" drawable="bundle" name="Bundle" />
   <item component="ComponentInfo{com.xaviertobin.noted/com.xaviertobin.noted.activities.ActivitySignIn}" drawable="bundled_notes" name="Bundled Notes" />
   <item component="ComponentInfo{com.xaviertobin.noted/com.xaviertobin.noted.activities.ActivityBundles}" drawable="bundled_notes" name="Bundled Notes" />
+  <item component="ComponentInfo{io.github.pyoncord.app/com.discord.main.MainMatteDark}" drawable="discord" name="Bunny" />
   <item component="ComponentInfo{io.github.pyoncord.app/com.discord.main.MainBlurpleTwilight}" drawable="discord" name="Bunny" />
   <item component="ComponentInfo{io.github.pyoncord.app/com.discord.main.MainManga}" drawable="discord" name="Bunny" />
   <item component="ComponentInfo{io.github.pyoncord.app/com.discord.main.MainController}" drawable="discord" name="Bunny" />
@@ -2620,6 +2628,7 @@
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenAux$Main}" drawable="discord" name="Discord" />
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenLoading}" drawable="discord" name="Discord" />
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenMain}" drawable="discord" name="Discord" />
+  <item component="ComponentInfo{com.discoverfinancial.mobile/pf541ae78.wa3b13fd1.e7dfda19d.o4531864c}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/c6471e4fe.w09cf6196.n6c037710.o50da4a26}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/r13fa4bdb.rcd00874d.e8944d836.y0b26d82e}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/g6dffb2ad.xc5285670.rea5c867d.rcd1d7b0d}" drawable="discover" name="Discover" />
@@ -4003,6 +4012,7 @@
   <item component="ComponentInfo{com.google.android.apps.playconsole/com.google.android.apps.play.console.mobile.MainActivity}" drawable="google_play_console" name="Google Play Console" />
   <item component="ComponentInfo{com.google.android.play.games/com.google.android.apps.play.games.features.gamefolder.appdrawer.GameFolderAppDrawerActivity}" drawable="google_play_games" name="Google Play Games" />
   <item component="ComponentInfo{com.google.android.play.games/com.google.android.gms.games.ui.destination.main.MainActivity}" drawable="google_play_games" name="Google Play Games" />
+  <item component="ComponentInfo{com.android.vending/org.lighthouseex.MainActivity}" drawable="google_play_store" name="Google Play Store" />
   <item component="ComponentInfo{com.android.vending/com.squareup.leakcanary.internal.DisplayLeakActivity}" drawable="google_play_store" name="Google Play Store" />
   <item component="ComponentInfo{com.android.vending/com.android.vending.AssetBrowserActivity}" drawable="google_play_store" name="Google Play Store" />
   <item component="ComponentInfo{com.android.vending/com.google.android.finsky.activities.PlayLauncherActivity}" drawable="google_play_store" name="Google Play Store" />
@@ -4278,6 +4288,8 @@
   <item component="ComponentInfo{com.fingersoft.hcr2/com.fingersoft.hcr2.AppActivity}" drawable="hill_climb_racing_2" name="Hill Climb Racing 2" />
   <item component="ComponentInfo{co.hinge.app/co.hinge.app.ui.AppActivity}" drawable="hinge" name="Hinge" />
   <item component="ComponentInfo{co.hinge.app/co.hinge.launch.LaunchActivity}" drawable="hinge" name="Hinge" />
+  <item component="ComponentInfo{com.transsion.hilauncher/com.transsion.theme.common.XThemeMain}" drawable="hios_launcher" name="HiOS Launcher" />
+  <item component="ComponentInfo{com.transsion.hilauncher/com.transsion.theme.MainActivity}" drawable="hios_launcher" name="HiOS Launcher" />
   <item component="ComponentInfo{com.transsion.hilauncher/com.android.launcher3.DynamicVirtualEntryActivity}" drawable="hios_launcher" name="HiOS Launcher" />
   <item component="ComponentInfo{cz.hipercalc.pro/cz.hipercalc.CalculatorActivity}" drawable="hiper_calc_pro" name="HiPER Calc Pro" />
   <item component="ComponentInfo{cz.hipercalc.pro/app.hipercalc.CalculatorActivity}" drawable="hiper_calc_pro" name="HiPER Calc Pro" />
@@ -4361,6 +4373,7 @@
   <item component="ComponentInfo{com.huawei.smarthome/com.huawei.smarthome.login.LauncherActivity}" drawable="huawei_ai_life" name="Huawei AI Life" />
   <item component="ComponentInfo{com.huawei.appmarket/com.huawei.appmarket.MainActivity}" drawable="huawei_appgallery" name="Huawei AppGallery" />
   <item component="ComponentInfo{com.huawei.browser/com.huawei.browser.Main2}" drawable="huawei_browser" name="Huawei Browser" />
+  <item component="ComponentInfo{com.huawei.HwMultiScreenShot/com.android.systemui.flashlight.FlashlightActivity}" drawable="flashlight" name="Huawei Flashlight" />
   <item component="ComponentInfo{com.huawei.health/com.huawei.healthcloud.cardui.MainActivity}" drawable="huawei_health" name="Huawei Health" />
   <item component="ComponentInfo{com.huawei.health/com.huawei.health.ui.SplashActivity}" drawable="huawei_health" name="Huawei Health" />
   <item component="ComponentInfo{com.huawei.health/com.huawei.health.MainActivity}" drawable="huawei_health" name="Huawei Health" />
@@ -4395,6 +4408,7 @@
   <item component="ComponentInfo{com.thehungrywasp.iamsober/com.thehungrywasp.iamsober.MainActivity}" drawable="i_am_sober" name="I Am Sober" />
   <item component="ComponentInfo{com.zutgames.ilovehue/com.ansca.corona.CoronaActivity}" drawable="i_love_hue" name="I Love Hue" />
   <item component="ComponentInfo{com.zutgames.ilovehue2/com.unity3d.player.UnityPlayerActivity}" drawable="i_love_hue_too" name="I Love Hue Too" />
+  <item component="ComponentInfo{com.android.VideoPlayer/com.kxk.ugc.video.splash.SplashActivity}" drawable="generic_player" name="i Video" />
   <item component="ComponentInfo{com.android.VideoPlayer/com.android.VideoPlayer.VideoPlayer}" drawable="generic_player" name="i Video" />
   <item component="ComponentInfo{com.epf.main/com.epf.main.view.activity.NewLogin}" drawable="iakaun" name="i-Akaun" />
   <item component="ComponentInfo{net.i2p.android/net.i2p.android.I2PActivity}" drawable="it2p" name="I2P" />
@@ -4830,6 +4844,7 @@
   <item component="ComponentInfo{com.kanopy/com.kanopy.RootTabbarActivity}" drawable="kanopy" name="Kanopy" />
   <item component="ComponentInfo{com.kantoninternet.customer/com.kantoninternet.customer.MainActivity}" drawable="kanton_internet" name="Kanton Internet" />
   <item component="ComponentInfo{com.kaorin.theme.iconpack/com.kaorin.theme.iconpack.activities.SplashActivity}" drawable="kaorin_icons" name="Kaorin Icons" />
+  <item component="ComponentInfo{uz.kapitalbank.kbonline/uz.kapitalbank.kbonline.presenter.activities.LoginActivity}" drawable="kapitalbank" name="Kapitalbank" />
   <item component="ComponentInfo{uz.kapitalbank.kbonline/uz.kapitalbank.kbonline.LoginActivity}" drawable="kapitalbank" name="Kapitalbank" />
   <item component="ComponentInfo{com.kardiawallet/com.kardiawallet.MainActivity}" drawable="kardiachain_wallet" name="KardiaChain Wallet" />
   <item component="ComponentInfo{com.telenav.streetview/com.telenav.osv.activity.SplashActivity}" drawable="kartaview" name="KartaView" />
@@ -5116,11 +5131,11 @@
   <item component="ComponentInfo{org.lufebe16.lbalance/org.kivy.android.PythonActivity}" drawable="lbalance" name="LBalance" />
   <item component="ComponentInfo{io.lbry.browser/io.lbry.browser.MainActivity}" drawable="lbry" name="LBRY" />
   <item component="ComponentInfo{com.lcwaikiki.android/com.lcwaikiki.android.iconclass.LCWLauncherImage}" drawable="lc_waikiki" name="LC Waikiki" />
-  <item component="ComponentInfo{com.lensdistortions.ld/com.lensdistortions.ld.ui.SplashActivity}" drawable="lens_distortions" name="LD" />
   <item component="ComponentInfo{com.ld.cph.gl/com.ldcloud.cloudphonenet.ui.activity.splash.SplashActivity}" drawable="ldcloud" name="LDCloud" />
   <item component="ComponentInfo{life.league/life.league.base.LaunchActivity}" drawable="league" name="League" />
   <item component="ComponentInfo{com.LeagueofComicGeeks.app2/com.LeagueofComicGeeks.app2.MainActivity}" drawable="league_of_comic_geeks" name="League of Comic Geeks" />
   <item component="ComponentInfo{com.riotgames.league.wildrift/com.tencent.lolm.lgame}" drawable="league_of_legends_wild_rift" name="League of Legends: Wild Rift" />
+  <item component="ComponentInfo{com.chess.chesscoach/com.chess.chesscoach.MainActivity}" drawable="chess" name="Learn Chess with Dr. Wolf" />
   <item component="ComponentInfo{com.companyname.MaturaMatematyka/crc64981dfae6ceaa18fa.MainActivity}" drawable="generic_pi" name="Learn Math &amp; Math problems" />
   <item component="ComponentInfo{com.companyname.MaturaMatematyka/crc641e16e0ee91153bdf.SplashActivity}" drawable="generic_pi" name="Learn Math &amp; Math problems" />
   <item component="ComponentInfo{fr.leboncoin/fr.leboncoin.feature.splashscreen.ui.activities.SplashScreenActivity}" drawable="leboncoin" name="leboncoin" />
@@ -5138,6 +5153,8 @@
   <item component="ComponentInfo{one4studio.iconpack.lenaadaptive/com.candybar.dev.activities.SplashActivity}" drawable="lena_adaptive_icons" name="Lena Adaptive Icons" />
   <item component="ComponentInfo{one4studio.iconpack.lenadark/com.candybar.dev.activities.SplashActivity}" drawable="lena_dark_icons" name="Lena Dark Icons" />
   <item component="ComponentInfo{com.zui.filemanager/com.zui.filemanager.MainActivity}" drawable="files" name="Lenovo ZUI File Manager" />
+  <item component="ComponentInfo{com.lensdistortions.ld/com.lensdistortions.ld.ui.choosephoto.ChoosePhotoActivity}" drawable="lens_distortions" name="Lens Distortions (LD)" />
+  <item component="ComponentInfo{com.lensdistortions.ld/com.lensdistortions.ld.ui.SplashActivity}" drawable="lens_distortions" name="Lens Distortions (LD)" />
   <item component="ComponentInfo{com.lensa.app/com.lensa.original}" drawable="lensa" name="Lensa" />
   <item component="ComponentInfo{com.lenskart.app/com.lenskart.app.main.ui.SplashActivity}" drawable="lenskart" name="Lenskart" />
   <item component="ComponentInfo{com.lesspass.android/com.lesspass.android.MainActivity}" drawable="lesspass" name="LessPass" />
@@ -5537,6 +5554,7 @@
   <item component="ComponentInfo{com.wsandroid.suite/com.android.mcafee.ui.framework.BaseActivity}" drawable="mcafee_security" name="McAfee Security" />
   <item component="ComponentInfo{com.md.mcdonalds.gomcdo/main.java.com.md.mcdonalds.gomcdo.activities.SplashscreenActivity}" drawable="mcdoplus" name="McDo+" />
   <item component="ComponentInfo{com.md.mcdonalds.gomcdo/fr.unifymcd.mcdplus.ui.MainActivity}" drawable="mcdoplus" name="McDo+" />
+  <item component="ComponentInfo{com.mcdonalds.mobileapp/com.mcdonalds.mobileapp.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdonalds.mobileapp/com.mcdonalds.mobileapp.redesign.MainActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdo.mcdonalds/com.gigigo.mcdonaldsbr.modules.splash.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdo.mcdonalds/com.gigigo.mcdonaldsbr.ui.activities.splash.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
@@ -5804,6 +5822,8 @@
   <item component="ComponentInfo{com.jlong.miccheck/com.jlong.miccheck.MainActivity}" drawable="miccheck" name="MicCheck" />
   <item component="ComponentInfo{dev.ukanth.iconmanager/dev.ukanth.iconmgr.MainActivity}" drawable="micopacks" name="MicoPacks" />
   <item component="ComponentInfo{com.constantin.microflux/com.constantin.microflux.ui.MainActivity}" drawable="microflux" name="Microflux" />
+  <item component="ComponentInfo{app.revanced.android.gms/org.microg.gms.ui.MainSettingsActivity}" drawable="microg_settings" name="microG Settings" />
+  <item component="ComponentInfo{com.google.android.gms/org.lighthouse.SettingsActivity}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{app.revanced.android.gms/org.microg.gms.ui.SettingsActivityLauncher}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{com.google.android.gms/org.mg.SettingsActivity}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{com.google.android.gms/com.google.android.gms.app.settings.GoogleSettingsActivity}" drawable="microg_settings" name="microG Settings" />
@@ -5902,6 +5922,7 @@
   <item component="ComponentInfo{com.bstro.MindShift/com.bstro.MindShift.screens.launchscreen.LaunchActivity}" drawable="mindshift_cbt" name="MindShift CBT" />
   <item component="ComponentInfo{io.anuke.mindustry/mindustry.android.AndroidLauncher}" drawable="mindustry" name="Mindustry" />
   <item component="ComponentInfo{io.anuke.mindustry/io.anuke.mindustry.AndroidLauncher}" drawable="mindustry" name="Mindustry" />
+  <item component="ComponentInfo{com.mojang.minecraftpe.patch/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftpe/com.byfen.archiver.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftpe/com.fiveplay.mod.RMS.Recovery}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftpe/com.jojoy.delegate.JojoyInstallerActivity}" drawable="minecraft" name="Minecraft" />
@@ -6113,6 +6134,7 @@
   <item component="ComponentInfo{com.mplayer.streamcast/com.mplayer.streamcast.activity.SplashScreen}" drawable="mplayer" name="MPlayer" />
   <item component="ComponentInfo{is.xyz.mpv/is.xyz.mpv.MainActivity}" drawable="mpv_android" name="mpv" />
   <item component="ComponentInfo{com.ketchapp.mrgun/org.cocos2dx.cpp.AppActivity}" drawable="mr_gun_ketchapp" name="Mr Gun" />
+  <item component="ComponentInfo{dev.sanmer.mrepo/dev.sanmer.mrepo.ui.activity.MainActivity}" drawable="mrepo" name="MRepo" />
   <item component="ComponentInfo{com.sanmer.mrepo/com.sanmer.mrepo.ui.activity.setup.SetupActivity}" drawable="mrepo" name="MRepo" />
   <item component="ComponentInfo{com.sanmer.mrepo/com.sanmer.mrepo.ui.activity.MainActivity}" drawable="mrepo" name="MRepo" />
   <item component="ComponentInfo{com.sanmer.mrepo/com.sanmer.mrepo.ui.activity.main.MainActivity}" drawable="mrepo" name="MRepo" />
@@ -6267,6 +6289,8 @@
   <item component="ComponentInfo{com.vna.service.vvm/com.tmobile.vvm.application.activity.setup.WelcomeActivity}" drawable="my_visual_voicemail" name="My Visual Voicemail" />
   <item component="ComponentInfo{com.vna.service.vvm/com.vna.service.vvm.activity.setup.WelcomeActivity}" drawable="my_visual_voicemail" name="My Visual Voicemail" />
   <item component="ComponentInfo{com.vnp.myvinaphone/com.vnp.myvinaphone.activities.WelcomeApplication}" drawable="my_vnpt" name="My VNPT" />
+  <item component="ComponentInfo{com.emeint.android.myservices/com.emeint.android.myservices.ui.screens.splash.DefaultLauncher}" drawable="my_vodafone" name="My Vodafone ~~ MeinVodafone" />
+  <item component="ComponentInfo{com.vodafone.selfservis/com.vodafone.selfservis.feature.growth.prelogin.ui.dashboard.DashboardActivity}" drawable="my_vodafone" name="My Vodafone ~~ MeinVodafone" />
   <item component="ComponentInfo{com.appseleration.android.selfcare/com.meinvodafone.rn.dev.MainActivity}" drawable="my_vodafone" name="My Vodafone ~~ MeinVodafone" />
   <item component="ComponentInfo{com.twinkle.MyVodafoneSamoa/com.twinkle.MyVodafoneSamoa.activities.SplashActivity}" drawable="my_vodafone" name="My Vodafone ~~ MeinVodafone" />
   <item component="ComponentInfo{ck.vodafone.apps.myvodafoneapp/ck.vodafone.apps.myvodafoneapp.MainActivity}" drawable="my_vodafone" name="My Vodafone ~~ MeinVodafone" />
@@ -8245,6 +8269,7 @@
   <item component="ComponentInfo{com.redbubble/com.redbubble.ui.MainActivity}" drawable="redbubble" name="Redbubble" />
   <item component="ComponentInfo{in.redbus.android/in.redbus.android.activity.SplashScreen}" drawable="redbus" name="redBus" />
   <item component="ComponentInfo{in.redbus.android/in.redbus.android.root.SplashScreen}" drawable="redbus" name="redBus" />
+  <item component="ComponentInfo{com.reddit.frontpage/launcher.stocks}" drawable="reddit" name="Reddit" />
   <item component="ComponentInfo{com.reddit.frontpage/launcher.neon}" drawable="reddit" name="Reddit" />
   <item component="ComponentInfo{com.reddit.frontpage/launcher.alien_blue}" drawable="reddit" name="Reddit" />
   <item component="ComponentInfo{com.reddit.frontpage/launcher.astronaut}" drawable="reddit" name="Reddit" />
@@ -8887,6 +8912,7 @@
   <item component="ComponentInfo{com.shopee.th/com.shopee.app.ui.home.HomeActivity_}" drawable="shopee" name="Shopee" />
   <item component="ComponentInfo{com.shopee.vn/com.shopee.app.ui.home.HomeActivity_}" drawable="shopee" name="Shopee" />
   <item component="ComponentInfo{com.shopee.lite.id/com.shopee.app.ui.home.HomeActivity_}" drawable="shopee" name="Shopee Lite" />
+  <item component="ComponentInfo{com.shopeepay.id/com.shopee.app.ui.home.HomeActivity_}" drawable="shopeepay" name="ShopeePay" />
   <item component="ComponentInfo{com.beeasy.airpay/com.airpay.login.splash.SplashActivity}" drawable="shopeepay" name="ShopeePay" />
   <item component="ComponentInfo{com.beeasy.toppay/com.airpay.login.splash.SplashActivity}" drawable="shopeepay" name="ShopeePay" />
   <item component="ComponentInfo{com.shopify.arrive/com.shopify.arrive.MainActivity}" drawable="shopify_shop" name="Shopify Shop" />
@@ -9489,6 +9515,7 @@
   <item component="ComponentInfo{com.kwai.bulldog/com.yxcorp.gifshow.tiny.TinyLaunchActivity}" drawable="snackvideo" name="SnackVideo" />
   <item component="ComponentInfo{com.kwai.bulldog/com.yxcorp.gifshow.homepage.HomeActivity}" drawable="snackvideo" name="SnackVideo" />
   <item component="ComponentInfo{com.bentostudio.ballsvsblocks/com.unity3d.player.UnityPlayerActivity}" drawable="snake_vs_block" name="Snake VS Block" />
+  <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.VhsAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.BlackMarbleAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.SnappyDoodleAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.AiWaveAlias}" drawable="snapchat" name="Snapchat" />
@@ -9685,6 +9712,7 @@
   <item component="ComponentInfo{com.spotify.music/com.spotify.login.loginflowimpl.LoginActivity}" drawable="spotify" name="Spotify" />
   <item component="ComponentInfo{com.spotify.music/com.spotify.music.MainActivity}" drawable="spotify" name="Spotify" />
   <item component="ComponentInfo{com.spotify.s4a/com.spotify.s4a.SplashActivity}" drawable="spotify_artists" name="Spotify for Artists" />
+  <item component="ComponentInfo{fm.anchor.android/com.spotify.app.s4p.main.applications.s4p.MainActivity}" drawable="spotify_podcasters" name="Spotify for Podcasters" />
   <item component="ComponentInfo{fm.anchor.android/anchor.MainActivity}" drawable="spotify_podcasters" name="Spotify for Podcasters" />
   <item component="ComponentInfo{com.spotify.lite/com.spotify.litenavigation.launcher.LauncherActivity}" drawable="spotify" name="Spotify Lite" />
   <item component="ComponentInfo{com.spotify.lite/com.spotify.lite.features.launcher.LauncherActivity}" drawable="spotify" name="Spotify Lite" />
@@ -9816,6 +9844,7 @@
   <item component="ComponentInfo{com.github.premnirmal.tickerwidget/com.github.premnirmal.ticker.home.SplashActivity}" drawable="stock_ticker" name="Stock Widget" />
   <item component="ComponentInfo{com.stock.widget/com.stock.widget.activity.home.HomeActivity}" drawable="stock_ticker" name="Stock Widget" />
   <item component="ComponentInfo{com.harry.stokie/com.harry.stokie.ui.activity.MainActivity}" drawable="stokie" name="STOKiE" />
+  <item component="ComponentInfo{com.harry.stokiepro/com.harry.stokiepro.ui.activity.MainActivity}" drawable="stokie" name="STOKiE PRO" />
   <item component="ComponentInfo{co.stone.banking.mobile.flagship/banking.features.login.verification.UserVerificationActivity}" drawable="stone" name="Stone" />
   <item component="ComponentInfo{com.mobile_infographics_tools.mydrive/com.mobile_infographics_tools.mydrive.activities.IntroActivity}" drawable="storage_analyzer" name="Storage Analyzer" />
   <item component="ComponentInfo{com.mobile_infographics_tools.mydrive/com.mobile_infographics_tools.mydrive.activities.MainActivity}" drawable="storage_analyzer" name="Storage Analyzer" />
@@ -10108,6 +10137,7 @@
   <item component="ComponentInfo{com.atr.tedit/com.atr.tedit.TEditActivity}" drawable="tedit" name="TEdit" />
   <item component="ComponentInfo{com.tmob.teknosa/com.tmob.teknosa.MainActivity}" drawable="teknosa" name="Teknosa" />
   <item component="ComponentInfo{com.tmob.teknosa/com.teknosa.MainActivity}" drawable="teknosa" name="Teknosa" />
+  <item component="ComponentInfo{ru.tele2.mytele2/ru.tele2.mytele2.ui.splash.SplashActivity}" drawable="tele2" name="Tele2" />
   <item component="ComponentInfo{nl.tele2.mytele2/nl.oberon.tmobile.my.activity.LoginActivity}" drawable="tele2" name="Tele2" />
   <item component="ComponentInfo{com.tivo.android.comhem/com.comhem.mandel.mobile.presentation.NavigationActivity}" drawable="tele2_play" name="Tele2 Play" />
   <item component="ComponentInfo{cn.tydic.ethiopay/com.huawei.module_basic_ui.splash.LauncherActivity}" drawable="telebirr" name="telebirr" />
@@ -11076,6 +11106,7 @@
   <item component="ComponentInfo{com.venmo/com.venmo.AppExperienceLauncherActivity}" drawable="venmo" name="Venmo" />
   <item component="ComponentInfo{com.whatever.verifit/com.example.verifit.MainActivity}" drawable="verifit" name="Verifit" />
   <item component="ComponentInfo{com.whatever.verifit/com.example.verifit.ui.MainActivity}" drawable="verifit" name="Verifit" />
+  <item component="ComponentInfo{org.fsociety.vernet.store/org.fsociety.vernet.MainActivity}" drawable="vernet" name="Vernet" />
   <item component="ComponentInfo{org.fsociety.vernet/org.fsociety.vernet.MainActivity}" drawable="vernet" name="Vernet" />
   <item component="ComponentInfo{co.vero.app/co.vero.admission.entry.SplashActivity}" drawable="vero" name="VERO" />
   <item component="ComponentInfo{com.watch.life/com.ido.life.module.splash.SplashDefaultActivity}" drawable="veryfit" name="VeryFit" />
@@ -11363,6 +11394,7 @@
   <item component="ComponentInfo{com.waze/com.waze.FreeMapAppActivity}" drawable="waze" name="Waze" />
   <item component="ComponentInfo{com.wrx.wazirx/com.wrx.wazirx.views.home.HomeActivity}" drawable="wazirx" name="WazirX" />
   <item component="ComponentInfo{com.wealthify.wealthifyapp/com.wealthify.arkham.MainActivity}" drawable="wealthify" name="Wealthify" />
+  <item component="ComponentInfo{com.wealthsimple.trade/com.wealthsimple.trade.MainActivityPremium}" drawable="wealthsimple" name="Wealthsimple" />
   <item component="ComponentInfo{com.wealthsimple.trade/com.wealthsimple.trade.LaunchActivity}" drawable="wealthsimple" name="Wealthsimple" />
   <item component="ComponentInfo{com.wealthsimple.trade/com.wealthsimple.trade.MainActivityDefault}" drawable="wealthsimple" name="Wealthsimple" />
   <item component="ComponentInfo{com.wealthsimple.trade/host.exp.exponent.LaunchActivity}" drawable="wealthsimple" name="Wealthsimple" />
@@ -11371,6 +11403,7 @@
   <item component="ComponentInfo{com.google.android.wearable.app/com.google.android.clockwork.companion.StatusActivity}" drawable="wear_os" name="Wear OS" />
   <item component="ComponentInfo{com.google.android.wearable.app.cn/com.google.android.clockwork.companion.launcher.LauncherActivity}" drawable="wear_os" name="Wear OS" />
   <item component="ComponentInfo{com.google.android.wearable.app.cn/com.google.android.clockwork.companion.StatusActivity}" drawable="wear_os" name="Wear OS" />
+  <item component="ComponentInfo{com.google.android.apps.weather/com.google.android.apps.weather.home.HomeActivity}" drawable="weather" name="Weather" />
   <item component="ComponentInfo{com.meizu.flyme.weather/com.meizu.flyme.weather.WeatherMainActivity}" drawable="weather" name="Weather" />
   <item component="ComponentInfo{com.meizu.flyme.weather/com.meizu.flyme.weather.modules.home.WeatherMainActivity}" drawable="weather" name="Weather" />
   <item component="ComponentInfo{com.rlk.weathers/com.rlk.weathers.ui.main.MainActivity}" drawable="weather" name="Weather" />
@@ -11759,6 +11792,7 @@
   <item component="ComponentInfo{com.xc3fff0e.xmanager/com.xc3fff0e.xmanager.SplashActivity}" drawable="xmanager" name="xManager" />
   <item component="ComponentInfo{net.xmind.doughnut/net.xmind.doughnut.MainActivity}" drawable="xmind" name="XMind" />
   <item component="ComponentInfo{com.xodo.pdf.reader/viewer.CompleteReaderMainActivity}" drawable="xodo_pdf" name="Xodo PDF Reader &amp; Editor" />
+  <item component="ComponentInfo{com.transsion.XOSLauncher/com.android.launcher3.DynamicVirtualEntryActivity}" drawable="xos_launcher" name="XOS Launcher" />
   <item component="ComponentInfo{com.transsion.XOSLauncher.upgrade/com.android.launcher3.DynamicVirtualEntryActivity}" drawable="xos_launcher" name="XOS Launcher" />
   <item component="ComponentInfo{co.xoss/co.xoss.sprint.ui.tool.LauncherUI}" drawable="xoss" name="XOSS" />
   <item component="ComponentInfo{video.player.videoplayer/com.inshot.xplayer.activities.FileExplorerActivity}" drawable="xplayer" name="XPlayer" />
@@ -12024,6 +12058,7 @@
   <item component="ComponentInfo{com.application.zomato/com.application.zomato.Splash}" drawable="zomato" name="Zomato" />
   <item component="ComponentInfo{mobi.zona/mobi.zona.ui.MainActivity}" drawable="zona" name="Zona" />
   <item component="ComponentInfo{us.zoom.videomeetings/com.zipow.videobox.LauncherActivity}" drawable="zoom" name="Zoom" />
+  <item component="ComponentInfo{com.zoopla.activity/com.zoopla.activity.MainActivityDefault}" drawable="zoopla" name="Zoopla" />
   <item component="ComponentInfo{com.zoopla.activity/com.zoopla.activity.MainActivity}" drawable="zoopla" name="Zoopla" />
   <item component="ComponentInfo{xyz.deepdaikon.zoysii/xyz.deepdaikon.zoysii.MainActivity}" drawable="zoysii" name="Zoysii" />
   <item component="ComponentInfo{cn.zte.recorder/cn.zte.recorder.RecordHomeActivity}" drawable="recorder" name="ZTE Voice Recorder" />
@@ -12265,6 +12300,7 @@
   <item component="ComponentInfo{com.baseus.intelligent/com.baseus.intelligent.view.SplashActivity}" drawable="baseus" name="倍思 ~~ Baseus" />
   <item component="ComponentInfo{com.kuss.rewind/com.kuss.rewind.MainActivity}" drawable="rewind" name="倒带 ~~ Rewind" />
   <item component="ComponentInfo{com.heytap.health/com.heytap.health.oobe.LaunchActivity}" drawable="ohealth" name="健康 ~~ OHealth" />
+  <item component="ComponentInfo{com.pxmart.android/com.pxmart.android.di.mvvm.view.start.SplashActivity}" drawable="pxpay" name="全聯福利中心 ~~ PXPay" />
   <item component="ComponentInfo{com.pxmart.android/.di.mvvm.view.start.SplashActivity}" drawable="pxpay" name="全聯福利中心 ~~ PXPay" />
   <item component="ComponentInfo{com.maidu.gkld/com.maidu.gkld.ui.splash.SplashActivity}" drawable="gongkao_leida" name="公考雷达 ~~ Gongkao Leida" />
   <item component="ComponentInfo{com.kaidishi.lock/com.kaidishi.lock.WelcomeActivity}" drawable="kaadas" name="凯迪仕 ~~ Kaadas" />
@@ -12329,6 +12365,7 @@
   <item component="ComponentInfo{com.copymanga.app/com.copymanga.app.MainActivity}" drawable="_k" name="拷貝漫畫 ~~ Copy Manga" />
   <item component="ComponentInfo{com.xunmeng.pinduoduo/com.xunmeng.pinduoduo.ui.activity.MainFrameActivity}" drawable="pinduoduo" name="拼多多 ~~ Pinduoduo" />
   <item component="ComponentInfo{ctrip.android.view/ctrip.business.splash.CtripSplashActivity}" drawable="ctrip" name="携程旅行 ~~ Ctrip" />
+  <item component="ComponentInfo{com.xayah.databackup/com.xayah.databackup.activity.screen.ScreenActivity}" drawable="databackup" name="数据备份 ~~ DataBackup" />
   <item component="ComponentInfo{com.xayah.databackup.foss/com.xayah.databackup.SplashActivity}" drawable="databackup" name="数据备份 ~~ DataBackup" />
   <item component="ComponentInfo{com.xayah.databackup.premium/com.xayah.databackup.ui.activity.splash.SplashActivity}" drawable="databackup" name="数据备份 ~~ DataBackup" />
   <item component="ComponentInfo{com.xayah.databackup.premium/com.xayah.databackup.SplashActivity}" drawable="databackup" name="数据备份 ~~ DataBackup" />


### PR DESCRIPTION
Fulfilling requests.
## Linked
AnTuTu Benchmark (`com.antutu.ABenchMark/org.uzuy.uzuy_emu.ui.main.MainActivity` → `antutu_benchmark.svg`)
Asphalt 8: Airborne (`com.gameloft.android.ANMP.GloftA8HM/com.byfen.archiver.MainActivity` → `asphalt_8_airborne.svg`)
AyuGram (`org.telegram.messenger.web/com.exteragram.messenger.MonetIconExtera` → `ayugram.svg`)
BeautyCam (`com.meitu.meiyancamera/com.android.camera.CameraLauncher` → `beautycam.svg`)
BGram (`org.telegram.BifToGram/org.telegram.messenger.DefaultIcon` → `bgram.svg`)
BHIM (`in.org.npci.upiapp/pqzfrpu.ae` → `bhim.svg`)
Blinkit (`com.grofers.customerapp/com.grofers.customerapp.RAKHI` → `blinkit.svg`)
Bunny (`io.github.pyoncord.app/com.discord.main.MainMatteDark` → `discord.svg`)
Discover (`com.discoverfinancial.mobile/pf541ae78.wa3b13fd1.e7dfda19d.o4531864c` → `discover.svg`)
Google Play Store (`com.android.vending/org.lighthouseex.MainActivity` → `google_play_store.svg`)
HiOS Launcher (`com.transsion.hilauncher/com.transsion.theme.common.XThemeMain` → `hios_launcher.svg`)
HiOS Launcher (`com.transsion.hilauncher/com.transsion.theme.MainActivity` → `hios_launcher.svg`)
Huawei Flashlight (`com.huawei.HwMultiScreenShot/com.android.systemui.flashlight.FlashlightActivity` → `flashlight.svg`)
i Video (`com.android.VideoPlayer/com.kxk.ugc.video.splash.SplashActivity` → `generic_player.svg`)
Kapitalbank (`uz.kapitalbank.kbonline/uz.kapitalbank.kbonline.presenter.activities.LoginActivity` → `kapitalbank.svg`)
Learn Chess with Dr. Wolf (`com.chess.chesscoach/com.chess.chesscoach.MainActivity` → `chess.svg`)
Lens Distortions (LD) (`com.lensdistortions.ld/com.lensdistortions.ld.ui.choosephoto.ChoosePhotoActivity` → `lens_distortions.svg`)
McDonald's (`com.mcdonalds.mobileapp/com.mcdonalds.mobileapp.SplashActivity` → `mcdonalds.svg`)
microG Settings (`app.revanced.android.gms/org.microg.gms.ui.MainSettingsActivity` → `microg_settings.svg`)
microG Settings (`com.google.android.gms/org.lighthouse.SettingsActivity` → `microg_settings.svg`)
Minecraft (`com.mojang.minecraftpe.patch/com.mojang.minecraftpe.MainActivity` → `minecraft.svg`)
MRepo (`dev.sanmer.mrepo/dev.sanmer.mrepo.ui.activity.MainActivity` → `mrepo.svg`)
My Vodafone ~~ MeinVodafone (`com.emeint.android.myservices/com.emeint.android.myservices.ui.screens.splash.DefaultLauncher` → `my_vodafone.svg`)
My Vodafone ~~ MeinVodafone (`com.vodafone.selfservis/com.vodafone.selfservis.feature.growth.prelogin.ui.dashboard.DashboardActivity` → `my_vodafone.svg`)
Reddit (`com.reddit.frontpage/launcher.stocks` → `reddit.svg`)
ShopeePay (`com.shopeepay.id/com.shopee.app.ui.home.HomeActivity_` → `shopeepay.svg`)
Snapchat (`com.snapchat.android/com.snapchat.android.VhsAlias` → `snapchat.svg`)
Spotify for Podcasters (`fm.anchor.android/com.spotify.app.s4p.main.applications.s4p.MainActivity` → `spotify_podcasters.svg`)
STOKiE PRO (`com.harry.stokiepro/com.harry.stokiepro.ui.activity.MainActivity` → `stokie.svg`)
Tele2 (`ru.tele2.mytele2/ru.tele2.mytele2.ui.splash.SplashActivity` → `tele2.svg`)
Vernet (`org.fsociety.vernet.store/org.fsociety.vernet.MainActivity` → `vernet.svg`)
Wealthsimple (`com.wealthsimple.trade/com.wealthsimple.trade.MainActivityPremium` → `wealthsimple.svg`)
Weather (`com.google.android.apps.weather/com.google.android.apps.weather.home.HomeActivity` → `weather.svg`)
XOS Launcher (`com.transsion.XOSLauncher/com.android.launcher3.DynamicVirtualEntryActivity` → `xos_launcher.svg`)
Zoopla (`com.zoopla.activity/com.zoopla.activity.MainActivityDefault` → `zoopla.svg`)
全聯福利中心 ~~ PXPay (`com.pxmart.android/com.pxmart.android.di.mvvm.view.start.SplashActivity` → `pxpay.svg`)
数据备份 ~~ DataBackup (`com.xayah.databackup/com.xayah.databackup.activity.screen.ScreenActivity` → `databackup.svg`)
## Contributor's checklist
- [x] I followed [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.