### PR TITLE
+17 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -16225,6 +16225,22 @@
   <item component="ComponentInfo{app.revanced.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube_revanced" name="YouTube ReVanced" />
   <item component="ComponentInfo{app.revanced.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube_revanced" name="YouTube ReVanced" />
   <item component="ComponentInfo{app.revanced.android.youtube/com.google.android.youtube.app.honeycomb.ShellHomeActivity}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_original_1}" drawable="youtube" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_original_2}" drawable="youtube" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_original_3}" drawable="youtube" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_original_4}" drawable="youtube" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_rounded_1}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_rounded_2}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_rounded_3}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_rounded_4}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_minimal_1}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_minimal_2}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_minimal_3}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_minimal_4}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_scaled_1}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_scaled_2}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_scaled_3}" drawable="youtube_revanced" name="YouTube ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.youtube/app.revanced.android.youtube.revanced_scaled_4}" drawable="youtube_revanced" name="YouTube ReVanced" />
   <item component="ComponentInfo{anddea.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube" name="YouTube Revanced" />
   <item component="ComponentInfo{com.rvx.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="revanced_extended" name="Youtube Revanced Extended" />
   <item component="ComponentInfo{app.rvx.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="revanced_extended" name="YouTube ReVanced Extended" />


### PR DESCRIPTION
## Icons
<!-- Please specify in the sections below which apps and packages you have worked on.
     Unnecessary sections can be deleted. -->
363e446
Linking the UC Browser icon to the Chinese variant of the app.

88ee1ca
YT Revanced update introduced customization of the app's icon and displayed name.
There's 4 different icons and 4 different names, totaling 16 new package activities. 4 of them use the default Youtube logo, 12 of them use variants of the Revanced logo. I assigned them accordingly.

Below is an image comparison of the 4 icon variants, respectively to their activities: 
`original`, `rounded`, `minimal` and `scaled`.
<img width="800" height="300" alt="image" src="https://github.com/user-attachments/assets/45f4274a-4728-4031-90a8-695db4f56dce" />


### Linked
<!--  New app components for existing icons. -->
UC Browser (`com.UCMobile` → `uc_browser.svg`)  
**4x** YouTube ReVanced (`app.revanced.android.youtube` → `youtube.svg`)  
**12x** YouTube ReVanced (`app.revanced.android.youtube` → `youtube_revanced.svg`)  