### PR TITLE
+2 link for BOC and Hutch App (Sri Lankan bank and a network provider app)

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4686,6 +4686,7 @@
   <item component="ComponentInfo{com.pavlenko.Habo/com.pavlenko.Habo.MainActivity}" drawable="habo" name="Habo" />
   <item component="ComponentInfo{org.pocketworkstation.pckeyboard/org.pocketworkstation.pckeyboard.Main}" drawable="hackers_keyboard" name="Hacker's Keyboard" />
   <item component="ComponentInfo{com.jiaqifeng.hacki/com.jiaqifeng.hacki.MainActivity}" drawable="hacki" name="Hacki" />
+  <item component="ComponentInfo{com.omobio.etisalatone/com.omobio.etisalatone.MainActivity}" drawable="hacki" name="Hutch App" />
   <item component="ComponentInfo{com.yy.hiyo/com.yy.hiyo.LaunchActivity}" drawable="hago" name="Hago" />
   <item component="ComponentInfo{com.yy.hiyo/com.yy.hiyo.MainActivity}" drawable="hago" name="Hago" />
   <item component="ComponentInfo{com.aistra.hail/com.aistra.hail.ui.main.MainActivity}" drawable="hail" name="Hail" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1358,6 +1358,7 @@
   <item component="ComponentInfo{com.blusmart.rider/com.blusmart.rider.DefaultAlias}" drawable="blusmart" name="BluSmart" />
   <item component="ComponentInfo{com.dsmart.blu.android/com.dsmart.blu.android.InitActivity}" drawable="blutv" name="BluTV" />
   <item component="ComponentInfo{cloud.blynk/cc.blynk.shell.activity.MainActivity}" drawable="blynk" name="Blynk" />
+  <item component="ComponentInfo{com.ofss.fcdb.mobile.android.phone.boc.launcher/com.ofss.fcdb.mobile.android.phone.boc.launcher.LauncherActivity}" drawable="blynk" name="BOC" />
   <item component="ComponentInfo{com.appovo.bmicalculator/com.appovo.bmicalculator.android.MainActivity}" drawable="bmi_calculator" name="BMI Calculator" />
   <item component="ComponentInfo{com.bmoharris.digital/com.bmoharris.bdb.MainActivity}" drawable="bmo_bank" name="BMO Bank" />
   <item component="ComponentInfo{com.bmo.mobile/com.bmo.mobile.BMOMobileBanking}" drawable="bmo_bank" name="BMO Bank" />


### PR DESCRIPTION
# Description
Added links of existing typeface icons to two new apps
- [Hutch App](https://play.google.com/store/apps/details?id=com.omobio.etisalatone&hl=en) - Sri Lankan network provider app
- [BOC](https://play.google.com/store/apps/details?id=com.ofss.fcdb.mobile.android.phone.boc.launcher&hl=en) - Sri Lankan bank app

## Icons addition information
### Linked
<!--  New links for new apps that already had matching icons in Lawnicons. -->
App Name (`com.omobio.etisalatone` → `hacki.svg`)
App Name (`com.ofss.fcdb.mobile.android.phone.boc.launcher` → `blynk.svg`)
