### PR TITLE
+1 link

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1421,6 +1421,7 @@
   <item component="ComponentInfo{com.bilibili.app.in/tv.danmaku.bili.ui.splash.SplashActivity}" drawable="bilibili" name="BiliBili" />
   <item component="ComponentInfo{com.bstar.intl/tv.danmaku.bili.ui.splash.SplashActivity}" drawable="bilibili" name="BiliBili" />
   <item component="ComponentInfo{tv.danmaku.bili/tv.danmaku.bili.MainActivityV2}" drawable="bilibili" name="BiliBili" />
+  <item component="ComponentInfo{tv.danmaku.bilibilihd/tv.danmaku.bili.MainActivityV2}" drawable="bilibili" name="BiliBili" />
   <item component="ComponentInfo{com.bilibili.app.in/tv.danmaku.bili.MainActivityV2}" drawable="bilibili" name="BiliBili" />
   <item component="ComponentInfo{com.bilibili.app.blue/tv.danmaku.bili.MainActivityV2}" drawable="bilibili" name="BiliBili" />
   <item component="ComponentInfo{com.bilibili.comic/com.bilibili.comic.splash.view.activity.SplashActivity}" drawable="bilibili" name="BiliBili" />


### PR DESCRIPTION
## Description
<!-- Please provide a short summary of your pull request. -->
Another variant of Bilibili - I presume it's a TV variant? since it forces landscape mode. However it's still installable on phones as well.

## Icons
<!-- Please specify in the sections below which apps and packages you have worked on. Unnecessary sections can be deleted. -->

### Linked
<!--  New app components for existing icons. -->
BiliBili (`tv.danmaku.bilibilihd` → `bilibili.svg`)  

Technically the app is called "哔哩哔哩HD", (or I guess "BilibiliHD"), however all the other Bilibili variants that have an expanded name (like `com.bilibili.app.blue`, `com.bilibili.comic` and `com.bilibili.bilibililive`) use just "Bilibili" as their names; and I don't feel confident enough in transliterating all of these Chinese names.
So I've made the name in-line with all the other entries: "Bilibili".