### PR TITLE
+20 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -2078,6 +2078,7 @@
   <item component="ComponentInfo{com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Orange}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Yellow}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Teal}" drawable="camera" name="Camera" />
+  <item component="ComponentInfo{com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Red}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Purple}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Pink}" drawable="camera" name="Camera" />
   <item component="ComponentInfo{com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Lime}" drawable="camera" name="Camera" />
@@ -3415,7 +3416,25 @@
   <item component="ComponentInfo{com.dsemu.drastic/com.dsemu.drastic.DraSticActivity}" drawable="drastic" name="DraStic" />
   <item component="ComponentInfo{com.simplemobiletools.draw/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity.Orange}" drawable="pencil" name="Draw" />
   <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Red}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Pink}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Purple}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Deep_purple}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Indigo}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Blue}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Light_blue}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Cyan}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Teal}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Green}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Light_green}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Lime}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Yellow}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Amber}" drawable="pencil" name="Draw" />
   <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Orange}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Deep_orange}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Brown}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Blue_grey}" drawable="pencil" name="Draw" />
+  <item component="ComponentInfo{com.simplemobiletools.draw/com.simplemobiletools.draw.activities.SplashActivity.Grey_black}" drawable="pencil" name="Draw" />
   <item component="ComponentInfo{com.simplemobiletools.draw.pro/com.simplemobiletools.draw.pro.activities.SplashActivity.Amber}" drawable="pencil" name="Draw" />
   <item component="ComponentInfo{com.simplemobiletools.draw.pro/com.simplemobiletools.draw.pro.activities.SplashActivity.Blue}" drawable="pencil" name="Draw" />
   <item component="ComponentInfo{com.simplemobiletools.draw.pro/com.simplemobiletools.draw.pro.activities.SplashActivity.Blue_grey}" drawable="pencil" name="Draw" />
@@ -11636,6 +11655,7 @@
   <item component="ComponentInfo{com.simplemobiletools.gallery.pro/com.simplemobiletools.gallery.pro.activities.SplashActivity.Teal}" drawable="fossify_gallery" name="Simple Gallery Pro" />
   <item component="ComponentInfo{com.simplemobiletools.gallery.pro/com.simplemobiletools.gallery.pro.activities.SplashActivity.Yellow}" drawable="fossify_gallery" name="Simple Gallery Pro" />
   <item component="ComponentInfo{com.simplemobiletools.keyboard/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity.Orange}" drawable="generic_keyboard" name="Simple Keyboard" />
+  <item component="ComponentInfo{com.simplemobiletools.keyboard/com.simplemobiletools.keyboard.activities.SplashActivity.Amber}" drawable="generic_keyboard" name="Simple Keyboard" />
   <item component="ComponentInfo{com.simplemobiletools.keyboard/com.simplemobiletools.keyboard.activities.SplashActivity.Blue}" drawable="generic_keyboard" name="Simple Keyboard" />
   <item component="ComponentInfo{com.simplemobiletools.keyboard/com.simplemobiletools.keyboard.activities.SplashActivity.Blue_grey}" drawable="generic_keyboard" name="Simple Keyboard" />
   <item component="ComponentInfo{com.simplemobiletools.keyboard/com.simplemobiletools.keyboard.activities.SplashActivity.Brown}" drawable="generic_keyboard" name="Simple Keyboard" />


### PR DESCRIPTION
# Description
<!-- Please provide a short summary of your pull request. -->
Linked a couple more SimpleMobileTools components, by checking against APKs available through the F-Droid Archive repo (since their icon changing capability isn't broken). Might as well complete the collection in case anyone still uses those apps for one reason or another.
## Icons
<!-- Please specify in the sections below which apps and packages you have worked on. Unnecessary sections can be deleted. -->


### Linked
<!--  New app components for existing icons. -->
- Camera (`com.simplemobiletools.camera/com.simplemobiletools.camera.activities.SplashActivity.Red` → `camera.svg`)
- **18x** Draw (`com.simplemobiletools.draw` → `pencil.svg`)
- Simple Keyboard (`com.simplemobiletools.keyboard/com.simplemobiletools.keyboard.activities.SplashActivity.Amber` → `generic_keyboard.svg`)
