### PR TITLE
Shorter PR stale period

### DIFF
--- a/.github/workflows/close_stale_prs.yml
+++ b/.github/workflows/close_stale_prs.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          stale-pr-message: This PR is now marked as stale due to 2 weeks of inactivity. Please update or comment to keep it active. Otherwise, it will be closed in a week.
+          stale-pr-message: This PR is now marked as stale due to 2 weeks of inactivity. Please apply the suggested changes or comment to keep it active. Otherwise, it will be closed in a week.
           close-pr-message: Closed due to inactivity.
           days-before-pr-stale: 14
           days-before-pr-close: 7


### PR DESCRIPTION
Contributor don't finish the PR they're dragging out, so it makes sense to remove such PRs promptly.