### PR TITLE
+67 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4960,7 +4960,7 @@
   <item component="ComponentInfo{com.fsck.k9/com.fsck.k9.activity.MessageList}" drawable="k9_mail" name="K-9 Mail" />
   <item component="ComponentInfo{com.kafka.user/com.kafka.user.MainActivity}" drawable="kafka" name="Kafka" />
   <item component="ComponentInfo{com.absinthe.kage/com.absinthe.kage.ui.main.MainActivity}" drawable="kage" name="Kage" />
-  <item component="ComponentInfo{no.mobitroll.kahoot.android/com.google.android.archive.ReactivateActivity}" drawable="kahoot" name="Kahoot" />
+  <item component="ComponentInfo{no.mobitroll.kahoot.android/com.google.android.archive.ReactivateActivity}" drawable="kahoot" name="Kahoot!" />
   <item component="ComponentInfo{no.mobitroll.kahoot.android/no.mobitroll.kahoot.android.application.SplashActivity}" drawable="kahoot" name="Kahoot!" />
   <item component="ComponentInfo{com.kai.kaiticketing/com.kai.kaiticketing.MainActivity}" drawable="kai_access" name="KAI Access" />
   <item component="ComponentInfo{com.app.dealfish.main/com.app.dealfish.activities.StartActivity}" drawable="kaidee" name="Kaidee" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -323,6 +323,7 @@
   <item component="ComponentInfo{com.iov.lordofalgorithms/com.unity3d.player.UnityPlayerActivity}" drawable="algorithms_and_data_structures" name="Algorithms and Data Structures" />
   <item component="ComponentInfo{com.alibaba.intl.android.apps.poseidon/com.alibaba.intl.android.apps.poseidon.app.activity.ActivityMainMaterial}" drawable="alibabacom" name="Alibaba.com" />
   <item component="ComponentInfo{app.myzel394.alibi/app.myzel394.alibi.MainActivity}" drawable="alibi" name="Alibi" />
+  <item component="ComponentInfo{com.alibaba.aliexpresshd/com.google.android.archive.ReactivateActivity}" drawable="aliexpress" name="AliExpress" />
   <item component="ComponentInfo{com.alibaba.aliexpresshd/com.alibaba.aliexpresshd.home.ui.MainActivity}" drawable="aliexpress" name="AliExpress" />
   <item component="ComponentInfo{com.alibaba.aliexpresshd/com.alibaba.aliexpresshd.module.home.MainActivity}" drawable="aliexpress" name="AliExpress" />
   <item component="ComponentInfo{com.alibaba.aliexpresshd/com.alibaba.aliexpresshd.module.home.SplashActivity}" drawable="aliexpress" name="AliExpress" />
@@ -1888,6 +1889,7 @@
   <item component="ComponentInfo{com.ai.chat.bot.aichat/com.ai.chat.bot.aichat.start.StartActivity}" drawable="chat_ai" name="CHAT AI" />
   <item component="ComponentInfo{newway.open.chatgpt.ai.chat.bot.free/com.example.cca.view_ver_2.splash.SplashNewActivity}" drawable="chatbot_ai_4o" name="Chatbot AI 4o" />
   <item component="ComponentInfo{newway.open.chatgpt.ai.chat.bot.free/com.example.cca.views.Splash.SplashActivity}" drawable="chatbot_ai_4o" name="Chatbot AI 4o" />
+  <item component="ComponentInfo{com.openai.chatgpt/com.google.android.archive.ReactivateActivity}" drawable="chatgpt" name="ChatGPT" />
   <item component="ComponentInfo{com.openai.chatgpt/md.elway.evo.screen.chat.ChatActivity}" drawable="chatgpt" name="ChatGPT" />
   <item component="ComponentInfo{com.openai.chatgpt/com.openai.chatgpt.MainActivity}" drawable="chatgpt" name="ChatGPT" />
   <item component="ComponentInfo{dev.theolm.wwc/dev.theolm.wwc.presentation.ui.dialog.MainActivity}" drawable="chatlaunch_for_whatsapp" name="ChatLaunch for WhatsApp" />
@@ -2141,6 +2143,7 @@
   <item component="ComponentInfo{com.coinbase.android/com.coinbase.android.LaunchActivity}" drawable="coinbase" name="Coinbase" />
   <item component="ComponentInfo{com.coinbase.android/com.coinbase.android.MainActivity}" drawable="coinbase" name="Coinbase" />
   <item component="ComponentInfo{com.coinbase.android/com.coinbase.android.signin.IntroActivity}" drawable="coinbase" name="Coinbase" />
+  <item component="ComponentInfo{org.toshi/com.google.android.archive.ReactivateActivity}" drawable="coinbase_wallet" name="Coinbase Wallet" />
   <item component="ComponentInfo{org.toshi/org.toshi.MainActivity}" drawable="coinbase_wallet" name="Coinbase Wallet" />
   <item component="ComponentInfo{org.toshi/com.toshi.application.MainActivity}" drawable="coinbase_wallet" name="Coinbase Wallet" />
   <item component="ComponentInfo{com.samruston.flip/com.samruston.flip.Launcher}" drawable="coincalc" name="CoinCalc" />
@@ -2508,6 +2511,7 @@
   <item component="ComponentInfo{com.decathlon.app/com.decathlon.app.BLUE}" drawable="decathlon" name="Decathlon" />
   <item component="ComponentInfo{com.rivafarabi.deckboard.pro/com.rivafarabi.deckboard.pro.MainActivity}" drawable="deckboard_pro" name="Deckboard PRO" />
   <item component="ComponentInfo{com.deen/com.deen.MainActivity}" drawable="deen" name="Deen" />
+  <item component="ComponentInfo{com.deepl.mobiletranslator/com.google.android.archive.ReactivateActivity}" drawable="deepl" name="DeepL" />
   <item component="ComponentInfo{com.example.deeplviewer/com.example.deeplviewer.activity.MainActivity}" drawable="deepl" name="DeepL" />
   <item component="ComponentInfo{com.deepl.mobiletranslator/com.deepl.mobiletranslator.MainActivity}" drawable="deepl" name="DeepL" />
   <item component="ComponentInfo{com.example.deeplviewer/com.example.deeplviewer.MainActivity}" drawable="deepl" name="DeepL" />
@@ -2990,6 +2994,7 @@
   <item component="ComponentInfo{com.mttnow.droid.easyjet/com.mttnow.droid.easyjet.ui.home.SplashActivity}" drawable="easyjet" name="easyJet" />
   <item component="ComponentInfo{pk.com.telenor.phoenix/pk.com.telenor.phoenix.views.home.SplashActivity}" drawable="easypaisa" name="Easypaisa" />
   <item component="ComponentInfo{pk.com.telenor.phoenix/pk.com.telenor.phoenix.views.home_rewamp.activity.HomeActivityMain}" drawable="easypaisa" name="Easypaisa" />
+  <item component="ComponentInfo{net.easypark.android/com.google.android.archive.ReactivateActivity}" drawable="easypark" name="EasyPark" />
   <item component="ComponentInfo{net.easypark.android/net.easypark.android.mvp.splash.SplashActivity}" drawable="easypark" name="EasyPark" />
   <item component="ComponentInfo{com.vivo.easyshare/com.vivo.easyshare.activity.SplashScreenActivity}" drawable="easyshare" name="EasyShare" />
   <item component="ComponentInfo{com.done.faasos/com.done.faasos.activity.SplashActivity}" drawable="eatsure" name="EatSure" />
@@ -3152,6 +3157,7 @@
   <item component="ComponentInfo{ch.evpass.evpass/ch.evpass.evpass.base.activities.SplashActivity}" drawable="evpass" name="evpass" />
   <item component="ComponentInfo{com.coolkit/com.coolkit.MainActivity}" drawable="ewelink" name="eWeLink" />
   <item component="ComponentInfo{com.coolkit/com.coolkit.SplashActivity}" drawable="ewelink" name="eWeLink" />
+  <item component="ComponentInfo{flar2.exkernelmanager/com.google.android.archive.ReactivateActivity}" drawable="ex_kernel_manager" name="EX Kernel Manager" />
   <item component="ComponentInfo{flar2.exkernelmanager/flar2.exkernelmanager.StartActivity}" drawable="ex_kernel_manager" name="EX Kernel Manager" />
   <item component="ComponentInfo{flar2.exkernelmanager/a.b}" drawable="ex_kernel_manager" name="EX Kernel Manager" />
   <item component="ComponentInfo{flar2.exkernelmanager/a.a}" drawable="ex_kernel_manager" name="EX Kernel Manager" />
@@ -3384,6 +3390,10 @@
   <item component="ComponentInfo{com.fineco.it/com.fineco.it.Splash}" drawable="fineco" name="Fineco" />
   <item component="ComponentInfo{com.overlook.android.fing/com.overlook.android.fing.SplashActivity}" drawable="fing" name="Fing" />
   <item component="ComponentInfo{com.overlook.android.fing/com.overlook.android.fing.ui.main.SplashActivity}" drawable="fing" name="Fing" />
+  <item component="ComponentInfo{com.finshell.fin/com.finshell.fin.activity.MainActivity}" drawable="finshell_pay" name="FinShell Pay" />
+  <item component="ComponentInfo{com.finshell.fin/com.finshell.fin.activity.SplashActivity}" drawable="finshell_pay" name="FinShell Pay" />
+  <item component="ComponentInfo{com.finshell.fin/com.finshell.fin.Default}" drawable="finshell_pay" name="FinShell Pay" />
+  <item component="ComponentInfo{com.finshell.fin/com.finshell.fin.splash.SplashActivity}" drawable="finshell_pay" name="FinShell Pay" />
   <item component="ComponentInfo{com.finshell.fin/com.finshell.fin.BuildIn}" drawable="finshell_pay" name="FinShell Pay" />
   <item component="ComponentInfo{com.finshell.wallet/com.nearme.wallet.SplashActivity}" drawable="finshell_wallet" name="FinShell Wallet" />
   <item component="ComponentInfo{com.amazon.storm.lightning.client.aosp/com.amazon.storm.lightning.client.main.MainActivity}" drawable="fire_tv" name="Fire TV" />
@@ -3662,6 +3672,7 @@
   <item component="ComponentInfo{org.fedorahosted.freeotp/org.fedorahosted.freeotp.PasswordActivity}" drawable="freeotp_authenticator" name="FreeOTP Authenticator" />
   <item component="ComponentInfo{org.liberty.android.freeotpplus/org.fedorahosted.freeotp.ui.MainActivity}" drawable="freeotp" name="FreeOTP+" />
   <item component="ComponentInfo{io.freetrade.android/in.icon.Default}" drawable="freetrade" name="Freetrade" />
