### PR TITLE
Removed the "discussion" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_discussion.yml
+++ b/.github/ISSUE_TEMPLATE/general_discussion.yml
@@ -1,6 +1,5 @@
-name: General Discussion
+name: General discussion
 description: Discuss something related to Lawnicons.
-labels: [discussion]
 body:
   - type: textarea
     id: question


### PR DESCRIPTION
To make the Issues page cleaner. We also discussed changes to the issue assessment process.