### PR TITLE
+5 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -3671,6 +3671,11 @@
   <item component="ComponentInfo{com.android.providers.downloads.ui/com.android.providers.downloads.ui.TrampolineActivity}" drawable="generic_download_arrow" name="Downloads" />
   <item component="ComponentInfo{com.android.providers.downloads.ui/.DownloadList}" drawable="generic_download_arrow" name="Downloads" />
   <item component="ComponentInfo{de.dpd.mobile/com.dpd.navigator.ui.splashscreen.SplashScreenActivity}" drawable="dpd" name="DPD" />
+  <item component="ComponentInfo{hu.dpd.mobile/hu.dpd.mobile.MainActivity}" drawable="dpd" name="DPD" />
+  <item component="ComponentInfo{pl.com.dpd.mobile.app.release/pl.com.dpd.mobile.app.launchscreens.ui.SplashScreenActivity}" drawable="dpd" name="DPD" />
+  <item component="ComponentInfo{ru.dpd.recipient/ru.dpd.features.launch.AppActivity}" drawable="dpd" name="DPD" />
+  <item component="ComponentInfo{com.dpd.driver/com.dpd.driver.MainActivity}" drawable="dpd" name="DPD Driver" />
+  <item component="ComponentInfo{com.ignitix.mda/com.ignitix.activity.InitActivity}" drawable="dpd" name="DPD Driver" />
   <item component="ComponentInfo{com.ansangha.drdriving/com.ansangha.drdriving.DrDrivingActivity}" drawable="dr_driving" name="Dr. Driving" />
   <item component="ComponentInfo{com.drweb.pro.market/com.drweb.ui.main.MainActivity}" drawable="dr_web" name="Dr.Web" />
   <item component="ComponentInfo{com.drweb/com.drweb.ui.main.MainActivity}" drawable="dr_web" name="Dr.Web Security Space" />


### PR DESCRIPTION
## Icons
<!-- Please specify in the sections below which apps and packages you have worked on.
     Unnecessary sections can be deleted. -->
Linking a bunch of regional DPD app variants.
Their naming scheme varies (DPD, DPD Mobile, DPD PickApp), but they all seem to be the consumer-facing app, so I named them just DPD.
As for `com.dpd.driver` its actual name is "DPD Saturn", but it seems to just be a fancy name for delivery driver-focused app (it doesn't seem to be related to the [Saturn](https://en.wikipedia.org/wiki/Saturn_(store)) retailer). `com.ignitix.mda` seems to serve the same purpose for a different region, and it is actually called "DPD Driver", so I called both of them "DPD Driver" for the sake of clarity of what they are. 

### Linked
<!--  New app components for existing icons. -->
DPD (`hu.dpd.mobile` → `dpd.svg`)  
DPD (`pl.com.dpd.mobile.app.release` → `dpd.svg`)  
DPD (`ru.dpd.recipient` → `dpd.svg`)  
DPD Driver (`com.dpd.driver` → `dpd.svg`)  
DPD Driver (`com.ignitix.mda` → `dpd.svg`)  