+  <item component="ComponentInfo{io.freetubeapp.freetube/io.freetubeapp.freetube}" drawable="freetube" name="FreeTube" />
   <item component="ComponentInfo{io.freetubeapp.freetube/io.freetubeapp.freetube.MainActivity}" drawable="freetube" name="FreeTube" />
   <item component="ComponentInfo{f.f.freezer/f.f.freezer.MainActivity}" drawable="deezer" name="Freezer" />
   <item component="ComponentInfo{com.jujinkim.frequaw/com.jujinkim.frequaw.ui.MainActivity}" drawable="frequaw" name="Frequaw" />
@@ -4001,6 +4012,7 @@
   <item component="ComponentInfo{com.google.android.apps.authenticator2/com.google.android.apps.authenticator2.main.MainActivity}" drawable="google_authenticator" name="Google Authenticator" />
   <item component="ComponentInfo{com.google.android.apps.authenticator2/com.google.android.apps.authenticator.AuthenticatorActivity}" drawable="google_authenticator" name="Google Authenticator" />
   <item component="ComponentInfo{arn.android.gcam/com.android.camera.CameraLauncher}" drawable="camera" name="Google Camera Mod" />
+  <item component="ComponentInfo{com.google.android.apps.dynamite/com.google.android.archive.ReactivateActivity}" drawable="google_chat" name="Google Chat" />
   <item component="ComponentInfo{com.google.android.apps.dynamite/com.google.android.apps.dynamite.startup.StartUpActivity}" drawable="google_chat" name="Google Chat" />
   <item component="ComponentInfo{com.android.chrome/com.android.chrome.Main}" drawable="google_chrome" name="Google Chrome" />
   <item component="ComponentInfo{com.android.chrome/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Google Chrome" />
@@ -4042,6 +4054,7 @@
   <item component="ComponentInfo{com.google.android.apps.searchlite/com.google.android.apps.searchlite.ui.SearchActivity}" drawable="google" name="Google Go" />
   <item component="ComponentInfo{com.google.android.apps.healthdata/com.google.android.apps.healthdata.home.phone.root.RootActivity}" drawable="google_health_connect" name="Google Health Connect" />
   <item component="ComponentInfo{com.google.android.apps.healthdata/com.google.android.apps.healthdata.LauncherActivity}" drawable="google_health_connect" name="Google Health Connect" />
+  <item component="ComponentInfo{com.google.android.apps.chromecast.app/com.google.android.archive.ReactivateActivity}" drawable="google_home" name="Google Home" />
   <item component="ComponentInfo{com.google.android.apps.chromecast.app/com.google.android.apps.chromecast.app.DiscoveryActivity}" drawable="google_home" name="Google Home" />
   <item component="ComponentInfo{com.google.android.keep/com.google.android.keep.activities.AnimatingListDetailsEditActivity}" drawable="google_keep" name="Google Keep" />
   <item component="ComponentInfo{com.google.android.keep/com.google.android.keep.activities.Br}" drawable="google_keep" name="Google Keep" />
@@ -4064,12 +4077,14 @@
   <item component="ComponentInfo{com.google.android.apps.mapslite/com.google.androidbrowserhelper.trusted.LauncherActivity}" drawable="maps" name="Google Maps Go" />
   <item component="ComponentInfo{com.google.android.apps.mapslite/com.google.maps.lite.twa.MapsLiteTwaLauncherActivity}" drawable="maps" name="Google Maps Go" />
   <item component="ComponentInfo{com.google.android.apps.mapslite/org.chromium.webapk.shell_apk.MainActivity}" drawable="maps" name="Google Maps Go" />
+  <item component="ComponentInfo{com.google.android.apps.tachyon/com.google.android.archive.ReactivateActivity}" drawable="google_meet" name="Google Meet" />
   <item component="ComponentInfo{com.google.android.apps.tachyon/com.google.android.apps.tachyon.MainActivity}" drawable="google_meet" name="Google Meet" />
   <item component="ComponentInfo{com.google.android.apps.tachyon/com.google.android.apps.tachyon.MainActivitySecondLauncher}" drawable="google_meet" name="Google Meet" />
   <item component="ComponentInfo{com.google.android.apps.meetings/com.google.android.apps.meetings.splash.SplashActivity}" drawable="google_meet" name="Google Meet" />
   <item component="ComponentInfo{com.google.android.apps.messaging/com.kyant.vanilla.MainActivity}" drawable="google_messages" name="Google Messages" />
   <item component="ComponentInfo{com.google.android.apps.messaging/com.google.android.apps.messaging.main.MainActivity}" drawable="google_messages" name="Google Messages" />
   <item component="ComponentInfo{com.google.android.apps.messaging/com.google.android.apps.messaging.ui.ConversationListActivity}" drawable="google_messages" name="Google Messages" />
+  <item component="ComponentInfo{com.google.android.apps.magazines/com.google.android.archive.ReactivateActivity}" drawable="google_news" name="Google News" />
   <item component="ComponentInfo{com.google.android.apps.magazines/com.google.apps.dots.android.app.activity.CurrentsStartActivity}" drawable="google_news" name="Google News" />
   <item component="ComponentInfo{com.google.android.apps.subscriptions.red/com.google.android.apps.subscriptions.red.LauncherActivity}" drawable="google_one" name="Google One" />
   <item component="ComponentInfo{com.google.android.apps.paidtasks/com.google.android.apps.paidtasks.activity.LaunchActivity}" drawable="google_opinion_rewards" name="Google Opinion Rewards" />
@@ -4084,6 +4099,7 @@
   <item component="ComponentInfo{com.google.android.apps.wearables.maestro.companion/com.google.android.apps.wearables.maestro.companion.ui.ShortCutActivity}" drawable="google_pixel_buds" name="Google Pixel Buds" />
   <item component="ComponentInfo{com.google.android.apps.wear.companion/com.google.android.apps.wear.companion.core.application.RootActivity}" drawable="google_pixel_watch" name="Google Pixel Watch" />
   <item component="ComponentInfo{com.google.android.apps.wear.companion/com.google.android.apps.wear.companion.application.RootActivity}" drawable="google_pixel_watch" name="Google Pixel Watch" />
+  <item component="ComponentInfo{com.google.android.apps.books/com.google.android.archive.ReactivateActivity}" drawable="google_play_books" name="Google Play Books" />
   <item component="ComponentInfo{com.google.android.apps.books/com.google.android.apps.books.app.BooksActivity}" drawable="google_play_books" name="Google Play Books" />
   <item component="ComponentInfo{com.google.android.apps.books/com.google.android.apps.books.app.HomeActivity}" drawable="google_play_books" name="Google Play Books" />
   <item component="ComponentInfo{com.google.android.apps.playconsole/com.google.android.apps.playconsole.activity.MainAndroidActivity}" drawable="google_play_console" name="Google Play Console" />
@@ -4099,16 +4115,19 @@
   <item component="ComponentInfo{com.google.android.apps.docs.editors.sheets/com.google.android.apps.docs.app.NewMainProxyActivity}" drawable="google_sheets" name="Google Sheets" />
   <item component="ComponentInfo{com.google.android.apps.docs.editors.sheets/com.google.android.apps.docs.editors.kix.KixDocumentCreatorActivity}" drawable="google_sheets" name="Google Sheets" />
   <item component="ComponentInfo{com.google.android.apps.docs.editors.sheets/com.google.android.apps.docs.editors.kix.KixEditorActivity}" drawable="google_sheets" name="Google Sheets" />
+  <item component="ComponentInfo{com.google.android.apps.docs.editors.slides/com.google.android.archive.ReactivateActivity}" drawable="google_slides" name="Google Slides" />
   <item component="ComponentInfo{com.google.android.apps.docs.editors.slides/com.google.android.apps.docs.app.NewMainProxyActivity}" drawable="google_slides" name="Google Slides" />
   <item component="ComponentInfo{com.google.android.apps.docs.editors.slides/com.google.android.apps.docs.editors.punch.PunchActivity}" drawable="google_slides" name="Google Slides" />
   <item component="ComponentInfo{com.google.android.street/com.google.android.street.Street}" drawable="google_street_view" name="Google Street View" />
   <item component="ComponentInfo{com.google.android.street/com.google.android.apps.dragonfly.activities.main.LauncherActivity}" drawable="google_street_view" name="Google Street View" />
   <item component="ComponentInfo{com.google.android.street/com.google.android.libraries.streetview.main.StreetViewActivity}" drawable="google_street_view" name="Google Street View" />
   <item component="ComponentInfo{com.google.android.street/com.google.android.apps.dragonfly.activities.main.MainActivity}" drawable="google_street_view" name="Google Street View" />
+  <item component="ComponentInfo{com.google.android.apps.tasks/com.google.android.archive.ReactivateActivity}" drawable="google_tasks" name="Google Tasks" />
   <item component="ComponentInfo{com.google.android.apps.tasks/com.google.android.apps.tasks.ui.TaskListsActivity}" drawable="google_tasks" name="Google Tasks" />
   <item component="ComponentInfo{com.google.android.apps.translate/com.google.android.apps.translate.HomeActivity}" drawable="google_translate" name="Google Translate" />
   <item component="ComponentInfo{com.google.android.apps.translate/com.google.android.apps.translate.TranslateActivity}" drawable="google_translate" name="Google Translate" />
   <item component="ComponentInfo{com.google.android.apps.translate/.TranslateActivity}" drawable="google_translate" name="Google Translate" />
+  <item component="ComponentInfo{com.google.android.videos/com.google.android.archive.ReactivateActivity}" drawable="google_tv" name="Google TV" />
   <item component="ComponentInfo{com.google.android.videos/com.google.android.videos.activity.HomeActivity}" drawable="google_tv" name="Google TV" />
   <item component="ComponentInfo{com.google.android.videos/com.google.android.videos.activity.LauncherActivity}" drawable="google_tv" name="Google TV" />
   <item component="ComponentInfo{com.google.android.videos/com.google.android.videos.GoogleTvEntryPoint}" drawable="google_tv" name="Google TV" />
@@ -4375,6 +4394,7 @@
   <item component="ComponentInfo{com.transsion.hilauncher/com.android.launcher3.DynamicVirtualEntryActivity}" drawable="hios_launcher" name="HiOS Launcher" />
   <item component="ComponentInfo{cz.hipercalc.pro/cz.hipercalc.CalculatorActivity}" drawable="hiper_calc_pro" name="HiPER Calc Pro" />
   <item component="ComponentInfo{cz.hipercalc.pro/app.hipercalc.CalculatorActivity}" drawable="hiper_calc_pro" name="HiPER Calc Pro" />
