### PR TITLE
+5 links, 1 changed link

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1784,7 +1784,6 @@
   <item component="ComponentInfo{com.englishscore/com.englishscore.MainActivity}" drawable="british_council_englishscore" name="British Council EnglishScore" />
   <item component="ComponentInfo{org.bromite.bromite/org.chromium.chrome.browser.ChromeTabbedActivity}" drawable="bromite" name="Bromite" />
   <item component="ComponentInfo{org.bromite.bromite/com.google.android.apps.chrome.Main}" drawable="bromite" name="Bromite" />
-  <item component="ComponentInfo{org.bromite.chromium/com.google.android.apps.chrome.Main}" drawable="bromite" name="Bromite" />
   <item component="ComponentInfo{org.bromite.bromite.dev/com.google.android.apps.chrome.Main}" drawable="google_chrome_dev" name="Bromite Dev" />
   <item component="ComponentInfo{org.godotengine.brotato/com.godot.game.GodotApp}" drawable="brotato" name="Brotato" />
   <item component="ComponentInfo{com.brotato.shooting.survivors.action.roguelike/com.nano.privacy.CatchActivity}" drawable="brotato" name="Brotato" />
@@ -2570,6 +2569,7 @@
   <item component="ComponentInfo{com.ilixa.chroma/com.ilixa.chroma.ChromaActivity}" drawable="chroma_lab" name="Chroma Lab" />
   <item component="ComponentInfo{com.google.chromeremotedesktop/com.google.remoting.androidwrapper.MainActivity}" drawable="chrome_remote_desktop" name="Chrome Remote Desktop" />
   <item component="ComponentInfo{com.google.chromeremotedesktop/org.chromium.chromoting.Chromoting}" drawable="chrome_remote_desktop" name="Chrome Remote Desktop" />
+  <item component="ComponentInfo{org.bromite.chromium/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Chromium" />
   <item component="ComponentInfo{org.chromium.chrome.stable/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Chromium" />
   <item component="ComponentInfo{org.chromium.chrome/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Chromium" />
   <item component="ComponentInfo{org.chromium.chrome/org.google.android.apps.chrome.Main}" drawable="google_chrome" name="Chromium" />
@@ -14107,6 +14107,7 @@
   <item component="ComponentInfo{com.frontier_silicon.fsirc.dok2/com.frontier_silicon.fsirc.dok2.SplashScreenActivity}" drawable="undok" name="UNDOK" />
   <item component="ComponentInfo{juloo.keyboard2/juloo.keyboard2.LauncherActivity}" drawable="unexpected_keyboard" name="Unexpected Keyboard" />
   <item component="ComponentInfo{org.ungoogled.chromium.stable/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Ungoogled Chromium" />
+  <item component="ComponentInfo{org.ungoogled.chromium.extensions.stable/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Ungoogled Chromium Extensions" />
   <item component="ComponentInfo{net.pluservice.unicoc/net.pluservice.unicoc.MainActivity}" drawable="unico" name="Unico" />
   <item component="ComponentInfo{com.unicredit/com.unicredit.MainActivity}" drawable="unicredit" name="UniCredit" />
   <item component="ComponentInfo{hr.asseco.android.jimba.mUCI.ro/hr.asseco.android.muci.ae.prelogin.SplashScreenActivity}" drawable="unicredit" name="UniCredit" />
@@ -14472,6 +14473,7 @@
   <item component="ComponentInfo{com.vimeo.android.videoapp/com.vimeo.android.videoapp.launch.LaunchActivity}" drawable="vimeo" name="Vimeo" />
   <item component="ComponentInfo{net.petafuel.mobile.vimpay/net.petafuel.mobile.vimpay.StartActivity}" drawable="vimpay" name="VIMpay" />
   <item component="ComponentInfo{it.vfsfitvnm.vimusic/it.vfsfitvnm.vimusic.MainActivity}" drawable="vimusic" name="ViMusic" />
+  <item component="ComponentInfo{it.vfsfitvnm.vimusic.nightly/it.vfsfitvnm.vimusic.MainActivity}" drawable="vimusic" name="ViMusic Nightly" />
   <item component="ComponentInfo{fr.vinted/com.vinted.activities.MDActivity}" drawable="vinted" name="Vinted" />
   <item component="ComponentInfo{com.esethnet.vinty/com.esethnet.vinty.LicenseActivity}" drawable="vinty_icons" name="Vinty Icons" />
   <item component="ComponentInfo{com.poupa.vinylmusicplayer/com.poupa.vinylmusicplayer.ui.activities.MainActivity}" drawable="vinyl_music_player" name="Vinyl Music Player" />
