### PR TITLE
Bump compileSdk & targetSdk to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ val version = "2.14.1"
 val versionDisplayName = version + if (!isReleaseBuild) " $devReleaseName" else ""
 
 android {
-    compileSdk = 35
+    compileSdk = 36
     namespace = "app.lawnchair.lawnicons"
 
     defaultConfig {


### PR DESCRIPTION
```diff
OLD: Lawnicons 2.14.1 (3fce1b6) v20_release-before.apk (signature: V2)
NEW: Lawnicons 2.14.1 (3fce1b6) v20_release-after.apk (signature: V2)

          │          compressed          │         uncompressed
          ├──────────┬──────────┬────────┼───────────┬───────────┬───────
 APK      │ old      │ new      │ diff   │ old       │ new       │ diff
──────────┼──────────┼──────────┼────────┼───────────┼───────────┼───────
      dex │  1.4 MiB │  1.4 MiB │  +57 B │   2.9 MiB │   2.9 MiB │ +20 B
     arsc │  1.5 MiB │  1.5 MiB │    0 B │   1.5 MiB │   1.5 MiB │   0 B
 manifest │  3.2 KiB │  3.2 KiB │    0 B │  14.4 KiB │  14.4 KiB │   0 B
      res │    9 MiB │    9 MiB │    0 B │  23.3 MiB │  23.3 MiB │   0 B
   native │ 91.9 KiB │ 91.8 KiB │ -130 B │  36.5 KiB │  36.5 KiB │   0 B
    asset │  8.8 KiB │  8.9 KiB │  +10 B │  73.2 KiB │  73.2 KiB │  +6 B
    other │ 87.3 KiB │ 87.3 KiB │    0 B │ 125.8 KiB │ 125.8 KiB │   0 B
──────────┼──────────┼──────────┼────────┼───────────┼───────────┼───────
    total │ 12.2 MiB │ 12.2 MiB │  -63 B │    28 MiB │    28 MiB │ +26 B

 DEX     │ old   │ new   │ diff
─────────┼───────┼───────┼────────────
   files │     1 │     1 │  0
 strings │ 14084 │ 14084 │  0 (+1 -1)
   types │  4901 │  4901 │  0 (+0 -0)
 classes │  4066 │  4066 │  0 (+0 -0)
 methods │ 20059 │ 20060 │ +1 (+1 -0)
  fields │ 14060 │ 14060 │  0 (+0 -0)

 ARSC    │ old   │ new   │ diff
─────────┼───────┼───────┼──────
 configs │   146 │   146 │  0
 entries │ 14010 │ 14010 │  0

=================
====   APK   ====
=================

    compressed     │  uncompressed   │
──────────┬────────┼─────────┬───────┤
 size     │ diff   │ size    │ diff  │ path
──────────┼────────┼─────────┼───────┼──────────────────────────────────────────────
 21.1 KiB │ -130 B │ 9.9 KiB │   0 B │ ∆ lib/arm64-v8a/libandroidx.graphics.path.so
  1.4 MiB │  +57 B │ 2.9 MiB │ +20 B │ ∆ classes.dex
  5.1 KiB │   +6 B │ 4.9 KiB │  +6 B │ ∆ assets/dexopt/baseline.prof
    777 B │   +4 B │   641 B │   0 B │ ∆ assets/dexopt/baseline.profm
──────────┼────────┼─────────┼───────┼──────────────────────────────────────────────
  1.5 MiB │  -63 B │ 2.9 MiB │ +26 B │ (total)

======================
====   MANIFEST   ====
======================

@@ -1,4 +1,4 @@
 <manifest
-    android:compileSdkVersion="35"
-    android:compileSdkVersionCodename="15"
+    android:compileSdkVersion="36"
+    android:compileSdkVersionCodename="16"
     android:versionCode="20"
@@ -6,4 +6,4 @@
     package="app.lawnchair.lawnicons"
-    platformBuildVersionCode="35"
-    platformBuildVersionName="15"
+    platformBuildVersionCode="36"
+    platformBuildVersionName="16"
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -12,3 +12,3 @@
       android:minSdkVersion="26"
-      android:targetSdkVersion="35"
+      android:targetSdkVersion="36"
       />

=================
====   DEX   ====
=================

STRINGS:

   old   │ new   │ diff
  ───────┼───────┼───────────
   14084 │ 14084 │ 0 (+1 -1)

  + ~~R8{"backend":"dex","compilation-mode":"release","has-checksums":false,"min-api":26,"pg-map-id":"9318486","r8-mode":"full","version":"8.10.24"}

  - ~~R8{"backend":"dex","compilation-mode":"release","has-checksums":false,"min-api":26,"pg-map-id":"348de66","r8-mode":"full","version":"8.10.24"}

METHODS:

   old   │ new   │ diff
  ───────┼───────┼────────────
   20059 │ 20060 │ +1 (+1 -0)

  + android.util.AttributeSet getAttributeValue(String, String) → String
```