+  <item component="ComponentInfo{cz.hipercalc/com.google.android.archive.ReactivateActivity}" drawable="hiper_scientific_calculator" name="HiPER Scientific Calculator" />
   <item component="ComponentInfo{cz.hipercalc/cz.hipercalc.CalculatorActivity}" drawable="hiper_scientific_calculator" name="HiPER Scientific Calculator" />
   <item component="ComponentInfo{cz.hipercalc/app.hipercalc.CalculatorActivity}" drawable="hiper_scientific_calculator" name="HiPER Scientific Calculator" />
   <item component="ComponentInfo{com.hishoot2i/com.hishoot2i.activities.SplashActivity}" drawable="hishoot2i" name="Hishoot2i" />
@@ -4552,11 +4572,13 @@
   <item component="ComponentInfo{com.deuskigames.idlepowerbeta/com.unity3d.player.UnityPlayerActivity}" drawable="idle_power" name="Idle Power" />
   <item component="ComponentInfo{br.com.brainweb.ifood/br.com.brainweb.ifood.mvp.splash.view.SplashScreenActivity}" drawable="ifood" name="iFood" />
   <item component="ComponentInfo{br.com.brainweb.ifood/br.com.ifood.activity.HomeActivity}" drawable="ifood" name="iFood" />
+  <item component="ComponentInfo{com.ifttt.ifttt/com.google.android.archive.ReactivateActivity}" drawable="ifttt" name="IFTTT" />
   <item component="ComponentInfo{com.ifttt.ifttt/com.ifttt.ifttt.home.ProPlusHomeActivity}" drawable="ifttt" name="IFTTT" />
   <item component="ComponentInfo{com.ifttt.ifttt/com.ifttt.ifttt.home.ProHomeActivity}" drawable="ifttt" name="IFTTT" />
   <item component="ComponentInfo{com.ifttt.ifttt/com.ifttt.ifttt.HomeActivity}" drawable="ifttt" name="IFTTT" />
   <item component="ComponentInfo{com.ifttt.ifttt/com.ifttt.ifttt.home.HomeActivity}" drawable="ifttt" name="IFTTT" />
   <item component="ComponentInfo{org.exarhteam.iitc_mobile/org.exarhteam.iitc_mobile.IITC_Mobile}" drawable="iitc" name="IITC" />
+  <item component="ComponentInfo{com.ingka.ikea.app/com.google.android.archive.ReactivateActivity}" drawable="ikea" name="IKEA" />
   <item component="ComponentInfo{hk.ikea.android/hk.com.ikea.flutter.hong_kong_native_flutter.MainActivity}" drawable="ikea" name="IKEA" />
   <item component="ComponentInfo{gr.mobile.ikea.cyprus/gr.mobile.ikea.ui.activity.LaunchActivity}" drawable="ikea" name="IKEA" />
   <item component="ComponentInfo{com.ingka.ikea.app/com.ingka.ikea.app.splash.FirstEntryActivity}" drawable="ikea" name="IKEA" />
@@ -4712,6 +4734,7 @@
   <item component="ComponentInfo{repost.share.instagram.videodownloader.photodownloader/repost.share.instagram.videodownloader.photodownloader.MainActivity}" drawable="generic_downloader" name="InsMate Pro" />
   <item component="ComponentInfo{repost.share.instagram.videodownloader.photodownloader/repost.share.instagram.videodownloader.photodownloader.StartupActivity}" drawable="generic_downloader" name="InsMate Pro" />
   <item component="ComponentInfo{mobi.charmer.quicksquarenew/mobi.charmer.quicksquarenew.InSquare_StartPageActivity}" drawable="insquare" name="InSquare" />
+  <item component="ComponentInfo{io.instabox.consumer/com.google.android.archive.ReactivateActivity}" drawable="instabox" name="Instabox" />
   <item component="ComponentInfo{io.instabox.consumer/io.instabox.consumer.ui.login.LoginActivityDefault}" drawable="instabox" name="Instabox" />
   <item component="ComponentInfo{com.instabridge.android/app.lawnchair.LawnchairLauncher}" drawable="instabridge" name="Instabridge" />
   <item component="ComponentInfo{com.instabridge.android/com.instabridge.android.ui.root.RootActivity}" drawable="instabridge" name="Instabridge" />
@@ -4900,6 +4923,7 @@
   <item component="ComponentInfo{io.jumptask.app/io.jt.app.MainActivity}" drawable="jumptask" name="JumpTask" />
   <item component="ComponentInfo{net.wooga.junes_journey_hidden_object_mystery_game/net.wooga.junes_journey.WoogaUnityPlayerActivity}" drawable="junes_journey" name="June's Journey" />
   <item component="ComponentInfo{studio14.application.juno/com.candybar.dev.activities.SplashActivity}" drawable="juno_icons" name="Juno Icons" />
+  <item component="ComponentInfo{money.jupiter/money.jupiter.MainActivity}" drawable="jupiter" name="Jupiter" />
   <item component="ComponentInfo{money.jupiter/money.jupiter.MainActivityDefault}" drawable="jupiter" name="Jupiter" />
   <item component="ComponentInfo{com.arexperiments.justaline/com.arexperiments.justaline.DrawARActivity}" drawable="just_a_line" name="Just a Line" />
   <item component="ComponentInfo{com.blockbasti.justanotherworkouttimer/com.blockbasti.just_another_workout_timer.MainActivity}" drawable="just_another_workout_timer" name="Just Another Workout Timer" />
@@ -4936,6 +4960,7 @@
   <item component="ComponentInfo{com.fsck.k9/com.fsck.k9.activity.MessageList}" drawable="k9_mail" name="K-9 Mail" />
   <item component="ComponentInfo{com.kafka.user/com.kafka.user.MainActivity}" drawable="kafka" name="Kafka" />
   <item component="ComponentInfo{com.absinthe.kage/com.absinthe.kage.ui.main.MainActivity}" drawable="kage" name="Kage" />
+  <item component="ComponentInfo{no.mobitroll.kahoot.android/com.google.android.archive.ReactivateActivity}" drawable="kahoot" name="Kahoot" />
   <item component="ComponentInfo{no.mobitroll.kahoot.android/no.mobitroll.kahoot.android.application.SplashActivity}" drawable="kahoot" name="Kahoot!" />
   <item component="ComponentInfo{com.kai.kaiticketing/com.kai.kaiticketing.MainActivity}" drawable="kai_access" name="KAI Access" />
   <item component="ComponentInfo{com.app.dealfish.main/com.app.dealfish.activities.StartActivity}" drawable="kaidee" name="Kaidee" />
@@ -4966,6 +4991,7 @@
   <item component="ComponentInfo{com.tplink.kasa_android/com.tplink.iot.view.welcome.StartupActivity}" drawable="kasa" name="Kasa" />
   <item component="ComponentInfo{com.kaskus.android/com.kaskus.forum.SplashActivity}" drawable="kaskus" name="KASKUS" />
   <item component="ComponentInfo{com.kms.free/com.kms.free.PermissionsActivityLauncher}" drawable="kaspersky" name="Kaspersky" />
+  <item component="ComponentInfo{com.perm.kate_new_6/com.perm.kate.InitialActivity}" drawable="kate_mobile" name="Kate Mobile" />
   <item component="ComponentInfo{com.perm.kate_new_6/com.perm.kate.MainActivity}" drawable="kate_mobile" name="Kate Mobile" />
   <item component="ComponentInfo{de.combirisk.katwarn/de.combirisk.katwarn.MainActivity}" drawable="katwarn" name="KATWARN" />
   <item component="ComponentInfo{com.kaufland.Kaufland/com.kaufland.kaufland.splash.SplashActivity}" drawable="kaufland" name="Kaufland" />
@@ -5109,6 +5135,7 @@
   <item component="ComponentInfo{com.kiriengine.app/com.kiriengine.app.app_entrance.ui.TransparentActivity}" drawable="kiri_engine" name="KIRI Engine" />
   <item component="ComponentInfo{fr.neamar.kiss/fr.neamar.kiss.MainActivity}" drawable="kiss_launcher" name="KISS Launcher" />
   <item component="ComponentInfo{com.yjllq.kito/cn.yujian.MainActivity}" drawable="kito" name="kito" />
+  <item component="ComponentInfo{com.kivra.Kivra/com.kivra.android.main.HomeActivity}" drawable="kivra" name="Kivra" />
   <item component="ComponentInfo{com.kivra.Kivra/com.kivra.android.login.LoginActivity}" drawable="kivra" name="Kivra" />
   <item component="ComponentInfo{com.kivra.Kivra/com.kivra.android.home.HomeActivity}" drawable="kivra" name="Kivra" />
   <item component="ComponentInfo{com.kiwibrowser.browser/com.google.android.apps.chrome.Main}" drawable="kiwi_browser" name="Kiwi Browser" />
@@ -5119,6 +5146,7 @@
   <item component="ComponentInfo{com.kkp.kkpmobile/com.kkp.kkpmobile.app.SplashActivity}" drawable="kkp" name="KKP" />
   <item component="ComponentInfo{org.androworks.klara/org.androworks.klara.MainActivity}" drawable="klara_weather" name="Klara weather" />
   <item component="ComponentInfo{de.klarmobil.kundenservice/de.freenet.android.base.login.LoginActivity}" drawable="klarmobilde" name="klarmobil" />
+  <item component="ComponentInfo{com.myklarnamobile/com.google.android.archive.ReactivateActivity}" drawable="klarna" name="Klarna" />
   <item component="ComponentInfo{com.myklarnamobile/com.klarna.MainActivity}" drawable="klarna" name="Klarna" />
   <item component="ComponentInfo{com.myklarnamobile/com.klarna.SplashActivity}" drawable="klarna" name="Klarna" />
   <item component="ComponentInfo{com.myklarnamobile/com.myklarnamobile.MainActivity}" drawable="klarna" name="Klarna" />
@@ -5281,6 +5309,7 @@
   <item component="ComponentInfo{com.abtnprojects.ambatana/com.abtnprojects.ambatana.ui.activities.ProductListingActivity}" drawable="letgo" name="letgo" />
   <item component="ComponentInfo{com.abtnprojects.ambatana/com.abtnprojects.ambatana.presentation.productlist.ProductListActivity}" drawable="letgo" name="letgo" />
   <item component="ComponentInfo{com.abtnprojects.ambatana/com.olxgroup.panamera.app.users.onboarding.activities.SplashActivity}" drawable="letgo" name="letgo" />
+  <item component="ComponentInfo{com.letterboxd.letterboxd/com.google.android.archive.ReactivateActivity}" drawable="letterboxd" name="Letterboxd" />
   <item component="ComponentInfo{com.letterboxd.letterboxd/com.letterboxd.letterboxd.ui.activities.LaunchActivity}" drawable="letterboxd" name="Letterboxd" />
   <item component="ComponentInfo{com.letterboxd.letterboxd/com.letterboxd.letterboxd.ui.activities.PopularActivity}" drawable="letterboxd" name="Letterboxd" />
   <item component="ComponentInfo{com.letyshops/com.lampa.letyshops.view.activity.SplashActivity}" drawable="letyshops" name="LetyShops" />
