### PR TITLE
Fix the warning for use-site for @DrawableRes

### DIFF
--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/util/ExternalLink.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/util/ExternalLink.kt
@@ -3,7 +3,7 @@ package app.lawnchair.lawnicons.ui.util
 import androidx.annotation.DrawableRes
 
 data class ExternalLink(
-    @DrawableRes val iconResId: Int,
+    @param:DrawableRes val iconResId: Int,
     val name: Int,
     val url: String,
 )


### PR DESCRIPTION
```
> Task :app:compileAppDebugKotlin
w: file:///home/runner/work/lawnicons/lawnicons/app/src/main/kotlin/app/lawnchair/lawnicons/ui/util/ExternalLink.kt:6:5 This annotation is currently applied to the value parameter only, but in the future it will also be applied to field.
- To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments.
- To keep applying to the value parameter only, use the '@param:' annotation target.

See https://youtrack.jetbrains.com/issue/KT-73255 for more details.
```

