### PR TITLE
Remove description from icon addition PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/icon_addition.md
@@ -5,9 +5,6 @@
      In other cases, choose something else to avoid confusion.
      Don't use "+ 1 icon" because the "+ " will be parsed as an indent. -->
 
-## Description
-<!-- Please provide a short summary of your pull request. -->
-
 ## Icons
 <!-- Please specify in the sections below which apps and packages you have worked on.
      Unnecessary sections can be deleted. -->


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, relevant motivation and context. -->  

I would suggest removing the description heading from the icon addition PR template because as it does not seem to serve any purpose. It is usually used to put text that is just repeating what is in the title, or just ignored and not used at all. If people need to add extra information to the PR they can do so themselves easily.


