### PR TITLE
Trying to get the changelog link back to the Lawnicons Nightly release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,17 +1,3 @@
 changelog:
   categories:
-    - title: 📱 New Icons & Links
-      labels:
-        - icons
-    - title: 🧹 Code
-      labels:
-        - code
-      exclude:
-        labels:
-          - dependencies
-    - title: 🧑‍💻 Dependencies
-      labels:
-        - dependencies
-    - title: 💬 Localization
-      labels:
-        - locale
+    - title: 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,3 +1,3 @@
 changelog:
   categories:
-    - title: 
+    - title: "A itle to display the changelog link"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,3 +1,3 @@
 changelog:
   categories:
-    - title: "A itle to display the changelog link"
+    - title: "A title to display the changelog link"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,3 +1,8 @@
 changelog:
   categories:
     - title: "A title to display the changelog link"
+      exclude:
+      - icons
+      - code
+      - dependencies
+      - locale

--- a/.github/workflows/build_debug_apk.yml
+++ b/.github/workflows/build_debug_apk.yml
@@ -151,4 +151,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag
-          gh release create "nightly" "$APK_NAME" -p -t "Lawnicons Nightly"
+          gh release create "nightly" "$APK_NAME" -p -t "Lawnicons Nightly" --generate-notes


### PR DESCRIPTION
I'm researching how to leave only the changelog link in the Lawnicons Nightly release.

## Type of change
<!-- Replace &cross; with &check; to "check" the specified bullet. -->

&cross; Bug fix (non-breaking change which fixes an issue)  
&check; General change (non-breaking change that doesn't fit the above categories, such as copyediting)  