@@ -5311,6 +5340,7 @@
   <item component="ComponentInfo{com.foobnix.pro.pdf.reader/com.foobnix.ui2.MainTabs2}" drawable="generic_book" name="Librera PRO" />
   <item component="ComponentInfo{com.dosse.speedtest/com.fdossena.speedtest.ui.MainActivity}" drawable="librespeed" name="LibreSpeed" />
   <item component="ComponentInfo{com.kaajjo.libresudoku/com.kaajjo.libresudoku.MainActivity}" drawable="libresudoku" name="LibreSudoku" />
+  <item component="ComponentInfo{org.proninyaroslav.libretorrent/com.google.android.archive.ReactivateActivity}" drawable="libretorrent" name="LibreTorrent" />
   <item component="ComponentInfo{org.proninyaroslav.libretorrent/lorg.proninyaroslav.ibretorrent.MainActivity}" drawable="libretorrent" name="LibreTorrent" />
   <item component="ComponentInfo{org.proninyaroslav.libretorrent/org.proninyaroslav.libretorrent.MainActivity}" drawable="libretorrent" name="LibreTorrent" />
   <item component="ComponentInfo{org.proninyaroslav.libretorrent/org.proninyaroslav.libretorrent.ui.main.MainActivity}" drawable="libretorrent" name="LibreTorrent" />
@@ -5656,6 +5686,7 @@
   <item component="ComponentInfo{com.xinto.mauth/com.xinto.mauth.ui.MainActivity}" drawable="mauth" name="Mauth" />
   <item component="ComponentInfo{com.xinto.mauth/com.xinto.mauth.MainActivity}" drawable="mauth" name="Mauth" />
   <item component="ComponentInfo{com.mavi.kartus/com.mavi.kartus.MainActivityAlias1}" drawable="mavi" name="Mavi" />
+  <item component="ComponentInfo{se.max.android.locator/com.google.android.archive.ReactivateActivity}" drawable="max" name="Max" />
   <item component="ComponentInfo{se.max.android.locator/se.max.android.locator.MainActivity}" drawable="max" name="Max" />
   <item component="ComponentInfo{se.max.android.locator/com.futureordering.android.mobile.ui.main.MainActivity}" drawable="max" name="Max" />
   <item component="ComponentInfo{com.applications.max/com.landmarkgroup.landmarkshops.module.splash.activity.SplashActivityV2}" drawable="max_fashion" name="Max Fashion" />
@@ -5750,6 +5781,7 @@
   <item component="ComponentInfo{com.medisafe.android.client/com.medisafe.android.client.SplashActivity}" drawable="medisafe" name="Medisafe" />
   <item component="ComponentInfo{com.medisafe.android.client/com.medisafe.android.base.activities.initial.InitialActivity}" drawable="medisafe" name="Medisafe" />
   <item component="ComponentInfo{sh.ftp.rocketninelabs.meditationassistant.opensource/sh.ftp.rocketninelabs.meditationassistant.MainActivity}" drawable="meditation_assistant" name="Meditation Assistant" />
+  <item component="ComponentInfo{meditofoundation.medito/com.meditofoundation.medito.MainActivity}" drawable="medito" name="Medito" />
   <item component="ComponentInfo{meditofoundation.medito/com.ryanheise.audioservice.AudioServiceActivity}" drawable="medito" name="Medito" />
   <item component="ComponentInfo{meditofoundation.medito/meditofoundation.medito.MainActivity}" drawable="medito" name="Medito" />
   <item component="ComponentInfo{com.medium.reader/com.medium.android.donkey.launcher.LauncherActivity}" drawable="medium" name="Medium" />
@@ -5884,6 +5916,7 @@
   <item component="ComponentInfo{com.oculus.twilight/com.oculus.twilight.crossapp.activity.XOCMainActivity}" drawable="meta_quest" name="Meta Quest" />
   <item component="ComponentInfo{com.facebook.work/com.facebook.work.LaunchActivity}" drawable="meta_workplace" name="Meta Workplace" />
   <item component="ComponentInfo{rocks.poopjournal.metadataremover/rocks.poopjournal.metadataremover.ui.MainActivity}" drawable="metadata_remover" name="Metadata Remover" />
+  <item component="ComponentInfo{io.metamask/com.google.android.archive.ReactivateActivity}" drawable="metamask" name="MetaMask" />
   <item component="ComponentInfo{io.metamask/io.metamask.MainActivity}" drawable="metamask" name="MetaMask" />
   <item component="ComponentInfo{pt.ipma.meteo/pt.ipma.meteo.StartActivity}" drawable="meteoipma" name="Meteo@IPMA" />
   <item component="ComponentInfo{pt.ipma.meteo/pt.ipma.meteo.activities.splashscreen.SplashActivity}" drawable="meteoipma" name="Meteo@IPMA" />
@@ -5929,6 +5962,7 @@
   <item component="ComponentInfo{com.sunshine.freeform/com.sunshine.freeform.ui.splash.SplashActivity}" drawable="mi_freeform" name="Mi Freeform" />
   <item component="ComponentInfo{com.mi.health/com.xiaomi.fitness.login.SplashActivity}" drawable="mi_health" name="Mi Health" />
   <item component="ComponentInfo{com.mi.health/com.mi.health.home.HomeActivity}" drawable="mi_health" name="Mi Health" />
+  <item component="ComponentInfo{com.xiaomi.smarthome/com.google.android.archive.ReactivateActivity}" drawable="mi_home" name="Mi Home" />
   <item component="ComponentInfo{com.xiaomi.smarthome/com.xiaomi.smarthome.StartupActivity}" drawable="mi_home" name="Mi Home" />
   <item component="ComponentInfo{com.xiaomi.smarthome/com.xiaomi.smarthome.SmartHomeMainActivity}" drawable="mi_home" name="Mi Home" />
   <item component="ComponentInfo{com.miui.huanji/com.miui.huanji.MainActivity}" drawable="mi_mover" name="Mi Mover" />
@@ -5979,6 +6013,7 @@
   <item component="ComponentInfo{com.ms.office365admin/com.ms.office365admin.SplashScreen}" drawable="microsoft_365_admin" name="Microsoft 365 Admin" />
   <item component="ComponentInfo{com.azure.authenticator/com.azure.authenticator.ui.LaunchActivity}" drawable="microsoft_authenticator" name="Microsoft Authenticator" />
   <item component="ComponentInfo{com.azure.authenticator/com.azure.authenticator.ui.MainActivity}" drawable="microsoft_authenticator" name="Microsoft Authenticator" />
+  <item component="ComponentInfo{com.microsoft.copilot/com.google.android.archive.ReactivateActivity}" drawable="microsoft_copilot" name="Microsoft Copilot" />
   <item component="ComponentInfo{com.microsoft.copilot/com.microsoft.sapphire.app.main.SapphireMainActivity}" drawable="microsoft_copilot" name="Microsoft Copilot" />
   <item component="ComponentInfo{com.microsoft.copilot/com.microsoft.shappire.app.main.ShappireMainActivity}" drawable="microsoft_copilot" name="Microsoft Copilot" />
   <item component="ComponentInfo{com.microsoft.scmx/com.microsoft.defender.ux.activity.MDMainActivity}" drawable="microsoft_defender" name="Microsoft Defender" />
@@ -6030,6 +6065,7 @@
   <item component="ComponentInfo{com.touchtype.swiftkey/com.touchtype.LauncherActivity}" drawable="microsoft_swiftkey_keyboard" name="Microsoft SwiftKey Keyboard" />
   <item component="ComponentInfo{com.touchtype.swiftkey/com.touchtype.LauncherActivity-Icon}" drawable="microsoft_swiftkey_keyboard" name="Microsoft SwiftKey Keyboard" />
   <item component="ComponentInfo{com.touchtype.swiftkey/com.touchtype.LauncherActivityIcon}" drawable="microsoft_swiftkey_keyboard" name="Microsoft SwiftKey Keyboard" />
+  <item component="ComponentInfo{com.microsoft.teams/com.google.android.archive.ReactivateActivity}" drawable="microsoft_teams" name="Microsoft Teams" />
   <item component="ComponentInfo{com.microsoft.teams/com.microsoft.skype.teams.Launcher}" drawable="microsoft_teams" name="Microsoft Teams" />
   <item component="ComponentInfo{com.microsoft.todos/com.microsoft.todoss}" drawable="microsoft_todo" name="Microsoft To Do" />
   <item component="ComponentInfo{com.microsoft.todos/com.microsoft.todos.ui.LaunchActivity}" drawable="microsoft_todo" name="Microsoft To Do" />
@@ -6348,6 +6384,7 @@
   <item component="ComponentInfo{in.krosbits.musicolet/in.krosbits.musicolet.MusicActivity}" drawable="musicolet_music_player" name="Musicolet Music Player" />
   <item component="ComponentInfo{com.gokadzev.musify.fdroid/com.ryanheise.audioservice.AudioServiceActivity}" drawable="musify" name="Musify" />
   <item component="ComponentInfo{com.gokadzev.musify/com.ryanheise.audioservice.AudioServiceActivity}" drawable="musify" name="Musify" />
+  <item component="ComponentInfo{com.musixmatch.android.lyrify/com.google.android.archive.ReactivateActivity}" drawable="musixmatch" name="Musixmatch" />
   <item component="ComponentInfo{com.musixmatch.android.lyrify/com.musixmatch.android.presentation.activities.SplashActivity}" drawable="musixmatch" name="Musixmatch" />
   <item component="ComponentInfo{com.musixmatch.android.lyrify/com.designfuture.music.ui.phone.DashBoardActivity}" drawable="musixmatch" name="Musixmatch" />
   <item component="ComponentInfo{com.musixmatch.android.lyrify/com.musixmatch.android.ui.phone.DashBoardActivity}" drawable="musixmatch" name="Musixmatch" />
@@ -6944,6 +6981,7 @@
   <item component="ComponentInfo{com.js.nowakelock/com.js.nowakelock.ui.mainActivity.MainActivity}" drawable="nowakelock" name="NoWakeLock" />
   <item component="ComponentInfo{com.wn.app.np/player.normal.np.activity.NPMainActivity}" drawable="np_manager" name="NP Manager" />
   <item component="ComponentInfo{com.wn.app.np/player.normal.np.activity.GuideActivity}" drawable="np_manager" name="NP Manager" />
