### PR TITLE
Time-limited icon requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ Whether you want to work on icons or solve development issues, please refer to o
 
 `Open Lawnicons → Tap "Request icons" → Select and request icons`
 
-Android devs can request support for their app via a related issue.
+Icon requests are time-limited. A 1-week icon request period opens at every thousand-icon milestone. Android devs can request support for their app via a related issue.


### PR DESCRIPTION
For many reasons, it makes sense to limit icon requests, but it makes little sense in disabling them so that people can request trending icons.