### PR TITLE
+4 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -677,6 +677,7 @@
   <item component="ComponentInfo{ro.antenaplay.app/ro.antenaplay.app.ui.MainActivity}" drawable="antenaplay_ro" name="AntenaPlay.ro" />
   <item component="ComponentInfo{de.danoeh.antennapod/de.danoeh.antennapod.activity.MainActivity}" drawable="antennapod" name="AntennaPod" />
   <item component="ComponentInfo{de.danoeh.antennapod/de.danoeh.antennapod.activity.SplashActivity}" drawable="antennapod" name="AntennaPod" />
+  <item component="ComponentInfo{com.logical.minato/dev.lucasnlm.antimine.MainActivity}" drawable="antimine" name="Antimine" />
   <item component="ComponentInfo{dev.lucanlm.antimine/dev.lucasnlm.antimine.main.MainActivity}" drawable="antimine" name="Antimine" />
   <item component="ComponentInfo{dev.lucanlm.antimine/dev.lucasnlm.antimine.splash.SplashActivity}" drawable="antimine" name="Antimine" />
   <item component="ComponentInfo{com.abdurazaaqmohammed.AntiSplit/com.abdurazaaqmohammed.AntiSplit.main.MainActivity}" drawable="antisplit_m" name="AntiSplit M" />
@@ -3820,6 +3821,7 @@
   <item component="ComponentInfo{im.vector.app/im.vector.riotx.features.Alias}" drawable="element" name="Element" />
   <item component="ComponentInfo{io.element.android.x/io.element.android.x.MainActivity}" drawable="element_x" name="Element X" />
   <item component="ComponentInfo{io.element.android.x.debug/io.element.android.x.MainActivity}" drawable="element_x" name="Element X Debug" />
+  <item component="ComponentInfo{io.element.enterprise/io.element.android.x.MainActivity}" drawable="element_x" name="Element Pro" />
   <item component="ComponentInfo{com.elfeedcljsrn/com.elfeedcljsrn.MainActivity}" drawable="elfeed" name="Elfeed" />
   <item component="ComponentInfo{ats.ksa.elite.patient/com.ats.hospital.presenter.ui.activities.SplashActivity}" drawable="elite_hospital" name="Elite Hospital" />
   <item component="ComponentInfo{com.eljur.client/com.eljur.client.feature.splash.view.SplashActivity}" drawable="eljur_student" name="Eljur.Student" />
@@ -9480,6 +9482,7 @@
   <item component="ComponentInfo{com.ddm.activity/com.ddm.activity.ui.MainActivity}" drawable="os_monitor" name="OS Monitor" />
   <item component="ComponentInfo{org.sbaudio.oscope/org.sbaudio.oscope.MainActivity}" drawable="oscilloscope" name="Oscilloscope" />
   <item component="ComponentInfo{de.storchp.opentracks.osmplugin/de.storchp.opentracks.osmplugin.MainActivity}" drawable="osm_dashboard" name="OSM Dashboard" />
+  <item component="ComponentInfo{de.storchp.opentracks.osmplugin.nightly/de.storchp.opentracks.osmplugin.MainActivity}" drawable="osm_dashboard" name="OSM Dashboard" />
   <item component="ComponentInfo{de.storchp.opentracks.osmplugin.offline/de.storchp.opentracks.osmplugin.MainActivity}" drawable="osm_dashboard" name="OSM Dashboard" />
   <item component="ComponentInfo{net.retiolus.osm2gmaps/net.retiolus.osm2gmaps.activities.MainActivity}" drawable="browser" name="osm2gmaps" />
   <item component="ComponentInfo{net.osmand/net.osmand.activities.MainMenuActivity}" drawable="osmand" name="OsmAnd" />
@@ -11106,6 +11109,7 @@
   <item component="ComponentInfo{it.ruppu/it.ruppu.ui.intro.LaunchActivity}" drawable="ruppu" name="Ruppu" />
   <item component="ComponentInfo{com.shub39.rush/com.shub39.rush.MainActivity}" drawable="rush" name="Rush" />
   <item component="ComponentInfo{com.shub39.rush/com.shub39.rush.app.MainActivity}" drawable="rush" name="Rush" />
+  <item component="ComponentInfo{com.shub39.rush.play/com.shub39.rush.MainActivity}" drawable="rush" name="Rush" />
   <item component="ComponentInfo{brownmonster.app.game.rushrally3demo/brownmonster.app.game.rushrally3.RushRally3Activity}" drawable="rush_rally_3_demo" name="Rush Rally 3 Demo" />
   <item component="ComponentInfo{brownmonster.app.game.rushrallyremastereddemo/brownmonster.app.game.rushrallyremastered.RushRallyRemasteredActivity}" drawable="rush_rally_origins_demo" name="Rush Rally Origins Demo" />
   <item component="ComponentInfo{org.dianqk.ruslin/org.dianqk.ruslin.MainActivity}" drawable="ruslin_notes" name="Ruslin Notes" />


### PR DESCRIPTION
## Description
<!-- Please provide a short summary of your pull request. -->
Additional variants of apps already present in Lawnicons.

## Icons
<!-- Please specify in the sections below which apps and packages you have worked on. Unnecessary sections can be deleted. -->

### Linked
<!--  New app components for existing icons. -->
Plainly Play Store variants:
- [Antimine](https://play.google.com/store/apps/details?id=com.logical.minato) (`com.logical.minato` → `antimine.svg`)  
- [Rush](https://play.google.com/store/apps/details?id=com.shub39.rush.play) (`com.shub39.rush.play` → `rush.svg`)  

Pro/Enterprise variant:
- [Element Pro](https://play.google.com/store/apps/details?id=io.element.enterprise) (`io.element.enterprise` → `element_x.svg`)  

Nightly variant: 
- [OSM Dashboard](https://fdroid.storchp.de/fdroid/repo/) (`de.storchp.opentracks.osmplugin.nightly` → `osm_dashboard.svg`)  