+  <item component="ComponentInfo{no.nordicsemi.android.mcp/com.google.android.archive.ReactivateActivity}" drawable="nrf_connect" name="nRF Connect" />
   <item component="ComponentInfo{no.nordicsemi.android.mcp/no.nordicsemi.android.mcp.DeviceListActivity}" drawable="nrf_connect" name="nRF Connect" />
   <item component="ComponentInfo{no.nordicsemi.android.mcp/no.nordicsemi.android.mcp.MainActivity}" drawable="nrf_connect" name="nRF Connect" />
   <item component="ComponentInfo{nl.ns.android.activity/nl.ns.android.activity.homepagina.HomePaginaActivity}" drawable="ns" name="NS" />
@@ -7128,6 +7166,7 @@
   <item component="ComponentInfo{mobisocial.arcade/mobisocial.arcade.sdk.activity.ArcadeSignInActivity}" drawable="omlet_arcade" name="Omlet Arcade" />
   <item component="ComponentInfo{mobisocial.arcade/mobisocial.arcade.DEFAULT}" drawable="omlet_arcade" name="Omlet Arcade" />
   <item component="ComponentInfo{uk.akane.omni/uk.akane.omni.ui.MainActivity}" drawable="omni" name="Omni" />
+  <item component="ComponentInfo{app.omnivore.omnivore/com.google.android.archive.ReactivateActivity}" drawable="omnivore" name="Omnivore" />
   <item component="ComponentInfo{app.omnivore.omnivore/app.omnivore.omnivore.MainActivity}" drawable="omnivore" name="Omnivore" />
   <item component="ComponentInfo{com.igloocreations.ondago/com.mapgears.ondago.application.StartupActivity}" drawable="ondago" name="Ondago" />
   <item component="ComponentInfo{rk.android.app.lockscreen/rk.android.app.lockscreen.activity.HomeActivity}" drawable="one_click_lock_screen" name="One Click Lock Screen" />
@@ -7457,6 +7496,7 @@
   <item component="ComponentInfo{com.ultraandre.pccreator2/com.google.firebase.MessagingUnityPlayerActivity}" drawable="pc_creator_2" name="PC Creator 2" />
   <item component="ComponentInfo{com.monect.portable/com.monect.core.ui.main.MainActivity}" drawable="pc_remote" name="PC Remote" />
   <item component="ComponentInfo{com.monect.portable/com.monect.core.ui.main.ComMainActivity}" drawable="pc_remote" name="PC Remote" />
+  <item component="ComponentInfo{com.emanuelef.remote_capture/com.google.android.archive.ReactivateActivity}" drawable="pcapdroid" name="PCAPdroid" />
   <item component="ComponentInfo{com.pcapdroid.mitm/com.pcapdroid.mitm.MainActivity}" drawable="pcapdroid" name="PCAPdroid" />
   <item component="ComponentInfo{com.emanuelef.remote_capture/com.emanuelef.remote_capture.activities.MainActivity}" drawable="pcapdroid" name="PCAPdroid" />
   <item component="ComponentInfo{com.pcloud.pcloud/com.pcloud.screens.Main}" drawable="pcloud" name="pCloud" />
@@ -7744,6 +7784,7 @@
   <item component="ComponentInfo{com.adobe.psmobile/com.adobe.psmobile.SplashScreen}" drawable="photoshop_express" name="Photoshop Express" />
   <item component="ComponentInfo{com.vyroai.photoeditorone/com.vyroai.photoeditorone.ui.MainActivity}" drawable="photoshot" name="PhotoShot" />
   <item component="ComponentInfo{com.vyroai.photoenhancer/com.vyroai.facefix.ui.MainActivity}" drawable="phototune" name="PhotoTune" />
+  <item component="ComponentInfo{de.rwth_aachen.phyphox/com.google.android.archive.ReactivateActivity}" drawable="phyphox" name="phyphox" />
   <item component="ComponentInfo{de.rwth_aachen.phyphox/de.rwth_aachen.phyphox.ExperimentList}" drawable="phyphox" name="phyphox" />
   <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.SplashActivityAliasVariant3}" drawable="physics_wallah" name="Physics Wallah (PW)" />
   <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.SplashActivityAliasNormal}" drawable="physics_wallah" name="Physics Wallah (PW)" />
@@ -7906,6 +7947,7 @@
   <item component="ComponentInfo{com.freevpnplanet/com.freevpnplanet.presentation.splash.view.SplashActivity}" drawable="planet_vpn" name="Planet VPN" />
   <item component="ComponentInfo{com.planitypublic/com.planitypublic.MainActivity}" drawable="planity" name="Planity" />
   <item component="ComponentInfo{de.dsvgruppe.pba/de.dsvgruppe.pba.SplashScreenActivity}" drawable="stock_market_learning" name="Planspiel Börse ~~ Stock Market Learning" />
+  <item component="ComponentInfo{org.plantnet/com.google.android.archive.ReactivateActivity}" drawable="plantnet" name="PlantNet" />
   <item component="ComponentInfo{org.plantnet/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="plantnet" name="PlantNet" />
   <item component="ComponentInfo{org.plantnet/org.plantnet.MainActivity}" drawable="plantnet" name="PlantNet" />
   <item component="ComponentInfo{com.ea.game.pvz2_row/com.popcap.PvZ2.PvZ2GameActivity}" drawable="plants_vs_zombies_2" name="Plants vs Zombies 2" />
@@ -8100,6 +8142,7 @@
   <item component="ComponentInfo{io.github.krlvm.powertunnel.android/io.github.krlvm.powertunnel.android.activities.SplashActivity}" drawable="powertunnel" name="PowerTunnel" />
   <item component="ComponentInfo{io.github.krlvm.powertunnel.android/io.github.krlvm.powertunnel.android.activities.MainActivity}" drawable="powertunnel" name="PowerTunnel" />
   <item component="ComponentInfo{bos.consoar.imagestitch/bos.consoar.imagestitch.ui.MainActivity}" drawable="ppiicc" name="PPIICC" />
+  <item component="ComponentInfo{org.ppsspp.ppsspp/com.google.android.archive.ReactivateActivity}" drawable="ppsspp" name="PPSSPP" />
   <item component="ComponentInfo{org.ppsspp.ppsspp/org.ppsspp.ppsspp.PpssppActivity}" drawable="ppsspp" name="PPSSPP" />
   <item component="ComponentInfo{org.ppsspp.ppssppgold/org.ppsspp.ppssppgold.PpssppActivity}" drawable="ppsspp" name="PPSSPP Gold" />
   <item component="ComponentInfo{org.ppsspp.ppssppgold/org.ppsspp.ppsspp.PpssppActivity}" drawable="ppsspp" name="PPSSPP Gold" />
@@ -8312,6 +8355,7 @@
   <item component="ComponentInfo{com.andi.alquran.urdu/com.andi.alquran.ActivityHome}" drawable="quran" name="Quran Urdu" />
   <item component="ComponentInfo{mwg.tgdd.loyalty/mwg.tgdd.loyalty.MainActivity}" drawable="qua_tang_vip" name="Quà Tặng VIP ~~ Qua Tang VIP" />
   <item component="ComponentInfo{ca.qc.gouv.mtq.Quebec511/crc646174e497c870c4a0.MainActivity}" drawable="quebec_511" name="Québec 511 ~~ Quebec 511 " />
+  <item component="ComponentInfo{com.debank.rabbymobile/com.google.android.archive.ReactivateActivity}" drawable="rabby_wallet" name="Rabby Wallet" />
   <item component="ComponentInfo{com.debank.rabbymobile/com.debank.rabbymobile.MainActivity}" drawable="rabby_wallet" name="Rabby Wallet" />
   <item component="ComponentInfo{nl.rabowallet/com.gieseckedevrient.convego.ui.MainActivity}" drawable="rabo_wallet" name="Rabo Wallet" />
   <item component="ComponentInfo{nl.rabomobiel/nl.rabobank.bankierenplus.URActivity}" drawable="rabobank" name="Rabobank" />
@@ -8666,6 +8710,7 @@
   <item component="ComponentInfo{com.testbook.tbapp.rrbjeme/com.testbook.tbapp.android.SplashActivity}" drawable="testbook" name="RRB JE ME" />
   <item component="ComponentInfo{de.rtli.tvnow/de.rtl.plus.RtlPlusLauncherActivity}" drawable="rtl" name="RTL+" />
   <item component="ComponentInfo{de.rtli.tvnow/de.rtli.everest.activity.SplashActivity}" drawable="rtl" name="RTL+" />
+  <item component="ComponentInfo{fr.ecp.ruler.app/com.google.android.archive.ReactivateActivity}" drawable="ruler" name="Ruler" />
   <item component="ComponentInfo{fr.ecp.ruler.app/com.xalphalab.rulerlib.MainActivity}" drawable="ruler" name="Ruler" />
   <item component="ComponentInfo{org.nixgame.ruler/org.nixgame.ruler.ActivityRuler}" drawable="ruler" name="Ruler" />
   <item component="ComponentInfo{net.kosev.rulering/net.kosev.rulering.MainActivity}" drawable="ruler_app" name="Ruler App: Measure centimeters" />
@@ -9597,6 +9642,7 @@
   <item component="ComponentInfo{felixwiemuth.simplereminder/felixwiemuth.simplereminder.ui.reminderslist.RemindersListActivity}" drawable="simplereminder" name="SimpleReminder" />
   <item component="ComponentInfo{com.thewizrd.simplewear/com.thewizrd.simplewear.MainActivity}" drawable="simplewear" name="SimpleWear" />
   <item component="ComponentInfo{com.thewizrd.wearsettings/com.thewizrd.wearsettings.LauncherActivity}" drawable="simplewear_settings" name="SimpleWear Settings" />
+  <item component="ComponentInfo{chat.simplex.app/com.google.android.archive.ReactivateActivity}" drawable="simplex" name="SimpleX" />
   <item component="ComponentInfo{chat.simplex.app/chat.simplex.app.MainActivity_dark_blue}" drawable="simplex" name="SimpleX" />
   <item component="ComponentInfo{chat.simplex.app/chat.simplex.app.MainActivity_default}" drawable="simplex" name="SimpleX" />
   <item component="ComponentInfo{com.pcfinancial.mobile/com.cibc.base.android.mobi.activity.MainActivity}" drawable="simplii" name="Simplii" />
@@ -9771,6 +9817,7 @@
   <item component="ComponentInfo{com.snapchat.android/.LandingPageActivity}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivity}" drawable="snapdeal" name="Snapdeal" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivityDefault}" drawable="snapdeal" name="Snapdeal" />
