### PR TITLE
+16 links, 1 relinked

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -5535,7 +5535,7 @@
   <item component="ComponentInfo{cc.honista.lite/com.instagram.business.activity.Ai5w}" drawable="honista" name="Honista Lite" />
   <item component="ComponentInfo{com.miHoYo.bh3oversea/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="Honkai Impact 3" />
   <item component="ComponentInfo{com.miHoYo.enterprise.NGHSoD/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="Honkai Impact 3" />
-  <item component="ComponentInfo{com.miHoYo.bh3oversea_vn/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="Honkai Impact 3-VN" />
+  <item component="ComponentInfo{com.miHoYo.bh3oversea_vn/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="Honkai Impact 3rd" />
   <item component="ComponentInfo{com.miHoYo.bh3global/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="Honkai Impact 3rd" />
   <item component="ComponentInfo{com.hihonor.magichome/com.hihonor.magichome.oversea.app.WelcomeActivity}" drawable="honor_ai_space" name="Honor AI Space" />
   <item component="ComponentInfo{com.hihonor.appmarket/com.hihonor.appmarket.module.splash.Splash}" drawable="huawei_appgallery" name="Honor App Market" />


### PR DESCRIPTION
# Description
- linked a bunch of regional variant of games,
- changed link of a note app to the same as the app's other variant, which has a more accurate icon

## Icons
<!-- Please specify in the sections below which apps and packages you have worked on. Unnecessary sections can be deleted. -->

### Linked
<!--  New app components for existing icons. -->


#### Games
アークナイツ ~~ Arknights (`com.YoStarJP.Arknights` → `arknights.svg`)
明日方舟 ~~ Arknights (`tw.txwy.and.arknights` → `arknights.svg`)
명일방주 ~~ Arknights (`com.YoStarKR.Arknights` → `arknights.svg`)

ブルーアーカイブ ~~ Blue Archive (15) (`com.nexon.bluearchiveteen` → `blue_archive.svg`)

勝利女神：妮姬 ~~ GODDESS OF VICTORY: NIKKE (`com.gamamobi.nikke` → `goddess_of_victory_nikke.svg`)

プロジェクトセカイ カラフルステージ！ feat. 初音ミク ~~ HATSUNE MIKU: COLORFUL STAGE! (`com.sega.pjsekai` → `hatsune_miku_colorful_stage.svg`)
世界計畫 繽紛舞台！feat. 初音未來 ~~ HATSUNE MIKU: COLORFUL STAGE! (`com.hermes.mk.asia` → `hatsune_miku_colorful_stage.svg`)
世界計畫 繽紛舞台！feat. 初音未來 ~~ HATSUNE MIKU: COLORFUL STAGE! (`com.hermes.mk.asia.qooapp` → `hatsune_miku_colorful_stage.svg`)
프로젝트 세카이 컬러풀 스테이지! feat.하츠네 미쿠 ~~ HATSUNE MIKU: COLORFUL STAGE! (`com.pjsekai.kr` → `hatsune_miku_colorful_stage.svg`)

Honkai Impact 3rd (`com.miHoYo.bh3global` → `honkai_impact_3.svg`)
Honkai Impact 3-VN (`com.miHoYo.bh3oversea_vn` → `honkai_impact_3.svg`)
崩坏3 ~~ Honkai Impact 3rd (`com.tencent.tmgp.bh3` → `honkai_impact_3.svg`)
崩壊3rd ~~ Honkai Impact 3rd (`com.miHoYo.bh3rdJP` → `honkai_impact_3.svg`)
崩壞3rd ~~ Honkai Impact 3rd (`com.miHoYo.bh3tw` → `honkai_impact_3.svg`)
붕괴3rd ~~ Honkai Impact 3rd (`com.miHoYo.bh3korea` → `honkai_impact_3.svg`)

鸣潮 ~~ Wuthering Waves (`com.kurogame.mingchao` → `wuthering_waves.svg`)

### Relinked
Easy Notes (Accrescent variant) (`me.easyapps.easynotes` → changed from `notes.svg` to `easy_notes.svg`)