### PR TITLE
+3 links, +1 rename

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -6243,6 +6243,7 @@
   <item component="ComponentInfo{imagetopdf.pdfmaker.pdfconverter.pdfreader/imagetopdf.pdfmaker.pdfconverter.pdfreader.ui.I2WelcomeActivity}" drawable="generic_pdf_file" name="Image to PDF" />
   <item component="ComponentInfo{com.vidmar.pti/com.vidmar.pti.SplashScreen}" drawable="generic_pdf_square" name="Image to PDF" />
   <item component="ComponentInfo{pdf.converter.imagetopdf.jpgtopdf.createpdf/pdf.converter.imagetopdf.jpgtopdf.createpdf.pdfviewer.onemb.imagetopdf.ui.splash.SplashActivity}" drawable="generic_pdf_file" name="Image to PDF Converter" />
+  <item component="ComponentInfo{ru.tech.imageresizershrinker/com.t8rin.imageresizershrinker.app.presentation.AppActivity}" drawable="image_toolbox" name="Image Toolbox" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.app.presentation.AppActivity}" drawable="image_toolbox" name="Image Toolbox" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.presentation.AppActivity}" drawable="image_toolbox" name="Image Toolbox" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.presentation.MainActivity}" drawable="image_toolbox" name="Image Toolbox" />
@@ -6413,6 +6414,7 @@
   <item component="ComponentInfo{dev.zwander.installwithoptions/dev.zwander.installwithoptions.MainActivity}" drawable="install_with_options" name="Install with Options" />
   <item component="ComponentInfo{com.rosan.installer.x/com.rosan.installer.ui.activity.SettingsActivity}" drawable="installerx" name="InstallerX" />
   <item component="ComponentInfo{com.rosan.installer.x.revived/com.rosan.installer.ui.activity.SettingsActivity}" drawable="installerx" name="InstallerX Revived" />
+  <item component="ComponentInfo{com.rosan.installer.x.revived/com.rosan.installer.ui.activity.LauncherAlias}" drawable="installerx" name="InstallerX Revived" />
   <item component="ComponentInfo{in.swiggy.android.instamart/in.swiggy.android.HomeIcon}" drawable="swiggy" name="Instamart" />
   <item component="ComponentInfo{com.instander.android/com.instagram.android.activity.MainTabActivity}" drawable="instander" name="Instander" />
   <item component="ComponentInfo{com.instander.android/com.instander.android.activity.MainTabActivity}" drawable="instander" name="Instander" />
@@ -9665,7 +9667,8 @@
   <item component="ComponentInfo{widget.dd.com.overdrop.pro/widget.dd.com.overdrop.activity.SplashScreenActivity}" drawable="overdrop_pro" name="Overdrop Pro" />
   <item component="ComponentInfo{widget.dd.com.overdrop.pro/widget.dd.com.overdrop.pro.MainActivity}" drawable="overdrop_pro" name="Overdrop Pro" />
   <item component="ComponentInfo{cloud.pablos.overload/cloud.pablos.overload.ui.MainActivity}" drawable="overload" name="Overload" />
-  <item component="ComponentInfo{com.marotidev.Overmorrow/com.example.overmorrow.MainActivity}" drawable="overmorrow_weather" name="Overmorrow weather" />
+  <item component="ComponentInfo{com.marotidev.Overmorrow/com.example.overmorrow.MainActivity}" drawable="overmorrow_weather" name="Overmorrow" />
+  <item component="ComponentInfo{com.marotidev.Overmorrow/com.marotidev.overmorrow.MainActivity}" drawable="overmorrow_weather" name="Overmorrow" />
   <item component="ComponentInfo{com.mutaeb.OVFEditor/com.mutaeb.OVFEditor.MainActivity}" drawable="ovf_editor" name="OVF Editor" />
   <item component="ComponentInfo{nl.skywave.ovinfo/nl.ovapi.ovinfo.MainActivity}" drawable="ovinfo" name="OVinfo" />
   <item component="ComponentInfo{ovo.id/ovo.id.auth.activity.LandingActivity}" drawable="ovo" name="OVO" />


### PR DESCRIPTION
<!-- Title example: "+1 icon, +2 links, +3 icon updates".
     +1 icon = +1 brand new icon (related links aren't considered).
     +2 links = +2 missing app components for existing icons.
     +3 icon updates = redesign of 3 existing icons.
     In other cases, choose something else to avoid confusion.
     Don't use "+ 1 icon" because the "+ " will be parsed as an indent. -->

## Icons
<!-- Please specify in the sections below which apps and packages you have worked on.
     Unnecessary sections can be deleted. -->

### Linked
<!--  New app components for existing icons. -->

- Image Toolbox (`ru.tech.imageresizershrinker` → `com.t8rin.imageresizershrinker.app.presentation.AppActivity`)  
- InstallerX Revived (`com.rosan.installer.x.revived` → `com.rosan.installer.ui.activity.LauncherAlias`)  
- Overmorrow (`com.marotidev.Overmorrow` → `com.marotidev.overmorrow.MainActivity`)  

### Renamed
- `Overmorrow weather` -> `Overmorrow`
(Not sure why "weather" was added to the name to begin with, let alone in lowercase, since the app and its GitHub always refers to itself as just Overmorrow)