### PR TITLE
Relink GSL activities; +2 Google app links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4684,6 +4684,8 @@
   <item component="ComponentInfo{com.apps.adrcotfas.goodtime/com.apps.adrcotfas.goodtime.main.TimerActivity}" drawable="goodtime" name="Goodtime" />
   <item component="ComponentInfo{com.apps.adrcotfas.goodtime/com.apps.adrcotfas.goodtime.MainActivity}" drawable="goodtime" name="Goodtime" />
   <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.search.clientui.SearchServiceClientActivity}" drawable="google" name="Google" />
+  <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.apps.search.soundsearch.shortcut.AddShortcutActivity}" drawable="sound_search" name="Google" />
+  <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.apps.search.soundsearch.shortcut.AliasAddShortcutActivity}" drawable="sound_search" name="Google" />
   <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.apps.search.weather.entrypoints.appicon.WeatherAppIconActivity}" drawable="google" name="Google" />
   <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.apps.gsa.staticplugins.opa.EnterOpaActivityFromLauncher}" drawable="google" name="Google" />
   <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.apps.gsa.velour.DynamicActivityTrampoline}" drawable="google" name="Google" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4827,25 +4827,25 @@
   <item component="ComponentInfo{com.google.android.apps.docs.editors.sheets/com.google.android.apps.docs.editors.kix.KixEditorActivity}" drawable="google_sheets" name="Google Sheets" />
   <item component="ComponentInfo{com.google.android.apps.docs.editors.sheets/com.google.android.archive.ReactivateActivity}" drawable="google_sheets" name="Google Sheets" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.SettingsActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.WeatherActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.WeatherActivity}" drawable="weathermaster" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.ui.SettingsActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.WeatherActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.WeatherActivity}" drawable="weathermaster" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.PasswordManagerActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.MusicSearchActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.MusicSearchActivity}" drawable="sound_search" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.GamesActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.AssistantActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.AssistantActivity}" drawable="google_gemini" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.PasswordManagerActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.MusicSearchActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.MusicSearchActivity}" drawable="sound_search" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.GameActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.AssistantActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.WeatherShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.AssistantActivity}" drawable="google_gemini" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.WeatherShortcut}" drawable="weathermaster" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.QuickShareShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.PasswordManagerShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.MusicSearchShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.LensShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.MusicSearchShortcut}" drawable="sound_search" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.LensShortcut}" drawable="google_lens" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.GamesShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.FilesShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
-  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.AssistantShortcut}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.FilesShortcut}" drawable="files" name="Google Shortcuts Launcher" />
+  <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.AssistantShortcut}" drawable="google_gemini" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.activity.SettingsActivity}" drawable="google_shortcuts_launcher" name="Google Shortcuts Launcher" />
   <item component="ComponentInfo{com.google.android.apps.docs.editors.slides/com.google.android.archive.ReactivateActivity}" drawable="google_slides" name="Google Slides" />
   <item component="ComponentInfo{com.google.android.apps.docs.editors.slides/com.google.android.apps.docs.app.NewMainProxyActivity}" drawable="google_slides" name="Google Slides" />


### PR DESCRIPTION
# Description
<!-- Please provide a short summary of your pull request. -->
I noticed that Google Shortcuts Launcher has all of its activities linked to `google_shortcuts_launcher.svg`, which in my opinion goes against the purpose of the app.
Here I made an attempt to pick better fitting icons for specific activities, where such icons already exist within Lawnicons.
If a change like this is undesired, that's fine; although skimming through the [Contributing guidelines](https://github.com/LawnchairLauncher/lawnicons/blob/84b8557c797469ebfcdfeabf3360246701e0db7a/CONTRIBUTING.md), I haven't noticed anything against such a change.

## Icons
<!-- Please specify in the sections below which apps and packages you have worked on. Unnecessary sections can be deleted. -->

### Linked
<!--  New app components for existing icons. -->

#### Google app ([`com.google.android.googlequicksearchbox`](https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox))
Activity:
`com.google.android.apps.search.soundsearch.shortcut.AddShortcutActivity` → `sound_search.svg`
`com.google.android.apps.search.soundsearch.shortcut.AliasAddShortcutActivity` → `sound_search.svg`

Here I'm hoping that this will apply the icon to the Sound Search widget provided by the Google app.

### Relinked
<!--  Outdated icons that you've updated. -->

#### Google Shortcuts Launcher ([`com.wstxda.gsl`](https://github.com/WSTxda/Google-Shortcuts-Launcher))
Changed below activities from `google_shortcuts_launcher.svg` to:
`com.wstxda.gsl.WeatherActivity` → `weathermaster.svg`
`com.wstxda.gsl.shortcut.WeatherActivity` → `weathermaster.svg`
`com.wstxda.gsl.shortcut.MusicSearchActivity` → `sound_search.svg`
`com.wstxda.gsl.shortcut.AssistantActivity` → `google_gemini.svg`
`com.wstxda.gsl.MusicSearchActivity` → `sound_search.svg`
`com.wstxda.gsl.AssistantActivity` → `google_gemini.svg`
`com.wstxda.gsl.shortcuts.WeatherShortcut` → `weathermaster.svg`
`com.wstxda.gsl.shortcuts.MusicSearchShortcut` → `sound_search.svg`
`com.wstxda.gsl.shortcuts.LensShortcut` → `google_lens.svg`
`com.wstxda.gsl.shortcuts.FilesShortcut` → `files.svg`
`com.wstxda.gsl.shortcuts.AssistantShortcut` → `google_gemini.svg`

### Notes on icon selection

- I have picked `weathermaster.svg` for GSL weather, because it resembles the GSL icon pretty closely,
- I have picked `google_gemini.svg` for GSL assistant, because GSL uses the Gemini icon, even though it might launch a different assistant,
- All other icon choices should be pretty self-explanatory.