### PR TITLE
+5 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -5895,6 +5895,7 @@
   <item component="ComponentInfo{keepass2android.keepass2android/crc64ae7e22645ed9821f.KeePass}" drawable="keepass2android" name="Keepass2Android" />
   <item component="ComponentInfo{keepass2android.keepass2android/crc64dd09b2a2e58bb27d.KeePass}" drawable="keepass2android" name="Keepass2Android" />
   <item component="ComponentInfo{keepass2android.keepass2android/crc64c98c008c0cd742cb.KeePass}" drawable="keepass2android" name="Keepass2Android" />
+  <item component="ComponentInfo{keepass2android.keepass2android_nonet/crc64dd09b2a2e58bb27d.KeePass}" drawable="keepass2android" name="Keepass2Android Offline" />
   <item component="ComponentInfo{com.kunzisoft.keepass.free/com.kunzisoft.keepass.activities.FileDatabaseSelectActivity}" drawable="keepassdx" name="KeePassDX" />
   <item component="ComponentInfo{com.kunzisoft.keepass.libre/com.kunzisoft.keepass.activities.FileDatabaseSelectActivity}" drawable="keepassdx" name="KeePassDX" />
   <item component="ComponentInfo{com.kunzisoft.keepass.libre/com.kunzisoft.keepass.fileselect.FilePickerStylishActivity}" drawable="keepassdx" name="KeePassDX" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -233,6 +233,7 @@
   <item component="ComponentInfo{com.runtastic.android/com.runtastic.android.activities}" drawable="adidas_running" name="adidas Running" />
   <item component="ComponentInfo{com.runtastic.android/com.runtastic.android.activities.StartActivity}" drawable="adidas_running" name="adidas Running" />
   <item component="ComponentInfo{com.adlock/com.adlock.MainActivity}" drawable="adlock" name="AdLock" />
+  <item component="ComponentInfo{com.davidshewitt.admincontrol/com.davidshewitt.admincontrol.ControlYourDeviceActivity}" drawable="volumelockr" name="AdminControl" />
   <item component="ComponentInfo{io.stark.admob/io.stark.admob.ui.MainActivity}" drawable="admobile" name="AdMobile" />
   <item component="ComponentInfo{fr.anidn/fr.anidn.MainActivity}" drawable="adn_animation_digital_network" name="ADN Animation Digital Network" />
   <item component="ComponentInfo{com.adobe.ims.accountaccess/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="adobe_account_access" name="Adobe Account Access" />
@@ -3418,6 +3419,7 @@
   <item component="ComponentInfo{com.dev47apps.droidcam/com.dev47apps.droidcam.DroidCam}" drawable="droidcam" name="DroidCam" />
   <item component="ComponentInfo{com.dev47apps.obsdroidcam/com.dev47apps.obsdroidcam.MainActivity}" drawable="droidcam_obs" name="DroidCam OBS" />
   <item component="ComponentInfo{com.dev47apps.droidcamx/com.dev47apps.droidcamx.DroidCamX}" drawable="droidcamx" name="DroidCamX" />
+  <item component="ComponentInfo{com.nemesis.droidcrypt/com.nemesis.droidcrypt.MainActivity}" drawable="volumelockr" name="DroidCrypt" />
   <item component="ComponentInfo{org.petero.droidfish/org.petero.droidfish.DroidFish}" drawable="droidfish" name="DroidFish" />
   <item component="ComponentInfo{sushi.hardcore.droidfs/sushi.hardcore.droidfs.MainActivity}" drawable="droidfs" name="DroidFS" />
   <item component="ComponentInfo{com.jgeek00.droid_hole/com.jgeek00.droid_hole.MainActivity}" drawable="droidhole" name="DroidHole" />
@@ -6449,6 +6451,7 @@
   <item component="ComponentInfo{co.localmonero.app/io.flutter.embedding.android.FlutterFragmentActivity}" drawable="localmonero" name="LocalMonero" />
   <item component="ComponentInfo{org.localsend.localsend_app/org.localsend.localsend_app.MainActivity}" drawable="localsend" name="LocalSend" />
   <item component="ComponentInfo{com.locationchanger/com.locationchanger.MainActivity}" drawable="location_changer" name="Location Changer" />
+  <item component="ComponentInfo{name.seguri.android.lock/name.seguri.android.lock.MainActivity}" drawable="volumelockr" name="Lock" />
   <item component="ComponentInfo{com.locket.Locket/com.locket.Locket.MainActivity}" drawable="locket_widget" name="Locket Widget" />
   <item component="ComponentInfo{com.fourchars.lmpfree/gui.SplashScreenActivity1}" drawable="lockmypix" name="LockMyPix" />
   <item component="ComponentInfo{com.fourchars.lmpfree/gui.SplashScreenActivity2}" drawable="lockmypix" name="LockMyPix" />
@@ -10420,6 +10423,7 @@
   <item component="ComponentInfo{com.wujiyun.scrcpy.pro/org.las2mile.scrcpy.MainActivity}" drawable="scrcpy" name="scrcpy" />
   <item component="ComponentInfo{com.bean.android.screeninspector/com.bean.android.screeninspector.MainActivity}" drawable="screen_check" name="Screen Check" />
   <item component="ComponentInfo{com.github.ericytsang.screenfilter.app.android/com.github.ericytsang.screenfilter.app.android.activity.MainActivity}" drawable="screen_dimmer" name="Screen Dimmer" />
+  <item component="ComponentInfo{com.tiendnm.zukulock/com.tiendnm.zukulock.MainActivity}" drawable="volumelockr" name="Screen Lock" />
   <item component="ComponentInfo{net.mm2d.android.orientationfaker/net.mm2d.android.orientationfaker.MainActivity}" drawable="screen_orientation_control" name="Screen Orientation Control" />
   <item component="ComponentInfo{com.kimcy929.screenrecorder/com.kimcy929.screenrecorder.activity.MainActivity}" drawable="kimcy_screen_recorder" name="Screen Recorder" />
   <item component="ComponentInfo{com.linuxauthority.screenrecorder/com.linuxauthority.screenrecorder.ui.main.MainActivity}" drawable="screen_recorder_naveensingh" name="Screen Recorder by naveensingh" />


### PR DESCRIPTION
## Icons addition information
<!-- Please specify in the sections below which applications and packages you have worked on. Unnecessary sections can be deleted. -->
### Linked
<!--  New links for apps that were already in Lawnicons. -->
[Keepass2Android Offline](https://play.google.com/store/apps/details?id=keepass2android.keepass2android_nonet) (`keepass2android.keepass2android_nonet` → `keepass2android.svg`)

[AdminControl](https://f-droid.org/packages/com.davidshewitt.admincontrol/) (`com.davidshewitt.admincontrol` → `volumelockr.svg`) ([source code](https://github.com/linux-colonel/AdminControl))
[DroidCrypt](https://f-droid.org/packages/com.nemesis.droidcrypt/) (`com.nemesis.droidcrypt` → `volumelockr.svg`) ([source code](https://github.com/umutcamliyurt/DroidCrypt))
[Lock](https://f-droid.org/packages/name.seguri.android.lock/) (`name.seguri.android.lock` → `volumelockr.svg`) ([source code](https://github.com/seguri/lock))
[Screen Lock](https://apt.izzysoft.de/fdroid/index/apk/com.tiendnm.zukulock) (`com.tiendnm.zukulock` → `volumelockr.svg`) ([source code](https://github.com/tiendnm/zukulock))