+  <item component="ComponentInfo{com.fmsys.snapdrop/com.google.android.archive.ReactivateActivity}" drawable="snapdrop" name="Snapdrop" />
   <item component="ComponentInfo{net.snapdrop/net.snapdrop.MainActivity}" drawable="snapdrop" name="Snapdrop" />
   <item component="ComponentInfo{com.fmsys.snapdrop/com.fmsys.snapdrop.MainActivity}" drawable="snapdrop" name="Snapdrop" />
   <item component="ComponentInfo{snapedit.app.remove/com.stub.stub01.StartActivity}" drawable="snapedit" name="SnapEdit" />
@@ -9875,6 +9922,7 @@
   <item component="ComponentInfo{com.soundcloud.android/com.soundcloud.android.launcher.LauncherActivity}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.soundcloud.android/com.soundcloud.android.main.LauncherActivity}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.soundcloud.android/com.soundcloud.android.main.MainActivity}" drawable="soundcloud" name="SoundCloud" />
+  <item component="ComponentInfo{com.oceanwing.soundcore/com.google.android.archive.ReactivateActivity}" drawable="soundcore" name="Soundcore" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.oceanwing.soundcore.activity.SelectCategoryNewActivity}" drawable="soundcore" name="Soundcore" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.oceanwing.soundcore.activity.WelcomeActivity}" drawable="soundcore" name="Soundcore" />
   <item component="ComponentInfo{com.melodis.midomiMusicIdentifier.freemium/com.melodis.midomiMusicIdentifier.appcommon.activity.SplashScreenActivity}" drawable="soundhound" name="SoundHound" />
@@ -9918,6 +9966,7 @@
   <item component="ComponentInfo{org.zwanoo.android.speedtest/com.ookla.speedtest.softfacade.MainActivity}" drawable="speedtest_by_ookla" name="Speedtest by Ookla" />
   <item component="ComponentInfo{org.zwanoo.android.speedtest/org.zwanoo.android.speedtest.MainTabActivity}" drawable="speedtest_by_ookla" name="Speedtest by Ookla" />
   <item component="ComponentInfo{com.delsorboilario.dnd/com.delsorboilario.dnd.MainActivity}" drawable="spells_list_5e" name="Spells List 5e" />
+  <item component="ComponentInfo{com.henrikherzig.playintegritychecker/com.google.android.archive.ReactivateActivity}" drawable="spic" name="SPIC" />
   <item component="ComponentInfo{com.henrikherzig.playintegritychecker/com.henrikherzig.playintegritychecker.MainActivity}" drawable="spic" name="SPIC" />
   <item component="ComponentInfo{com.pingapp.app/com.pingapp.app.SpikeActivity}" drawable="spike" name="Spike" />
   <item component="ComponentInfo{com.spinthewheeldecider/com.spinthewheeldecider.MainActivity}" drawable="spin_the_wheel" name="Spin The Wheel" />
@@ -10147,6 +10196,7 @@
   <item component="ComponentInfo{com.oray.sunlogin/com.oray.sunlogin.application.Main}" drawable="sunlogin" name="Sunlogin" />
   <item component="ComponentInfo{com.lgi.upcch/com.libertyglobal.horizonx.MainActivity}" drawable="sunrise_tv" name="Sunrise TV" />
   <item component="ComponentInfo{au.org.cancervic.globaluv/au.org.cancervic.globaluv.MainActivity}" drawable="sunsmart" name="SunSmart" />
+  <item component="ComponentInfo{com.forrestguice.suntimeswidget/com.forrestguice.suntimeswidget.SuntimesLaunchActivity}" drawable="suntimes" name="Suntimes" />
   <item component="ComponentInfo{com.forrestguice.suntimeswidget/com.forrestguice.suntimeswidget.alarmclock.ui.AlarmClockActivityLauncher}" drawable="suntimes" name="Suntimes" />
   <item component="ComponentInfo{com.forrestguice.suntimeswidget/com.forrestguice.suntimeswidget.SuntimesActivity}" drawable="suntimes" name="Suntimes" />
   <item component="ComponentInfo{com.forrestguice.suntimescalendars/com.forrestguice.suntimeswidget.calendar.SuntimesCalendarActivity}" drawable="suntimes_calendars" name="Suntimes Calendars" />
@@ -10188,6 +10238,7 @@
   <item component="ComponentInfo{dev.suyu.suyu_emu.relWithDebInfo/dev.suyu.suyu_emu.ui.main.MainActivity}" drawable="suyu" name="Suyu Debug" />
   <item component="ComponentInfo{dev.suyu.suyu_emu/dev.suyu.suyu_emu.ui.main.MainActivity}" drawable="suyu" name="Suyu Dev" />
   <item component="ComponentInfo{com.msil.suzukiconnect_generation_2/com.msil.suzukiconnect_generation_2.ui_modules.splash.ui.SplashActivity}" drawable="suzuki_connect" name="Suzuki Connect" />
+  <item component="ComponentInfo{com.svpteam.svp/com.google.android.archive.ReactivateActivity}" drawable="svplayer" name="SVPlayer" />
   <item component="ComponentInfo{com.svpteam.svp/com.svpteam.SVPActivity}" drawable="svplayer" name="SVPlayer" />
   <item component="ComponentInfo{com.sweatwallet/com.sweatwallet.MainActivity}" drawable="sweat_wallet" name="Sweat Wallet" />
   <item component="ComponentInfo{in.sweatco.app/com.app.sweatcoin.ui.activities.RootActivity}" drawable="sweatcoin" name="Sweatcoin" />
@@ -10199,6 +10250,7 @@
   <item component="ComponentInfo{in.swiggy.android/in.swiggy.android.activities.HomeActivity}" drawable="swiggy" name="Swiggy" />
   <item component="ComponentInfo{in.swiggy.android/in.swiggy.android.activities.HomeActivityNewYear}" drawable="swiggy" name="Swiggy" />
   <item component="ComponentInfo{in.swiggy.android/in.swiggy.android.activities.SplashActivity}" drawable="swiggy" name="Swiggy" />
+  <item component="ComponentInfo{app.swipefy.mobile/com.google.android.archive.ReactivateActivity}" drawable="swipefy" name="Swipefy" />
   <item component="ComponentInfo{app.swipefy.mobile/app.swipefy.mobile.MainActivity}" drawable="swipefy" name="Swipefy" />
   <item component="ComponentInfo{se.bankgirot.swish/se.bankgirot.swish.ui.SplashActivity}" drawable="swish" name="Swish" />
   <item component="ComponentInfo{com.yoc.swiss.swiss/com.lhgroup.lhgroupapp.MainActivity}" drawable="swiss" name="SWISS" />
@@ -10467,6 +10519,7 @@
   <item component="ComponentInfo{com.dubox.drive/com.dubox.drive.ui.Logo0LauncherActivity}" drawable="terabox" name="TeraBox" />
   <item component="ComponentInfo{com.dubox.drive/com.dubox.drive.ui.Navigate}" drawable="terabox" name="TeraBox" />
   <item component="ComponentInfo{jackpal.androidterm/jackpal.androidterm.Term}" drawable="terminal_emulator" name="Terminal Emulator" />
+  <item component="ComponentInfo{com.server.auditor.ssh.client/com.google.android.archive.ReactivateActivity}" drawable="termius" name="Termius" />
   <item component="ComponentInfo{com.server.auditor.ssh.client/com.server.auditor.ssh.client.navigation.SshNavigationDrawerActivity}" drawable="termius" name="Termius" />
   <item component="ComponentInfo{com.server.auditor.ssh.client/com.server.auditor.ssh.client.navigation.SplashScreenActivity}" drawable="termius" name="Termius" />
   <item component="ComponentInfo{com.termoneplus/com.termoneplus.TermActivity}" drawable="termone_plus" name="TermOne Plus" />
@@ -10890,6 +10943,7 @@
   <item component="ComponentInfo{io.mrarm.mctoolbox/io.mrarm.mctoolbox.ToolboxActivity}" drawable="toolbox_for_minecraft_pe" name="Toolbox for Minecraft: PE" />
   <item component="ComponentInfo{io.mrarm.mctoolbox/io.mrarm.mctoolbox.MainActivity}" drawable="toolbox_for_minecraft_pe" name="Toolbox for Minecraft: PE" />
   <item component="ComponentInfo{io.mrarm.mctoolbox/io.mrarm.mctoolbox.MinecraftActivity}" drawable="toolbox_for_minecraft_pe" name="Toolbox for Minecraft: PE" />
+  <item component="ComponentInfo{com.yousx.thetoolsapp/com.google.android.archive.ReactivateActivity}" drawable="tooly" name="Tooly" />
   <item component="ComponentInfo{com.yousx.thetoolsapp/com.yousx.thetoolsapp.SplashScreenActivity}" drawable="tooly" name="Tooly" />
   <item component="ComponentInfo{br.com.autopass.top/br.com.autopass.top.MainActivity}" drawable="top" name="TOP" />
   <item component="ComponentInfo{com.tophat.android.app/com.tophat.android.app.login.splash.SplashScreenActivity}" drawable="top_hat" name="Top Hat" />
@@ -10987,6 +11041,7 @@
   <item component="ComponentInfo{tk.hack5.treblecheck/tk.hack5.treblecheck.ui.MainActivity}" drawable="treble_info" name="Treble Info" />
   <item component="ComponentInfo{com.genonbeta.TrebleShot/com.genonbeta.TrebleShot.activity.HomeActivity}" drawable="trebleshot" name="TrebleShot" />
   <item component="ComponentInfo{com.genonbeta.TrebleShot/org.monora.uprotocol.client.android.activity.HomeActivity}" drawable="trebleshot" name="TrebleShot" />
+  <item component="ComponentInfo{com.trello/com.google.android.archive.ReactivateActivity}" drawable="trello" name="Trello" />
   <item component="ComponentInfo{com.trello/com.trello.authentication.AuthLoginActivity}" drawable="trello" name="Trello" />
   <item component="ComponentInfo{com.trello/com.trello.home.HomeActivity}" drawable="trello" name="Trello" />
   <item component="ComponentInfo{org.equeim.tremotesf/org.equeim.tremotesf.mainactivity.MainActivity}" drawable="tremotesf" name="Tremotesf" />
@@ -10998,6 +11053,7 @@
   <item component="ComponentInfo{com.lynxspa.prontotreno/com.ibm.android.states.startup.StartUpActivity}" drawable="trenitalia" name="Trenitalia" />
   <item component="ComponentInfo{com.lynxspa.prontotreno/com.ibm.android.states.main.MainActivity}" drawable="trenitalia" name="Trenitalia" />
   <item component="ComponentInfo{com.tresorit.mobile/com.tresorit.android.activity.RootTresoritActivity}" drawable="tresorit" name="Tresorit" />
