### PR TITLE
Update for the app linking issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Link apps to existing icons
+  - name: Link apps to identical icons
     url: https://github.com/LawnchairLauncher/lawnicons/blob/develop/CONTRIBUTING.md#adding-an-icon-to-lawnicons
-    about: Learn more about linking an app to an existing icon and making a PR to contribute to Lawnicons.
+    about: Learn more about linking an app to an existing icon via a pull request.
   - name: Icon Request
     url: https://forms.gle/xt7sJhgWEasuo9TR9
     about: Please request your icons in this form.


### PR DESCRIPTION
I have clarified the description of the issue to emphasize in which cases it makes sense to link an app to an existing icon.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
