### PR TITLE
Reverting the latest workflow changes

### DIFF
--- a/.github/workflows/build_debug_apk.yml
+++ b/.github/workflows/build_debug_apk.yml
@@ -5,27 +5,7 @@ on:
   push:
     branches:
       - develop
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - '.idea/**'
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.gitignore'
-      - '.gitattributes'
-      - '.github/labeler.yml'
-      - '.github/release.yml'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - '.idea/**'
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.gitignore'
-      - '.gitattributes'
-      - '.github/labeler.yml'
-      - '.github/release.yml'
 
 jobs:
   build-debug-apk:


### PR DESCRIPTION
I'm undoing the latest changes because they stop the workflow in editorial PRs, rather than skipping the app build process.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet. -->
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: General change (non-breaking change that doesn't fit the above categories, such as copyediting)
