### PR TITLE
+1 icon & +3 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -12641,6 +12641,8 @@
   <item component="ComponentInfo{org.wikipedia/org.wikipedia.PageActivity}" drawable="wikipedia" name="Wikipedia" />
   <item component="ComponentInfo{org.wikipedia/org.wikipedia.page.PageActivity}" drawable="wikipedia" name="Wikipedia" />
   <item component="ComponentInfo{org.wikipedia/org.wikipedia.WikipediaActivity}" drawable="wikipedia" name="Wikipedia" />
+  <item component="ComponentInfo{org.wikipedia/org.wikipedia.onboarding.InitialOnboardingActivity}" drawable="wikipedia" name="Wikipedia" />
+  <item component="ComponentInfo{org.wikipedia/org.wikipedia.DefaultIcon}" drawable="wikipedia" name="Wikipedia" />
   <item component="ComponentInfo{org.wikipedia.beta/org.wikipedia.main.MainActivity}" drawable="wikipedia_beta" name="Wikipedia Beta" />
   <item component="ComponentInfo{com.wildberries.ru/com.wildberries.ru.Splash.SplashActivity}" drawable="wildberries" name="Wildberries" />
   <item component="ComponentInfo{com.wildberries.ru/ru.wildberries.SplashActivity}" drawable="wildberries" name="Wildberries" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -2957,7 +2957,7 @@
   <item component="ComponentInfo{com.dolby/com.dolby.ds1appUI.MainActivity}" drawable="dolby" name="Dolby" />
   <item component="ComponentInfo{co.aospa.dolby.xiaomi/co.aospa.dolby.xiaomi.DolbyActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos" />
   <item component="ComponentInfo{com.dolby.daxappui/com.dolby.daxappui.MainActivity}" drawable="dolby_atmos" name="Dolby Atmos" />
-  <item component="ComponentInfo{co.aospa.dolby/co.aospa.dolby.DolbyActivity}" drawable="dolby_atmos" name="Dolby Atmos" />
+  <item component="ComponentInfo{co.aospa.dolby/co.aospa.dolby.DolbyActivity}" drawable="dolby" name="Dolby Atmos" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.introduction.IntroductionActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.sst.SSTActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.LauncherActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
@@ -7373,6 +7373,7 @@
   <item component="ComponentInfo{com.nothing.weather/com.nothing.weather.main.ui.MainActivity}" drawable="nothing_weather" name="Nothing Weather" />
   <item component="ComponentInfo{com.nothing.smartcenter/com.nothing.smart.index.activity.WelcomeActivity}" drawable="nothing_x" name="Nothing X" />
   <item component="ComponentInfo{com.nothing.smartcenter/com.nothing.home.activity.WelcomeActivity}" drawable="nothing_x" name="Nothing X" />
+  <item component="ComponentInfo{com.nothing.gallery/com.nothing.gallery.activity.EntryActivity}" drawable="nothing_gallery" name="Nothing Gallery" />
   <item component="ComponentInfo{com.dev.nothingbutwalls.app/com.blogger.waller.activity.ActivitySplash}" drawable="nothingbutwallpapers" name="NothingbutWallpapers" />
   <item component="ComponentInfo{com.dev.nothingbutwalls.app/com.dev.nothingbutwalls.app.MainActivity}" drawable="nothingbutwallpapers" name="NothingbutWallpapers" />
   <item component="ComponentInfo{com.theveloper.nothink.app/com.theveloper.nothink.app.MainActivity}" drawable="nothink" name="NothinK" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -2957,6 +2957,7 @@
   <item component="ComponentInfo{com.dolby/com.dolby.ds1appUI.MainActivity}" drawable="dolby" name="Dolby" />
   <item component="ComponentInfo{co.aospa.dolby.xiaomi/co.aospa.dolby.xiaomi.DolbyActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos" />
   <item component="ComponentInfo{com.dolby.daxappui/com.dolby.daxappui.MainActivity}" drawable="dolby_atmos" name="Dolby Atmos" />
+  <item component="ComponentInfo{co.aospa.dolby/co.aospa.dolby.DolbyActivity}" drawable="dolby_atmos" name="Dolby Atmos" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.introduction.IntroductionActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.sst.SSTActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.LauncherActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
@@ -4057,6 +4058,7 @@
   <item component="ComponentInfo{com.transsion.gamespace.app/com.transsion.gamespace.activity.GameSpaceActivity}" drawable="generic_games" name="Game Space" />
   <item component="ComponentInfo{io.chaldeaprjkt.gamespace/.settings.SettingsActivity}" drawable="game_space" name="Game Space" />
   <item component="ComponentInfo{io.chaldeaprjkt.gamespace/io.chaldeaprjkt.gamespace.settings.SettingsActivity}" drawable="game_space" name="Game Space" />
+  <item component="ComponentInfo{com.neoteric.gamespace/com.neoteric.gamespace.settings.SettingsActivity}" drawable="game_space" name="Game Space" />
   <item component="ComponentInfo{ru.elron.gamepadtester/ru.elron.gamepadtester.ui.main.MainActivity}" drawable="gamepad_tester" name="Gamepad tester" />
   <item component="ComponentInfo{com.oplus.games/com.oplus.assistant.activity.SpeedUpStartActivity}" drawable="generic_games" name="Games" />
   <item component="ComponentInfo{com.oplus.games/com.oplus.assistant.activity.StartActivity}" drawable="generic_games" name="Games" />

--- a/svgs/nothing_gallery.svg
+++ b/svgs/nothing_gallery.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="192"
+   height="192"
+   viewBox="0 0 192 192"
+   fill="none"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="nothing_gallery.svg"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="3.3678698"
+     inkscape:cx="102.5871"
+     inkscape:cy="95.460935"
+     inkscape:window-width="1472"
+     inkscape:window-height="890"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1" />
+  <g
+     id="g3"
+     transform="matrix(1.0691895,0,0,1.0687706,-1.6543108,-15.056582)">
+    <g
+       id="g1">
+      <path
+         id="path2"
+         style="fill-opacity:0.831731;stroke:#000000;stroke-width:11.2257;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 84.930577,110.34307 a 60,60 0 0 1 -17.573594,42.42641 60,60 0 0 1 -42.426406,17.57359 v -60 z" />
+      <path
+         id="path2-3"
+         style="fill-opacity:0.831731;stroke:#000000;stroke-width:11.2257;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 157.739,37.47802 A 60,60 0 0 1 140.1654,79.904427 60,60 0 0 1 97.738999,97.47802 v -60 z" />
+      <path
+         id="path2-3-9-8"
+         style="fill-opacity:0.831731;stroke:#000000;stroke-width:11.2257;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 97.738986,110.34307 a 60.000238,59.99998 0 0 1 42.426584,17.57358 60.000238,59.99998 0 0 1 17.57366,42.4264 H 97.738986 Z" />
+      <path
+         id="path3"
+         style="fill-opacity:0.831731;stroke:#000000;stroke-width:11.2257;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 79.607017,67.156316 a 25,25 0 0 1 -25,25 25,25 0 0 1 -25,-25 25,25 0 0 1 25,-25 25,25 0 0 1 25,25 z" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
# Description
Added:
icon for Nothing Gallery 
links for com.neoteric.gamespace & co.aospa.dolby
Updated:
links for Wikipedia

### Added
Nothing Gallery (`com.nothing.gallery/com.nothing.gallery.activity.EntryActivity`)

### Linked
Game Sapce (`com.neoteric.gamespace` → `game_space.svg`)
Dolby Manager (`co.aospa.dolby` → `dolby.svg`)
