### PR TITLE
Removing changelogs generation for Lawnicons Nightly

### DIFF
--- a/.github/workflows/build_debug_apk.yml
+++ b/.github/workflows/build_debug_apk.yml
@@ -151,4 +151,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag
-          gh release create "nightly" "$APK_NAME" -p -t "Lawnicons Nightly" --generate-notes
+          gh release create "nightly" "$APK_NAME" -p -t "Lawnicons Nightly"


### PR DESCRIPTION
## Description
Because of the long breaks between releases, we have huge changelogs going up, so it's a long way to scroll to the assets on PC and smartphone (GitHub app). It's a bigger inconvenience than clicking on a link to see the changelog. If the GitHub UI changes to make it easier in this case, or if the changelogs become more important than the assets, we'll bring it back.

## Type of change
<!-- Replace &cross; with &check; to "check" the specified bullet. -->

&cross; Bug fix (non-breaking change which fixes an issue)  
&check; General change (non-breaking change that doesn't fit the above categories, such as copyediting)  
