### PR TITLE
Link Iconify FOSS to Iconify icon

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -5092,6 +5092,9 @@
   <item component="ComponentInfo{com.drdisagree.iconify/com.drdisagree.iconify.SplashActivityThemed}" drawable="iconify" name="Iconify" />
   <item component="ComponentInfo{com.drdisagree.iconify/com.drdisagree.iconify.SplashActivityRetro}" drawable="iconify" name="Iconify" />
   <item component="ComponentInfo{com.drdisagree.iconify/com.drdisagree.iconify.SplashActivity}" drawable="iconify" name="Iconify" />
+  <item component="ComponentInfo{com.drdisagree.iconify.foss/com.drdisagree.iconify.SplashActivity}" drawable="iconify" name="Iconify" />
+  <item component="ComponentInfo{com.drdisagree.iconify.foss/com.drdisagree.iconify.SplashActivityRetro}" drawable="iconify" name="Iconify" />
+  <item component="ComponentInfo{com.drdisagree.iconify.foss/com.drdisagree.iconify.SplashActivityThemed}" drawable="iconify" name="Iconify" />
   <item component="ComponentInfo{com.drdisagree.iconify.debug/com.drdisagree.iconify.SplashActivityRetro}" drawable="iconify" name="Iconify Debug" />
   <item component="ComponentInfo{com.drdisagree.iconify.debug/com.drdisagree.iconify.SplashActivity}" drawable="iconify" name="Iconify Debug" />
   <item component="ComponentInfo{com.xm.csee/com.xworld.activity.welcome.view.WelcomePageActivity}" drawable="icsee" name="iCSee" />


### PR DESCRIPTION
# Description
Link the new version of Iconify (FOSS) to the corresponding icon
### Linked
<!--  New links for apps that were already in Lawnicons. -->
Iconify (`com.drdisagree.iconify.foss` → `iconify.svg`)
