### PR TITLE
fix: Fix icon list ignoring some unthemed icons

### DIFF
--- a/app/src/main/kotlin/app/lawnchair/lawnicons/repository/IconRepository.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/repository/IconRepository.kt
@@ -54,7 +54,6 @@ class IconRepositoryImpl @Inject constructor(application: Application) : IconRep
             _searchedIconInfoModel.value = _iconInfoModel.value
 
             val systemPackageList = application.getSystemIconInfoAppfilter()
-                .associateBy { it.label }.values
                 .sortedBy { it.label.lowercase() }
             getIconRequestList(systemPackageList)
         }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the fix and context. -->  

This PR attempts to resolve #2691, by removing the `.associateBy {}` logic.

TODO: do proper testing to see if this actually resolves this PR
