### PR TITLE
Minor copyediting to improve the guides clarity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -364,7 +364,7 @@ Tips
 - Add missing components to icons that are identical to the originals.
 - Make sure your icons or missing app components haven't been added earlier: search the `appfilter.xml` and check PRs.
 
-[View on YouTube](https://youtu.be/EAvYelOK5Nw) • [Icon contribution tools](#icon-contribution-tools) • [appfilter.xml](app/assets/appfilter.xml) • [PRs](https://github.com/LawnchairLauncher/lawnicons/pulls)
+[View on YouTube](https://youtu.be/EAvYelOK5Nw) • [How to find app components](#how-to-find-app-components) • [Icon contribution tools](#icon-contribution-tools) • [appfilter.xml](app/assets/appfilter.xml) • [PRs](https://github.com/LawnchairLauncher/lawnicons/pulls)
 
 ### Manual process
 


### PR DESCRIPTION
Linked sections "Adding icons and missing app components to Lawnicons" and "How to find app components" more explicitly.

## Type of change
<!-- Replace &cross; with &check; to "check" the specified bullet. -->

&cross; Bug fix (non-breaking change which fixes an issue)  
&check; General change (non-breaking change that doesn't fit the above categories, such as copyediting)  