+  <item component="ComponentInfo{com.tribab.tricount.android/com.bunq.tricount.android.ui.activity.LoadingTricountStartupInfoActivity}" drawable="tricount" name="Tricount" />
   <item component="ComponentInfo{com.tribab.tricount.android/com.tribab.tricount.android.view.activity.SplashActivity}" drawable="tricount" name="Tricount" />
   <item component="ComponentInfo{com.errorsevendev.games.trikky/com.unity3d.player.UnityPlayerActivity}" drawable="trikky" name="Trikky" />
   <item component="ComponentInfo{com.osfans.trime/com.osfans.trime.PrefLauncherAlias}" drawable="trime" name="Trime" />
@@ -11113,6 +11169,7 @@
   <item component="ComponentInfo{com.perflyst.twire/com.perflyst.twire.activities.StartUpActivity}" drawable="twire" name="Twire" />
   <item component="ComponentInfo{com.sidefeed.TCViewer/st.moi.tcviewer.presentation.home.HomeActivity}" drawable="twitcast" name="Twitcast" />
   <item component="ComponentInfo{com.sidefeed.TCViewer/st.moi.tcviewer.presentation.launcher.LauncherActivity}" drawable="twitcast" name="Twitcast" />
+  <item component="ComponentInfo{tv.twitch.android.app/com.google.android.archive.ReactivateActivity}" drawable="twitch" name="Twitch" />
   <item component="ComponentInfo{tv.twitch.android.app/tv.twitch.starshot64.app.StarshotActivity}" drawable="twitch" name="Twitch" />
   <item component="ComponentInfo{tv.twitch.android.app/tv.twitch.android.app.core.LandingActivity}" drawable="twitch" name="Twitch" />
   <item component="ComponentInfo{tv.twitch.android.app/tv.twitch.android.apps.LandingActivity}" drawable="twitch" name="Twitch" />
@@ -11294,6 +11351,7 @@
   <item component="ComponentInfo{cloud.valetudo.companion/cloud.valetudo.companion.MainActivity}" drawable="valetudo" name="Valetudo Companion" />
   <item component="ComponentInfo{ch.vab.twint/ch.twint.payment.ui.activities.start.StartActivity}" drawable="valiant_twint" name="Valiant TWINT" />
   <item component="ComponentInfo{se.arctosoft.vault/se.arctosoft.vault.LaunchActivity}" drawable="valv" name="Valv" />
+  <item component="ComponentInfo{com.poncle.vampiresurvivors/com.google.android.archive.ReactivateActivity}" drawable="vampire_survivors" name="Vampire Survivors" />
   <item component="ComponentInfo{com.poncle.vampiresurvivors/com.unity3d.player.UnityPlayerActivity}" drawable="vampire_survivors" name="Vampire Survivors" />
   <item component="ComponentInfo{app.vanadium.browser/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Vanadium" />
   <item component="ComponentInfo{com.vanced.manager/com.vanced.manager.ui.core.SplashScreenActivity}" drawable="vanced_manager" name="Vanced Manager" />
@@ -11468,6 +11526,7 @@
   <item component="ComponentInfo{com.vivaldi.browser/com.google.android.apps.chrome.Main}" drawable="vivaldi" name="Vivaldi" />
   <item component="ComponentInfo{com.vivaldi.browser.snapshot/com.google.android.apps.chrome.Main}" drawable="vivaldi" name="Vivaldi Browser Snapshot" />
   <item component="ComponentInfo{com.quvideo.xiaoying/com.quvideo.xiaoying.app.splash.SplashActivity}" drawable="vivavideo" name="VivaVideo" />
+  <item component="ComponentInfo{vivino.web.app/com.google.android.archive.ReactivateActivity}" drawable="vivino" name="Vivino" />
   <item component="ComponentInfo{vivino.web.app/com.sphinx_solution.Launcher}" drawable="vivino" name="Vivino" />
   <item component="ComponentInfo{br.com.vivo/br.com.vivo.MainActivity}" drawable="vivo" name="vivo" />
   <item component="ComponentInfo{com.bbk.appstore/com.bbk.appstore.ui.AppStore}" drawable="vivo_app_store" name="vivo App Store" />
@@ -11508,6 +11567,8 @@
   <item component="ComponentInfo{de.ph1b.audiobook/de.ph1b.audiobook.features.coldStart.SplashActivity}" drawable="voice" name="Voice" />
   <item component="ComponentInfo{de.ph1b.audiobook/de.ph1b.audiobook.features.MainActivity}" drawable="voice" name="Voice" />
   <item component="ComponentInfo{de.ph1b.audiobook/voice.app.features.MainActivity}" drawable="voice" name="Voice" />
+  <item component="ComponentInfo{com.google.android.apps.accessibility.voiceaccess/com.google.android.apps.accessibility.voiceaccess.activities.Launchapp.pixel_Jauncher}" drawable="voice_access" name="Voice Access" />
+  <item component="ComponentInfo{com.google.android.apps.accessibility.voiceaccess/com.google.android.apps.accessibility.voiceaccess.LauncherActivity}" drawable="voice_access" name="Voice Access" />
   <item component="ComponentInfo{com.google.android.apps.accessibility.voiceaccess/com.google.android.apps.accessibility.voiceaccess.activities.LaunchActivity}" drawable="voice_access" name="Voice Access" />
   <item component="ComponentInfo{com.baviux.voicechanger/com.baviux.voicechanger.activities.MainActivity}" drawable="voice_changer_with_effects" name="Voice changer with effects" />
   <item component="ComponentInfo{com.first75.voicerecorder2/com.first75.voicerecorder2.ui.MainActivity}" drawable="recorder" name="Voice Recorder" />
@@ -11616,6 +11677,7 @@
   <item component="ComponentInfo{com.alaory.wallmewallpaper/com.alaory.wallmewallpaper.MainActivity}" drawable="wallme" name="Wallme" />
   <item component="ComponentInfo{io.otim.wallow/io.otim.wallow.MainActivity}" drawable="wallow" name="Wallow" />
   <item component="ComponentInfo{de.j4velin.wallpaperChanger/de.j4velin.wallpaperChanger.settings.Settings}" drawable="wallpaper_changer" name="Wallpaper Changer" />
+  <item component="ComponentInfo{io.wallpaperengine.weclient/com.google.android.archive.ReactivateActivity}" drawable="wallpaper_engine" name="Wallpaper Engine" />
   <item component="ComponentInfo{io.wallpaperengine.weclient/io.wallpaperengine.weclient.BrowseActivity}" drawable="wallpaper_engine" name="Wallpaper Engine" />
   <item component="ComponentInfo{com.github.cvzi.wallpaperexport/com.github.cvzi.wallpaperexport.MainActivity}" drawable="wallpaperexport" name="WallpaperExport" />
   <item component="ComponentInfo{com.google.android.apps.wallpapers/com.google.android.apps.wallpaper.picker.CategoryPickerActivity}" drawable="wallpapers" name="Wallpapers" />
@@ -11927,6 +11989,7 @@
   <item component="ComponentInfo{com.contextlogic.wish/com.contextlogic.wish.activity.browse.BrowseActivity}" drawable="wish" name="Wish" />
   <item component="ComponentInfo{com.wishexplorer/com.wishexplorer.MainActivity}" drawable="wish_explorer" name="Wish Explorer" />
   <item component="ComponentInfo{com.withings.wiscale2/com.withings.wiscale2.MainActivity}" drawable="withings_health_mate" name="Withings Health Mate" />
+  <item component="ComponentInfo{com.wix.admin/com.google.android.archive.ReactivateActivity}" drawable="wix_owner" name="Wix Owner" />
   <item component="ComponentInfo{com.wix.admin/com.wix.MainActivity}" drawable="wix_owner" name="Wix Owner" />
   <item component="ComponentInfo{com.tao.wiz/com.tao.wiz.front.activities.splashscreen.SplashScreenActivity}" drawable="wiz" name="WiZ" />
   <item component="ComponentInfo{com.wizconnected.wiz2/com.wizconnected.wiz_v2.MainActivity}" drawable="wiz" name="WiZ Connected" />
@@ -11989,6 +12052,7 @@
   <item component="ComponentInfo{com.wtmp.svdsoftware/com.wtmp.svdsoftware.HomeActivity}" drawable="wtmp" name="WTMP — Who touched my phone?" />
   <item component="ComponentInfo{io.github.wulkanowy/io.github.wulkanowy.ui.modules.splash.SplashActivity}" drawable="wulkanowy_dzienniczek" name="Wulkanowy Dzienniczek" />
   <item component="ComponentInfo{com.hf.findlostdevice/com.hf.findlostdevice.DeviceListActivity}" drawable="wunderfind" name="Wunderfind" />
+  <item component="ComponentInfo{com.kurogame.wutheringwaves.global/com.wutheringwaves.russian.MainActivity}" drawable="wuthering_waves" name="Wuthering Waves" />
   <item component="ComponentInfo{com.kurogame.wutheringwaves.global/com.kurogame.wutheringwaves.global.KuroSplashActivity}" drawable="wuthering_waves" name="Wuthering Waves" />
   <item component="ComponentInfo{com.bsbportal.music/com.bsbportal.music.activities.LauncherScreenActivity}" drawable="wynk_music" name="Wynk Music" />
   <item component="ComponentInfo{com.bsbportal.music/com.bsbportal.music.v2.features.main.ui.HomeActivity}" drawable="wynk_music" name="Wynk Music" />
@@ -12197,6 +12261,7 @@
   <item component="ComponentInfo{com.sirma.mobile.bible.android/com.youversion.ui.MainActivity}" drawable="bible" name="YouVersion Bible" />
   <item component="ComponentInfo{com.sirma.mobile.bible.android/com.youversion.ui.SplashActivity}" drawable="bible" name="YouVersion Bible" />
   <item component="ComponentInfo{yo.app/yo.activity.MainActivity}" drawable="yowindow" name="YoWindow" />
+  <item component="ComponentInfo{no.nrk.yr/no.nrk.yr.SplashScreenActivity}" drawable="yr" name="Yr" />
   <item component="ComponentInfo{no.nrk.yr/no.nrk.yr.StartActivity}" drawable="yr" name="Yr" />
   <item component="ComponentInfo{no.nrk.yr/no.nrk.yr.activity.MainActivity}" drawable="yr" name="Yr" />
   <item component="ComponentInfo{com.deniscerri.ytdl/com.deniscerri.ytdl.DarkIcon}" drawable="ytdlnis" name="YTDLnis" />
@@ -12340,6 +12405,7 @@
   <item component="ComponentInfo{com.application.zomato/com.application.zomato.activities.Splash}" drawable="zomato" name="Zomato" />
   <item component="ComponentInfo{com.application.zomato/com.application.zomato.Splash}" drawable="zomato" name="Zomato" />
   <item component="ComponentInfo{mobi.zona/mobi.zona.ui.MainActivity}" drawable="zona" name="Zona" />