@@ -14510,6 +14512,7 @@
   <item component="ComponentInfo{com.snowcorp.vita/com.snow.stuckyi.presentation.splash.SplashActivity}" drawable="vita" name="VITA" />
   <item component="ComponentInfo{org.vita3k.emulator/org.vita3k.emulator.Emulator}" drawable="vita3k" name="Vita3K" />
   <item component="ComponentInfo{app.vitune.android/app.vitune.android.MainActivity}" drawable="vitune" name="ViTune" />
+  <item component="ComponentInfo{app.vitune.android.nightly/app.vitune.android.MainActivity}" drawable="vitune" name="ViTune Nightly" />
   <item component="ComponentInfo{com.viu.phone/com.viu.phone.ui.activity.WelcomeActivity}" drawable="viu" name="Viu" />
   <item component="ComponentInfo{com.vuclip.viu/com.viu.phone.ui.activity.WelcomeActivity}" drawable="viu" name="Viu" />
   <item component="ComponentInfo{com.vuclip.viu/com.vuclip.viu.ui.screens.MainActivity}" drawable="viu" name="Viu" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -14106,7 +14106,9 @@
   <item component="ComponentInfo{nyc.underway.underway/nyc.underway.underway.screens.MtaMapScreen.MtaMapActivity}" drawable="underway" name="Underway" />
   <item component="ComponentInfo{com.frontier_silicon.fsirc.dok2/com.frontier_silicon.fsirc.dok2.SplashScreenActivity}" drawable="undok" name="UNDOK" />
   <item component="ComponentInfo{juloo.keyboard2/juloo.keyboard2.LauncherActivity}" drawable="unexpected_keyboard" name="Unexpected Keyboard" />
+  <item component="ComponentInfo{org.ungoogled.chromium/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Ungoogled Chromium" />
   <item component="ComponentInfo{org.ungoogled.chromium.stable/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Ungoogled Chromium" />
+  <item component="ComponentInfo{org.ungoogled.chromium.extensions/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Ungoogled Chromium Extensions" />
   <item component="ComponentInfo{org.ungoogled.chromium.extensions.stable/com.google.android.apps.chrome.Main}" drawable="google_chrome" name="Ungoogled Chromium Extensions" />
   <item component="ComponentInfo{net.pluservice.unicoc/net.pluservice.unicoc.MainActivity}" drawable="unico" name="Unico" />
   <item component="ComponentInfo{com.unicredit/com.unicredit.MainActivity}" drawable="unicredit" name="UniCredit" />


### PR DESCRIPTION
## Description
<!-- Please provide a short summary of your pull request. -->
Description included below alongside relevant components.
## Icons
<!-- Please specify in the sections below which apps and packages you have worked on. Unnecessary sections can be deleted. -->

### Linked
<!--  New app components for existing icons. -->
[wchen342](https://github.com/wchen342/ungoogled-chromium-android)'s build of Ungoogled Chromium:
- Ungoogled Chromium (`org.ungoogled.chromium` → `google_chrome.svg`)  

The short-lived Ungoogled Chromium variant with support for extensions:
- Ungoogled Chromium Extensions ([by wchen342](https://github.com/wchen342/ungoogled-chromium-android/releases?q=Extensions)) (`org.ungoogled.chromium.extensions` → `google_chrome.svg`)  
- Ungoogled Chromium Extensions ([by ungoogled-software](https://github.com/ungoogled-software/ungoogled-chromium-android/releases?q=Extensions)) (`org.ungoogled.chromium.extensions.stable` → `google_chrome.svg`)  

From the [ViTune](https://github.com/25huizengek1/ViTune/) creator's [repo](https://repo.vitune.app/):
- ViMusic Nightly (`it.vfsfitvnm.vimusic.nightly` → `vimusic.svg`)  
- ViTune Nightly (`app.vitune.android.nightly` → `vitune.svg`)  

### Changed link and renamed app
<!--  Outdated icons that you've updated. -->
- `org.bromite.chromium` (changed `drawable="bromite" name="Bromite"` to `drawable="google_chrome" name="Chromium"`)  
Quoting the description in its [F-Droid repo](https://www.bromite.org/fdroid):
> Vanilla Chromium built side-by-side with Bromite

So it's Chromium, not Bromite.