+  <item component="ComponentInfo{us.zoom.videomeetings/com.google.android.archive.ReactivateActivity}" drawable="zoom" name="Zoom" />
   <item component="ComponentInfo{us.zoom.videomeetings/com.zipow.videobox.LauncherActivity}" drawable="zoom" name="Zoom" />
   <item component="ComponentInfo{com.zoopla.activity/com.zoopla.activity.MainActivityDefault}" drawable="zoopla" name="Zoopla" />
   <item component="ComponentInfo{com.zoopla.activity/com.zoopla.activity.MainActivity}" drawable="zoopla" name="Zoopla" />
@@ -12381,6 +12447,7 @@
   <item component="ComponentInfo{ru.vkusvill/ru.vkusvill.ui.screens.splash.SplashActivityV1}" drawable="vkusvill" name="ВкусВилл ~~ VkusVill" />
   <item component="ComponentInfo{ru.vkusvill/ru.vkusvill.ui.screens.splash.SplashActivity}" drawable="vkusvill" name="ВкусВилл ~~ VkusVill" />
   <item component="ComponentInfo{com.apegroup.mcdonaldsrussia/com.apegroup.mcdonaldsrussia.activities.main.MainActivity}" drawable="tasty_period" name="Вкусно — и точка ~~ Tasty, period" />
+  <item component="ComponentInfo{ru.vtb24.mobilebanking.android/ru.vtb24.mobilebanking.android.gui.activity.LoadingScreenActivity}" drawable="vtb" name="ВТБ ~~ VTB" />
   <item component="ComponentInfo{ru.vtb24.mobilebanking.android/ru.vtb.feature.signup.impl.loading.presentation.view.LoadingScreenActivity}" drawable="vtb" name="ВТБ ~~ VTB" />
   <item component="ComponentInfo{com.vtosters.lite/com.vtosters.lite.id112}" drawable="vtosters_lite" name="ВТостерс Lite ~~ VTosters Lite" />
   <item component="ComponentInfo{com.vtosters.lite/com.vtosters.lite.id20}" drawable="vtosters_lite" name="ВТостерс Lite ~~ VTosters Lite" />


### PR DESCRIPTION
Fulfilling requests.
## Linked
AliExpress (`com.alibaba.aliexpresshd/com.google.android.archive.ReactivateActivity` → `aliexpress.svg`)
ChatGPT (`com.openai.chatgpt/com.google.android.archive.ReactivateActivity` → `chatgpt.svg`)
Coinbase Wallet (`org.toshi/com.google.android.archive.ReactivateActivity` → `coinbase_wallet.svg`)
DeepL (`com.deepl.mobiletranslator/com.google.android.archive.ReactivateActivity` → `deepl.svg`)
EasyPark (`net.easypark.android/com.google.android.archive.ReactivateActivity` → `easypark.svg`)
EX Kernel Manager (`flar2.exkernelmanager/com.google.android.archive.ReactivateActivity` → `ex_kernel_manager.svg`)
FinShell Pay (`com.finshell.fin/com.finshell.fin.activity.MainActivity` → `finshell_pay.svg`)
FinShell Pay (`com.finshell.fin/com.finshell.fin.activity.SplashActivity` → `finshell_pay.svg`)
FinShell Pay (`com.finshell.fin/com.finshell.fin.Default` → `finshell_pay.svg`)
FinShell Pay (`com.finshell.fin/com.finshell.fin.splash.SplashActivity` → `finshell_pay.svg`)
FreeTube (`io.freetubeapp.freetube/io.freetubeapp.freetube` → `freetube.svg`)
Google Chat (`com.google.android.apps.dynamite/com.google.android.archive.ReactivateActivity` → `google_chat.svg`)
Google Home (`com.google.android.apps.chromecast.app/com.google.android.archive.ReactivateActivity` → `google_home.svg`)
Google Meet (`com.google.android.apps.tachyon/com.google.android.archive.ReactivateActivity` → `google_meet.svg`)
Google News (`com.google.android.apps.magazines/com.google.android.archive.ReactivateActivity` → `google_news.svg`)
Google Play Books (`com.google.android.apps.books/com.google.android.archive.ReactivateActivity` → `google_play_books.svg`)
Google Slides (`com.google.android.apps.docs.editors.slides/com.google.android.archive.ReactivateActivity` → `google_slides.svg`)
Google Tasks (`com.google.android.apps.tasks/com.google.android.archive.ReactivateActivity` → `google_tasks.svg`)
Google TV (`com.google.android.videos/com.google.android.archive.ReactivateActivity` → `google_tv.svg`)
HiPER Scientific Calculator (`cz.hipercalc/com.google.android.archive.ReactivateActivity` → `hiper_scientific_calculator.svg`)
IFTTT (`com.ifttt.ifttt/com.google.android.archive.ReactivateActivity` → `ifttt.svg`)
IKEA (`com.ingka.ikea.app/com.google.android.archive.ReactivateActivity` → `ikea.svg`)
Instabox (`io.instabox.consumer/com.google.android.archive.ReactivateActivity` → `instabox.svg`)
Jupiter (`money.jupiter/money.jupiter.MainActivity` → `jupiter.svg`)
Kahoot (`no.mobitroll.kahoot.android/com.google.android.archive.ReactivateActivity` → `kahoot.svg`)
Kate Mobile (`com.perm.kate_new_6/com.perm.kate.InitialActivity` → `kate_mobile.svg`)
Kivra (`com.kivra.Kivra/com.kivra.android.main.HomeActivity` → `kivra.svg`)
Klarna (`com.myklarnamobile/com.google.android.archive.ReactivateActivity` → `klarna.svg`)
Letterboxd (`com.letterboxd.letterboxd/com.google.android.archive.ReactivateActivity` → `letterboxd.svg`)
LibreTorrent (`org.proninyaroslav.libretorrent/com.google.android.archive.ReactivateActivity` → `libretorrent.svg`)
Max (`se.max.android.locator/com.google.android.archive.ReactivateActivity` → `max.svg`)
Medito (`meditofoundation.medito/com.meditofoundation.medito.MainActivity` → `medito.svg`)
MetaMask (`io.metamask/com.google.android.archive.ReactivateActivity` → `metamask.svg`)
Mi Home (`com.xiaomi.smarthome/com.google.android.archive.ReactivateActivity` → `mi_home.svg`)
Microsoft Copilot (`com.microsoft.copilot/com.google.android.archive.ReactivateActivity` → `microsoft_copilot.svg`)
Microsoft Teams (`com.microsoft.teams/com.google.android.archive.ReactivateActivity` → `microsoft_teams.svg`)
Musixmatch (`com.musixmatch.android.lyrify/com.google.android.archive.ReactivateActivity` → `musixmatch.svg`)
nRF Connect (`no.nordicsemi.android.mcp/com.google.android.archive.ReactivateActivity` → `nrf_connect.svg`)
Omnivore (`app.omnivore.omnivore/com.google.android.archive.ReactivateActivity` → `omnivore.svg`)
PCAPdroid (`com.emanuelef.remote_capture/com.google.android.archive.ReactivateActivity` → `pcapdroid.svg`)
phyphox (`de.rwth_aachen.phyphox/com.google.android.archive.ReactivateActivity` → `phyphox.svg`)
PlantNet (`org.plantnet/com.google.android.archive.ReactivateActivity` → `plantnet.svg`)
PPSSPP (`org.ppsspp.ppsspp/com.google.android.archive.ReactivateActivity` → `ppsspp.svg`)
Rabby Wallet (`com.debank.rabbymobile/com.google.android.archive.ReactivateActivity` → `rabby_wallet.svg`)
Ruler (`fr.ecp.ruler.app/com.google.android.archive.ReactivateActivity` → `ruler.svg`)
SimpleX (`chat.simplex.app/com.google.android.archive.ReactivateActivity` → `simplex.svg`)
Snapdrop (`com.fmsys.snapdrop/com.google.android.archive.ReactivateActivity` → `snapdrop.svg`)
Soundcore (`com.oceanwing.soundcore/com.google.android.archive.ReactivateActivity` → `soundcore.svg`)
SPIC (`com.henrikherzig.playintegritychecker/com.google.android.archive.ReactivateActivity` → `spic.svg`)
Suntimes (`com.forrestguice.suntimeswidget/com.forrestguice.suntimeswidget.SuntimesLaunchActivity` → `suntimes.svg`)
SVPlayer (`com.svpteam.svp/com.google.android.archive.ReactivateActivity` → `svplayer.svg`)
Swipefy (`app.swipefy.mobile/com.google.android.archive.ReactivateActivity` → `swipefy.svg`)
Termius (`com.server.auditor.ssh.client/com.google.android.archive.ReactivateActivity` → `termius.svg`)
Tooly (`com.yousx.thetoolsapp/com.google.android.archive.ReactivateActivity` → `tooly.svg`)
Trello (`com.trello/com.google.android.archive.ReactivateActivity` → `trello.svg`)
Tricount (`com.tribab.tricount.android/com.bunq.tricount.android.ui.activity.LoadingTricountStartupInfoActivity` → `tricount.svg`)
Twitch (`tv.twitch.android.app/com.google.android.archive.ReactivateActivity` → `twitch.svg`)
Vampire Survivors (`com.poncle.vampiresurvivors/com.google.android.archive.ReactivateActivity` → `vampire_survivors.svg`)
Vivino (`vivino.web.app/com.google.android.archive.ReactivateActivity` → `vivino.svg`)
Voice Access (`com.google.android.apps.accessibility.voiceaccess/com.google.android.apps.accessibility.voiceaccess.activities.Launchapp.pixel_Jauncher` → `voice_access.svg`)
Voice Access (`com.google.android.apps.accessibility.voiceaccess/com.google.android.apps.accessibility.voiceaccess.LauncherActivity` → `voice_access.svg`)
Wallpaper Engine (`io.wallpaperengine.weclient/com.google.android.archive.ReactivateActivity` → `wallpaper_engine.svg`)
Wix Owner (`com.wix.admin/com.google.android.archive.ReactivateActivity` → `wix_owner.svg`)
Wuthering Waves (`com.kurogame.wutheringwaves.global/com.wutheringwaves.russian.MainActivity` → `wuthering_waves.svg`)
Yr (`no.nrk.yr/no.nrk.yr.SplashScreenActivity` → `yr.svg`)
Zoom (`us.zoom.videomeetings/com.google.android.archive.ReactivateActivity` → `zoom.svg`)
ВТБ ~~ VTB (`ru.vtb24.mobilebanking.android/ru.vtb24.mobilebanking.android.gui.activity.LoadingScreenActivity` → `vtb.svg`)
## Contributor's checklist
- [x] I followed [the Lawnicons Guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md) and will make changes if someone suggests. I will also make sure that Lawnicons builds correctly.