### PR TITLE
+52 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -79,6 +79,7 @@
   <item component="ComponentInfo{com.a0soft.gphone.acc.free/com.a0soft.gphone.acc.free.MainWnd}" drawable="_1tap_cleaner" name="1Tap Cleaner" />
   <item component="ComponentInfo{one.track.app/com.onetrackapp.MainActivity}" drawable="_1track" name="1Track" />
   <item component="ComponentInfo{lol.onevone/com.playtika.unity.plugincomposition.ComposeActivity}" drawable="_1v1_lol" name="1v1.LOL" />
+  <item component="ComponentInfo{lol.onevone/com.playtika.unity.plugincomposition.CompositeActivity}" drawable="_1v1_lol" name="1v1.LOL" />
   <item component="ComponentInfo{com.handmark.expressweather/com.handmark.expressweather.ui.activities.MainActivity}" drawable="_1weather" name="1Weather" />
   <item component="ComponentInfo{com.handmark.expressweather/com.oneweather.app.MainActivity}" drawable="_1weather" name="1Weather" />
   <item component="ComponentInfo{com.ction.playergames/com.ction.playergames.RunnerActivity}" drawable="_2_3_4_player_mini_games" name="2 3 4 Player Mini Games" />
@@ -102,6 +103,8 @@
   <item component="ComponentInfo{com.excelliance.multiaccount/com.yqox.u4t.epr54wtc.rlv72yj10anaa}" drawable="_2accounts" name="2Accounts" />
   <item component="ComponentInfo{com.excelliance.multiaccount/com.excelliance.kxqp.ui.StartActivity}" drawable="_2accounts" name="2Accounts" />
   <item component="ComponentInfo{be.tweedehands.m/nl.marktplaats.android.features.homepage.SpringboardActivity}" drawable="_2dehands" name="2dehands" />
+  <item component="ComponentInfo{be.tweedehands.m/com.horizon.android.feature.feeds.homepage.SpringboardActivity}" drawable="_2dehands" name="2dehands" />
+  <item component="ComponentInfo{be.tweedehands.m/com.horizon.android.feature.homepage.SpringboardActivity}" drawable="_2dehands" name="2dehands" />
   <item component="ComponentInfo{com.twofasapp/com.twofasapp.start.ui.start.StartActivity}" drawable="_2fa_authenticator_2fas" name="2FA Authenticator (2FAS)" />
   <item component="ComponentInfo{com.twofasapp/com.twofasapp.features.start.StartActivity}" drawable="_2fa_authenticator_2fas" name="2FA Authenticator (2FAS)" />
   <item component="ComponentInfo{com.twofasapp/com.twofasapp.ui.main.StartActivity}" drawable="_2fa_authenticator_2fas" name="2FA Authenticator (2FAS)" />
@@ -547,6 +550,7 @@
   <item component="ComponentInfo{deltazero.amarok.foss/deltazero.amarok.launcher.default}" drawable="amarok" name="Amarok" />
   <item component="ComponentInfo{deltazero.amarok.foss/deltazero.amarok.ui.MainActivity}" drawable="amarok" name="Amarok" />
   <item component="ComponentInfo{au.com.amaysim.android/au.com.amaysim.poc.android.activities.MainActivity}" drawable="amaysim" name="amaysim" />
+  <item component="ComponentInfo{au.com.amaysim.android/au.com.amaysim.poc.android.MainActivity}" drawable="amaysim" name="amaysim" />
   <item component="ComponentInfo{com.amaze.filemanager/com.amaze.filemanager.activities.MainActivity}" drawable="amaze_file_manager" name="Amaze File Manager" />
   <item component="ComponentInfo{com.amaze.filemanager/com.amaze.filemanager.ui.activities.MainActivity}" drawable="amaze_file_manager" name="Amaze File Manager" />
   <item component="ComponentInfo{com.amaze.fileutilities/com.amaze.fileutilities.home_page.MainActivity}" drawable="amaze_file_utilities" name="Amaze File Utilities" />
@@ -652,6 +656,7 @@
   <item component="ComponentInfo{com.dokeraj.androtainer/com.dokeraj.androtainer.MainActiviy}" drawable="androtainer" name="AndroTainer" />
   <item component="ComponentInfo{org.angelauramc.amethyst.debug/net.kdt.pojavlaunch.TestStorageActivity}" drawable="angel_aura_amethyst" name="Angel Aura Amethyst" />
   <item component="ComponentInfo{com.msf.angelmobile/com.angelbroking.spark.splash.SplashActivity}" drawable="angel_one" name="Angel One" />
+  <item component="ComponentInfo{com.msf.angelmobile/com.angelbroking.spark.common.MainActivity}" drawable="angel_one" name="Angel One" />
   <item component="ComponentInfo{com.anghami/com.anghami.activities.SplashActivity_}" drawable="anghami" name="Anghami" />
   <item component="ComponentInfo{com.angkas.passenger/com.whitewidget.angkas.customer.splash.SplashActivity}" drawable="angkas" name="Angkas" />
   <item component="ComponentInfo{com.angkas.passenger/com.whitewidget.angkas.customer.floodgatesplash.FloodgateSplashActivity}" drawable="angkas" name="Angkas" />
@@ -704,6 +709,7 @@
   <item component="ComponentInfo{com.logical.minato/dev.lucasnlm.antimine.MainActivity}" drawable="antimine" name="Antimine" />
   <item component="ComponentInfo{dev.lucanlm.antimine/dev.lucasnlm.antimine.main.MainActivity}" drawable="antimine" name="Antimine" />
   <item component="ComponentInfo{dev.lucanlm.antimine/dev.lucasnlm.antimine.splash.SplashActivity}" drawable="antimine" name="Antimine" />
+  <item component="ComponentInfo{com.logical.minato/dev.lucasnlm.antimine.main.MainActivity}" drawable="antimine" name="Antimine" />
   <item component="ComponentInfo{com.abdurazaaqmohammed.AntiSplit/com.abdurazaaqmohammed.AntiSplit.main.MainActivity}" drawable="antisplit_m" name="AntiSplit M" />
   <item component="ComponentInfo{com.JindoBlu.Antistress/com.unity3d.player.UnityPlayerActivity}" drawable="antistress" name="Antistress" />
   <item component="ComponentInfo{yio.tro.onliyoy/yio.tro.onliyoy.AndroidLauncher}" drawable="antiyoy_online" name="Antiyoy Online" />
@@ -719,6 +725,7 @@
   <item component="ComponentInfo{com.antutu.ABenchMark/com.example.ABenchMark.ABenchMarkStart}" drawable="antutu_benchmark" name="AnTuTu Benchmark" />
   <item component="ComponentInfo{com.antutu.ABenchMark/org.sumi.sumi_emu.ui.main.MainActivity}" drawable="antutu_benchmark" name="AnTuTu Benchmark" />
   <item component="ComponentInfo{com.anxcye.anx_reader/com.anxcye.anx_reader.MainActivity}" drawable="anx_reader" name="Anx Reader" />
+  <item component="ComponentInfo{com.anxcye.anx_reader/com.example.anx_reader.MainActivity}" drawable="anx_reader" name="Anx Reader" />
   <item component="ComponentInfo{com.anydo/com.anydo.activity.SplashActivity}" drawable="any_do" name="Any.do" />
   <item component="ComponentInfo{com.cisco.anyconnect.vpn.android.avf/com.cisco.anyconnect.ui.PrimaryActivity}" drawable="anyconnect" name="AnyConnect" />
   <item component="ComponentInfo{com.anydesk.anydeskandroid/com.anydesk.anydeskandroid.gui.activity.MainActivity}" drawable="anydesk" name="AnyDesk" />
@@ -741,6 +748,7 @@
   <item component="ComponentInfo{com.android.diales/com.android.diales.main.impl.MainActivity}" drawable="generic_dialer" name="AOSP Dialer" />
   <item component="ComponentInfo{mnn.Android/com.apnews.app.ui.splash.StartupActivity}" drawable="ap_news" name="AP News" />
   <item component="ComponentInfo{mnn.Android/com.apnews.app.activity.MainActivity}" drawable="ap_news" name="AP News" />
+  <item component="ComponentInfo{mnn.Android/com.apnews.app.ui.splash.AppChecksActivity}" drawable="ap_news" name="AP News" />
   <item component="ComponentInfo{me.bmax.apatch/me.bmax.apatch.ui.MainActivity}" drawable="apatch" name="APatch" />
   <item component="ComponentInfo{pl.m4x.sphinx_customer_android_mobile_app_v2/pl.m4x.sphinx_customer_android_mobile_app_v2.MainActivity}" drawable="aperitif" name="Aperitif" />
   <item component="ComponentInfo{com.ea.gp.apexlegendsmobilefps/com.epicgames.ue4.GameActivity}" drawable="apex_legends" name="Apex Legends" />
@@ -1006,6 +1014,7 @@
   <item component="ComponentInfo{com.asus.soundrecorder/com.asus.soundrecorder.AsusRecorder}" drawable="generic_voice_recorder_microphone" name="ASUS Sound Recorder" />
   <item component="ComponentInfo{com.asus.supernote/com.asus.supernote.picker.NoteBookPickerActivity}" drawable="blacknote" name="ASUS SuperNote" />
   <item component="ComponentInfo{com.asus.themeapp/com.asus.themeapp.ThemeAppActivityAlias}" drawable="asus_themes" name="ASUS Themes" />
+  <item component="ComponentInfo{com.asus.themeapp/com.asus.themeapp.ThemeAppActivity}" drawable="asus_themes" name="ASUS Themes" />
   <item component="ComponentInfo{com.asus.tips/com.asus.tips.TipListActivity}" drawable="asus_tips" name="ASUS Tips" />
   <item component="ComponentInfo{com.asus.weathertime/com.asus.weathertime.WeatherTimeSettings}" drawable="asus_weather" name="ASUS Weather" />
   <item component="ComponentInfo{com.ecareme.asuswebstorage/com.ecareme.asuswebstorage.view.common.SplashActivity}" drawable="asus_webstorage" name="ASUS WebStorage" />
@@ -1281,6 +1290,7 @@
   <item component="ComponentInfo{com.grppl.android.shell.BOS/co.uk.apptivation.nga.library.application.GrappleActivity}" drawable="bank_of_scot" name="Bank of Scot" />
   <item component="ComponentInfo{no.vipps.bankid/no.vipps.bankid.launcher_ae69bf386f0435245ec790ab9acca249c7607e2f3228a1af32d76c1a023a05ab}" drawable="bankid" name="BankID" />
   <item component="ComponentInfo{no.vipps.bankid/no.vipps.bankid.launcher_b4b0bffff2e769b7f96b2d72abb8ecdcc5e1a8f36c79788ddd4d9d0cc98020f5}" drawable="bankid" name="BankID" />
+  <item component="ComponentInfo{no.vipps.bankid/no.vipps.bankid.launcher_dcbbc7676b75102e15c11476fdbfa662bbd7b945dcdf092065517232b5e9e0aa}" drawable="bankid" name="BankID" />
   <item component="ComponentInfo{com.bankid.bus/com.bankid.bus.activities.InitActivity}" drawable="bankid_security" name="BankID Security" />
   <item component="ComponentInfo{subsembly.banking/subsembly.superwallet.StartActivity}" drawable="banking4" name="Banking4" />
   <item component="ComponentInfo{com.bankkart.mobil/com.bankkart.mobil.SplashActivity}" drawable="bankkart" name="Bankkart" />
@@ -1570,6 +1580,7 @@
   <item component="ComponentInfo{com.microsoft.bing/com.microsoft.sapphire.app.main.SapphireMainActivity}" drawable="bing" name="Bing" />
   <item component="ComponentInfo{com.microsoft.mobileexperiences.bing/com.microsoft.clients.bing.app.MainActivity}" drawable="bing" name="Bing" />
   <item component="ComponentInfo{com.microsoft.bingintl/com.microsoft.sapphire.app.main.SapphireMainActivity}" drawable="bing" name="Bing International" />
+  <item component="ComponentInfo{com.microsoft.bingintl/com.microsoft.sapphire.app.main.SplashActivity}" drawable="bing" name="Bing International" />
   <item component="ComponentInfo{com.microsoft.android.bingplaces/md5414ae3c27ff7131caef7ef9b90ad5e5b.MainActivity}" drawable="bing" name="Bing places for business" />
   <item component="ComponentInfo{pro.bingbon.app/pro.bingintl.ui.activity.MainActivity}" drawable="bingx" name="BingX" />
   <item component="ComponentInfo{com.biopassport.rkzu/com.biopassport.rkzu.MainActivity}" drawable="biopassport" name="Biopassport" />
@@ -2141,7 +2152,9 @@
   <item component="ComponentInfo{com.radinc.csharpshell/crc6435a96f15045e045c.MainActivity}" drawable="c_sharp_shell_dot_net_ide" name="C# Shell .NET IDE" />
   <item component="ComponentInfo{com.radinc.csharpshell/crc6483cd2bca369317c1.MainActivity}" drawable="c_sharp_shell_dot_net_ide" name="C# Shell .NET IDE" />
   <item component="ComponentInfo{com.example.c001apk.compose/.ui.main.MainActivity}" drawable="c001apk" name="c001apk-compose" />
+  <item component="ComponentInfo{com.example.c001apk.compose/com.example.c001apk.compose.ui.main.MainActivity}" drawable="c001apk" name="c001apk-compose" />
   <item component="ComponentInfo{com.example.c001apk.flutter/.MainActivity}" drawable="c001apk" name="c001apk-flutter" />
+  <item component="ComponentInfo{com.example.c001apk.flutter/com.example.c001apk.flutter.MainActivity}" drawable="c001apk" name="c001apk-flutter" />
   <item component="ComponentInfo{de.c24.bankapp/de.check24.c24.MainActivity}" drawable="c24" name="C24" />
   <item component="ComponentInfo{de.c24.bankapp/de.check24.c24.pages.startup.SplashScreenActivity}" drawable="c24" name="C24" />
   <item component="ComponentInfo{de.c24.bankapp/de.check24.c24.pages.startup.InitialSplashScreenActivity}" drawable="c24" name="C24" />
@@ -2518,6 +2531,7 @@
   <item component="ComponentInfo{com.canva.editor/com.canva.app.editor.splash.SplashActivity}" drawable="canva" name="Canva" />
   <item component="ComponentInfo{com.canva.editor/com.google.android.archive.ReactivateActivity}" drawable="canva" name="Canva" />
   <item component="ComponentInfo{com.canva.editor.samsung/com.canva.app.editor.splash.SplashActivity}" drawable="canva" name="Canva" />
+  <item component="ComponentInfo{cn.canva.editor/com.canva.app.editor.splash.DataConsentSplashActivity}" drawable="canva" name="Canva" />
   <item component="ComponentInfo{com.instructure.candroid/com.instructure.student.activity.NavigationActivity}" drawable="canvas_student" name="Canvas Student" />
   <item component="ComponentInfo{com.instructure.candroid/com.instructure.candroid.activity.LoginActivity}" drawable="canvas_student" name="Canvas Student" />
   <item component="ComponentInfo{com.instructure.candroid/com.instructure.student.activity.LoginActivity}" drawable="canvas_student" name="Canvas Student" />
@@ -2841,6 +2855,7 @@
   <item component="ComponentInfo{com.citymapper.app.release/com.citymapper.app.MainActivity}" drawable="citymapper" name="Citymapper" />
   <item component="ComponentInfo{com.citymapper.app.release/com.citymapper.app.MainActivity_Rainbow}" drawable="citymapper" name="Citymapper" />
   <item component="ComponentInfo{es.aeat.pin24h/es.aeat.pin24h.presentation.activities.splash.SplashActivity}" drawable="clave" name="Cl@ve" />
+  <item component="ComponentInfo{es.aeat.pin24h/es.aeat.pin24h.presentation.activities.main.MainActivity}" drawable="clave" name="Cl@ve" />
   <item component="ComponentInfo{com.claroColombia.contenedor/com.speedymovil.contenedor.gui.activities.AppsContainerActivity}" drawable="claro" name="Claro" />
   <item component="ComponentInfo{com.clarocolombia.miclaro/com.clarocolombia.miclaro.activities.Splash}" drawable="claro" name="Claro" />
   <item component="ComponentInfo{com.clarocolombia.miclaro/com.claro.superapp.SplashActivity}" drawable="claro" name="Claro" />
@@ -3174,6 +3189,8 @@
   <item component="ComponentInfo{de.rki.coronawarnapp/de.rki.coronawarnapp.ui.launcher.LauncherActivity}" drawable="corona_warn" name="Corona-Warn" />
   <item component="ComponentInfo{nl.rijksoverheid.ctr.holder/nl.rijksoverheid.ctr.holder.HolderMainActivity}" drawable="coronacheck" name="CoronaCheck" />
   <item component="ComponentInfo{de.corporatebenefits.app/de.corporatebenefits.app.SetupActivity}" drawable="corporate_benefits" name="corporate benefits" />
+  <item component="ComponentInfo{at.corporatebenefits.app/de.corporatebenefits.app.ui.MainActivity}" drawable="corporate_benefits" name="corporate benefits" />
+  <item component="ComponentInfo{de.corporatebenefits.app/de.corporatebenefits.app.ui.MainActivity}" drawable="corporate_benefits" name="corporate benefits" />
   <item component="ComponentInfo{br.com.correios.preatendimento/br.com.correios.preatendimento.MainActivity}" drawable="correios" name="Correios" />
   <item component="ComponentInfo{com.corridordigital.watchcorridor/com.corridordigital.watchcorridor.ui.MainActivity}" drawable="corridor" name="Corridor" />
   <item component="ComponentInfo{so.cosmos.www/so.cosmos.www.LauncherActivity}" drawable="cosmos" name="Cosmos" />
@@ -3444,6 +3461,7 @@
   <item component="ComponentInfo{nl.degiro.trader/nl.degiro.trader.MainActivity}" drawable="degiro" name="DEGIRO" />
   <item component="ComponentInfo{com.degoo.android/com.degoo.android.features.splash.view.SplashActivity}" drawable="degoo" name="Degoo" />
   <item component="ComponentInfo{com.afkanerd.deku/com.afkanerd.deku.DefaultSMS.DefaultCheckActivity}" drawable="dekusms" name="DekuSMS" />
+  <item component="ComponentInfo{com.afkanerd.deku/com.afkanerd.deku.MainActivity}" drawable="dekusms" name="DekuSMS" />
   <item component="ComponentInfo{com.delhiveryConsigneeApp/com.delhiveryConsigneeApp.MainActivity}" drawable="delhivery" name="Delhivery" />
   <item component="ComponentInfo{de.orrs.deliveries/de.orrs.deliveries.DeliveryListActivity}" drawable="deliveries" name="Deliveries" />
   <item component="ComponentInfo{de.orrs.deliveries/de.orrs.deliveries.LaunchActivity}" drawable="deliveries" name="Deliveries" />
@@ -3569,6 +3587,7 @@
   <item component="ComponentInfo{com.digilocker.android/com.digilocker.android.ui.activity.ActivitySplashScreen}" drawable="digilocker" name="DigiLocker" />
   <item component="ComponentInfo{com.digilocker.android/in.gov.digilocker.views.mainactivity.SplashScreenActivity}" drawable="digilocker" name="DigiLocker" />
   <item component="ComponentInfo{nethical.digipaws/nethical.digipaws.ui.activity.MainActivity}" drawable="digipaws" name="DigiPaws" />
+  <item component="ComponentInfo{nethical.digipaws/nethical.digipaws.MainActivity}" drawable="digipaws" name="DigiPaws" />
   <item component="ComponentInfo{no.digipost.android/no.digipost.android.MainActivity}" drawable="digipost" name="Digipost" />
   <item component="ComponentInfo{com.laposte.bnum.digiposteplus/com.laposte.bnum.digiposteplus.feature.splashscreen.SplashscreenActivity}" drawable="digiposte" name="Digiposte" />
   <item component="ComponentInfo{pk.digiskills.lms/pk.digiskills.lms.activities.SplashScreen}" drawable="digiskills" name="DigiSkills" />
@@ -4629,6 +4648,7 @@
   <item component="ComponentInfo{com.overlook.android.fing/com.overlook.android.fing.SplashActivity}" drawable="fing" name="Fing" />
   <item component="ComponentInfo{com.overlook.android.fing/com.overlook.android.fing.ui.main.SplashActivity}" drawable="fing" name="Fing" />
   <item component="ComponentInfo{no.finn.android/no.finn.android.ui.homepage.HomeActivity}" drawable="finn_no" name="FINN.no" />
+  <item component="ComponentInfo{no.finn.android/com.schibsted.nmp.NmpActivity}" drawable="finn_no" name="FINN.no" />
   <item component="ComponentInfo{com.menny.anysoftkeyboard.finnish/com.menny.anysoftkeyboard.finnish.MainActivity}" drawable="anysoftkeyboard" name="Finnish for AnySoftKeyboard" />
   <item component="ComponentInfo{com.finshell.fin/com.finshell.fin.activity.MainActivity}" drawable="finshell_pay" name="FinShell Pay" />
   <item component="ComponentInfo{com.finshell.fin/com.finshell.fin.activity.SplashActivity}" drawable="finshell_pay" name="FinShell Pay" />
@@ -5388,6 +5408,7 @@
   <item component="ComponentInfo{com.g19mobile.gameboosterplus/com.g19mobile.gameboosterplus.SplashActivity}" drawable="game_booster" name="Game Booster" />
   <item component="ComponentInfo{com.g19mobile.gamebooster/com.fenixphoneboosterltd.gamebooster.SplashActivity}" drawable="game_booster" name="Game Booster" />
   <item component="ComponentInfo{com.samsung.android.game.honeyplayplus/com.samsung.android.game.honeyplayplus.main.ui.LaunchActivity}" drawable="game_booster_plus" name="Game Booster +" />
+  <item component="ComponentInfo{com.samsung.android.game.honeyplayplus/com.samsung.android.game.honeyplayplus.ui.LaunchActivity}" drawable="game_booster_plus" name="Game Booster +" />
   <item component="ComponentInfo{com.nearme.gamecenter/com.nearme.gamecenter.DefaultAlias}" drawable="game_center" name="Game Center" />
   <item component="ComponentInfo{com.nearme.gamecenter/com.nearme.gamecenter.DynamicAliasTwo}" drawable="game_center" name="Game Center" />
   <item component="ComponentInfo{com.nearme.gamecenter/com.nearme.gamecenter.ui.activity.SplashActivity}" drawable="game_center" name="Game Center" />
@@ -6586,6 +6607,7 @@
   <item component="ComponentInfo{com.hulu.plus/com.hulu.plusx.activity.Root}" drawable="hulu" name="Hulu ~~ フールー" />
   <item component="ComponentInfo{com.hulu.plus/com.hulu.features.splash.SplashActivity}" drawable="hulu" name="Hulu ~~ フールー" />
   <item component="ComponentInfo{net.humans.fintech_uz/net.humans.fintech_uz.app_start.SplashScreenActivity}" drawable="humans_uz" name="HUMANS.uz" />
+  <item component="ComponentInfo{net.humans.fintech_uz/net.humans.fintech_uz.app_start.SplashScreenActivityHumansPay}" drawable="humans_uz" name="HUMANS.uz" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.hungarian_oss/com.anysoftkeyboard.languagepack.hungarian_oss.MainActivity}" drawable="anysoftkeyboard" name="Hungarian for AnySoftKeyboard" />
   <item component="ComponentInfo{com.hungerbox.customer.common/com.hungerbox.customer.prelogin.activity.MainActivity}" drawable="hungerbox_cafe" name="HungerBox Cafe" />
   <item component="ComponentInfo{com.hungerstation.android.web/com.hungerstation.android.web.hungeractivities.MainActivity}" drawable="hungerstation" name="Hungerstation" />
@@ -6695,6 +6717,7 @@
   <item component="ComponentInfo{com.idagio.app/com.idagio.app.features.onboarding.IntroActivityBase}" drawable="idagio" name="IDAGIO" />
   <item component="ComponentInfo{de.idealo.android/de.idealo.android.MainActivity}" drawable="idealo" name="idealo" />
   <item component="ComponentInfo{gov.dukcapil.mobile_id/gov.dukcapil.mobile_id.MainActivity}" drawable="identitas_kependudukan_digital_ikd" name="Identitas Kependudukan Digital (IKD)" />
+  <item component="ComponentInfo{gov.dukcapil.mobile_id/com.google.android.archive.ReactivateActivity}" drawable="identitas_kependudukan_digital_ikd" name="Identitas Kependudukan Digital (IKD)" />
   <item component="ComponentInfo{com.idfcfirstbank.optimus/com.idfcfirstbank.optimus.MainActivity}" drawable="idfc_first" name="IDFC FIRST" />
   <item component="ComponentInfo{com.fiserv.IDFCMerchantServices/com.idfcfirstbank.optimus.MainActivity}" drawable="idfc_first" name="IDFC FIRST" />
   <item component="ComponentInfo{com.fluffyfairygames.idleminertycoon/com.unity3d.player.UnityPlayerActivity}" drawable="idle_miner_tycoon_gold_and_cash" name="Idle Miner Tycoon: Gold &amp; Cash" />
@@ -7133,6 +7156,7 @@
   <item component="ComponentInfo{com.olx.ssa.ug/com.olx.ssa.app.activities.OlxMainActivity}" drawable="jiji" name="Jiji" />
   <item component="ComponentInfo{com.olx.ssa.ke/ng.jiji.app.ui.splash.SplashActivity}" drawable="jiji" name="Jiji" />
   <item component="ComponentInfo{ng.jiji.app/ng.jiji.app.ui.splash.SplashActivity}" drawable="jiji" name="Jiji" />
+  <item component="ComponentInfo{et.jiji.app/ng.jiji.app.ui.splash.SplashActivity}" drawable="jiji" name="Jiji" />
   <item component="ComponentInfo{com.jimmyjohns/com.launcher.jimmyjohns.ui.activities.Splash.SplashActivity}" drawable="jimmy_johns" name="Jimmy John's" />
   <item component="ComponentInfo{com.jins.sales/com.jins.sales.view.ui.splash.SplashActivity}" drawable="jins" name="JINS" />
   <item component="ComponentInfo{com.jio.join/com.witsoftware.wmc.SplashScreenActivity}" drawable="jiocall" name="JioCall" />
@@ -8133,6 +8157,7 @@
   <item component="ComponentInfo{com.aswat.carrefouruae/com.aswat.carrefouruae.feature.splash.view.activity.SplashActivity}" drawable="maf_carrefour" name="MAF Carrefour" />
   <item component="ComponentInfo{software.indi.android.mpd/software.indi.android.mpd.client.splash.SplashActivity}" drawable="mafa" name="MAFA" />
   <item component="ComponentInfo{com.luizalabs.mlapp/com.luizalabs.mlapp.home.ui.HomeActivity}" drawable="magalu" name="Magalu" />
+  <item component="ComponentInfo{com.luizalabs.mlapp/com.luizalabs.mlapp.home.ui.MainActivity}" drawable="magalu" name="Magalu" />
   <item component="ComponentInfo{com.mobilechess.gp/com.moba.unityplugin.MobaGameMainActivityWithExtractor}" drawable="magic_chess_go_go" name="Magic Chess: GO GO" />
   <item component="ComponentInfo{com.fastsoft.cubeW/com.fastsoft.cubeW.cube}" drawable="cube_solver" name="Magic Cube" />
   <item component="ComponentInfo{com.generalmagic.magicearth/com.magiclane.androidsphere.map.MapActivity}" drawable="magic_earth" name="Magic Earth" />
@@ -10675,6 +10700,8 @@
   <item component="ComponentInfo{com.patreon.android/com.patreon.android.screens.launcher.LauncherActivity}" drawable="patreon" name="Patreon" />
   <item component="ComponentInfo{de.payback.client.android/de.payback.app.ui.main.MainActivity}" drawable="payback" name="PAYBACK" />
   <item component="ComponentInfo{pl.payback/de.payback.app.ui.main.MainActivity}" drawable="payback" name="PAYBACK" />
+  <item component="ComponentInfo{at.payback.client.android/de.payback.app.ui.main.MainActivity}" drawable="payback" name="PAYBACK" />
+  <item component="ComponentInfo{it.payback.client.android/de.payback.app.ui.main.MainActivity}" drawable="payback" name="PAYBACK" />
   <item component="ComponentInfo{com.paybooks.in/com.paybooks.in.MainActivity}" drawable="paybook" name="Paybook" />
   <item component="ComponentInfo{com.paybyphone/com.paybyphone.paybyphoneparking.app.ui.activities.SplashActivity}" drawable="paybyphone" name="PayByPhone" />
   <item component="ComponentInfo{com.turkcell.paycell/com.turkcell.paycell.ui.main.controller.MainActivity}" drawable="paycell" name="Paycell" />
@@ -11203,6 +11230,7 @@
   <item component="ComponentInfo{com.expremio.pizzahut/com.expremio.mobileapp.MainActivity}" drawable="pizza_hut" name="Pizza Hut" />
   <item component="ComponentInfo{lk.gamma.pizzakraft.PizzaHut/lk.gamma.pizzakraft.PizzaHut.MainActivity}" drawable="pizza_hut" name="Pizza Hut" />
   <item component="ComponentInfo{nz.co.pizzahut/com.pizzahut.general.activities.DefaultSplashActivity}" drawable="pizza_hut" name="Pizza Hut" />
+  <item component="ComponentInfo{tr.com.pizzahut/tr.com.pizzahut.MainActivity}" drawable="pizza_hut" name="Pizza Hut" />
   <item component="ComponentInfo{com.paytronix.client.android.app.pizzaranch/com.paytronix.nexgenfl.MainActivity}" drawable="pizza_ranch" name="Pizza Ranch" />
   <item component="ComponentInfo{ca.mealsy.onlineordering.pizzasalvatore/crc64725d112ca099db26.MainActivity}" drawable="pizza_salvatore" name="Pizza Salvatoré" />
   <item component="ComponentInfo{pkp.ic.eicmobile/pkp.ic.eicmobile.MainActivity}" drawable="pkp_intercity" name="PKP INTERCITY" />
@@ -11712,6 +11740,7 @@
   <item component="ComponentInfo{com.speedy.vpn/bai.ui.FirstActivity}" drawable="quarkvpn" name="QuarkVPN" />
   <item component="ComponentInfo{com.teskann.quax/com.teskann.quax.MainActivity}" drawable="quax" name="QuaX" />
   <item component="ComponentInfo{com.hero.iot/com.hero.iot.ui.splash.LoadingActivity}" drawable="qubo" name="Qubo" />
+  <item component="ComponentInfo{m.hero.iot/com.hero.iot.ui.splash.LoadingActivity}" drawable="qubo" name="Qubo" />
   <item component="ComponentInfo{com.querodelivery/com.querodelivery.MainActivity}" drawable="quero_delivery" name="quero delivery" />
   <item component="ComponentInfo{com.querodelivery/com.querodelivery.SplashActivity}" drawable="quero_delivery" name="quero delivery" />
   <item component="ComponentInfo{br.com.queropassagem/br.com.queropassagem.MainActivity}" drawable="quero_passagem" name="Quero Passagem" />
@@ -12252,6 +12281,7 @@
   <item component="ComponentInfo{com.shub39.rush/com.shub39.rush.MainActivity}" drawable="rush" name="Rush" />
   <item component="ComponentInfo{com.shub39.rush/com.shub39.rush.app.MainActivity}" drawable="rush" name="Rush" />
   <item component="ComponentInfo{com.shub39.rush.play/com.shub39.rush.MainActivity}" drawable="rush" name="Rush" />
+  <item component="ComponentInfo{com.shub39.rush.play/com.shub39.rush.app.MainActivity}" drawable="rush" name="Rush" />
   <item component="ComponentInfo{brownmonster.app.game.rushrally3demo/brownmonster.app.game.rushrally3.RushRally3Activity}" drawable="rush_rally_3_demo" name="Rush Rally 3 Demo" />
   <item component="ComponentInfo{brownmonster.app.game.rushrallyremastereddemo/brownmonster.app.game.rushrallyremastered.RushRallyRemasteredActivity}" drawable="rush_rally_origins_demo" name="Rush Rally Origins Demo" />
   <item component="ComponentInfo{org.dianqk.ruslin/org.dianqk.ruslin.MainActivity}" drawable="ruslin_notes" name="Ruslin Notes" />
@@ -12310,10 +12340,12 @@
   <item component="ComponentInfo{com.mtv.sai/com.mtv.sai.ui.activities.main.MainActivity}" drawable="sai" name="SAI" />
   <item component="ComponentInfo{pro.mtv.sai/pro.mtv.sai.ui.activities.MainActivity}" drawable="sai_pro" name="SAI Pro" />
   <item component="ComponentInfo{com.saily.android/com.saily.android.mainActivity.MainActivity}" drawable="saily_esim" name="Saily eSim" />
+  <item component="ComponentInfo{com.saily.android/com.saily.android.MainActivity}" drawable="saily_esim" name="Saily eSim" />
   <item component="ComponentInfo{com.sainsburys.ssa/com.sainsburys.ssa.presentation.views.main.MainActivity}" drawable="sainsburys" name="Sainsbury's" />
   <item component="ComponentInfo{com.raimbekov.android.sajde/com.raimbekov.android.sajde.main.ui.screen.MainActivity}" drawable="sajda" name="Sajda" />
   <item component="ComponentInfo{com.raimbekov.android.sajde/com.raimbekov.android.sajde.DefaultIcon}" drawable="sajda" name="Sajda" />
   <item component="ComponentInfo{com.raimbekov.android.sajde/com.raimbekov.android.sajde.GreenIcon}" drawable="sajda" name="Sajda" />
+  <item component="ComponentInfo{com.raimbekov.android.sajde/com.raimbekov.android.sajde.DarkIcon}" drawable="sajda" name="Sajda" />
   <item component="ComponentInfo{com.anafthdev.saku/com.anafthdev.saku.runtime.MainActivity}" drawable="sudoku" name="Saku" />
   <item component="ComponentInfo{com.linkedin.android.salesnavigator/com.linkedin.android.salesnavigator.ui.login.LoginActivity}" drawable="compass_synapsetech" name="Sales Navigator" />
   <item component="ComponentInfo{com.salesforce.chatter/com.salesforce.chatter.Chatter}" drawable="salesforce" name="Salesforce" />
@@ -12875,6 +12907,7 @@
   <item component="ComponentInfo{de.shoop.app/de.shoop.app.MainActivity}" drawable="shoop" name="Shoop" />
   <item component="ComponentInfo{com.shopify.arrive/com.shopify.arrive.MainActivity}" drawable="shop" name="Shop" />
   <item component="ComponentInfo{shop.shop_apotheke.com.shopapotheke/com.shopapotheke.activities.splash.AliasSplashActivityIT}" drawable="shop_apotheke" name="Shop Apotheke" />
+  <item component="ComponentInfo{shop.shop_apotheke.com.shopapotheke/com.shopapotheke.activities.splash.AliasSplashActivityDE}" drawable="shop_apotheke" name="Shop Apotheke" />
   <item component="ComponentInfo{com.shopback.app/com.google.android.archive.ReactivateActivity}" drawable="shopback" name="ShopBack" />
   <item component="ComponentInfo{com.shopback.app/com.shopback.app.core.ui.splash.SplashActivity}" drawable="shopback" name="ShopBack" />
   <item component="ComponentInfo{com.shopee.my/com.shopee.app.ui.tutorial.TutorialActivity_}" drawable="shopee" name="Shopee" />
@@ -13473,6 +13506,7 @@
   <item component="ComponentInfo{com.tgc.sky.android/com.tgc.sky.TGCBootActivity}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.netease.sky/com.tgc.sky.netease.GameActivity_Netease}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.netease.sky/com.tgc.sky.TGCBootActivity}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
+  <item component="ComponentInfo{com.netease.sky/com.netease.ntunisdk.external.protocol.ProtocolLauncher}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.flightradar24.skycards/com.flightradar24.skycards.MainActivity}" drawable="skycards" name="SkyCards" />
   <item component="ComponentInfo{com.skycash.beta/com.norbsoft.android.ease.activities.SplashScreenActivity}" drawable="skycash" name="SkyCash" />
   <item component="ComponentInfo{skyline.emu/emu.skyline.MainActivity}" drawable="skyline" name="Skyline" />
@@ -13668,6 +13702,7 @@
   <item component="ComponentInfo{jp.co.softbank.OfficialApp/jp.softbank.mb.dtm.features.sb16home.HomeScreenActivity}" drawable="softbank" name="SoftBank" />
   <item component="ComponentInfo{br.com.ridsoftware.shoppinglist/br.com.ridsoftware.shoppinglist.StartActivity}" drawable="softlist" name="SoftList" />
   <item component="ComponentInfo{com.paradyme.solarsmash/com.unity3d.player.UnityPlayerActivity}" drawable="solar_smash" name="Solar Smash" />
+  <item component="ComponentInfo{Materialcom.paradyme.solarsmash/com.unity3d.player.UnityPlayerActivitycom.zegoggles.smssync}" drawable="solar_smash" name="Solar Smash" />
   <item component="ComponentInfo{dev.solsynth.solian/dev.solsynth.solian.MainActivity}" drawable="solian" name="Solian" />
   <item component="ComponentInfo{utarit.SoliPay/utarit.SoliPay.view.SplashActivity}" drawable="soliclub" name="SoliClub" />
   <item component="ComponentInfo{pl.solidexplorer2/pl.solidexplorer.SolidExplorer}" drawable="solid_explorer" name="Solid Explorer" />
@@ -14042,6 +14077,7 @@
   <item component="ComponentInfo{com.harry.stokiepro/com.harry.stokiepro.ui.activity.MainActivity}" drawable="stokie_pro" name="STOKiE PRO" />
   <item component="ComponentInfo{co.stone.banking.mobile.flagship/banking.features.login.verification.UserVerificationActivity}" drawable="stone" name="Stone" />
   <item component="ComponentInfo{com.cateater.stopmotionstudio/com.cateater.stopmotionstudio.MainActivity_start}" drawable="stop_motion_studio" name="Stop Motion Studio" />
+  <item component="ComponentInfo{com.cateater.stopmotionstudio/com.cateater.stopmotionstudio.MainActivity}" drawable="stop_motion_studio" name="Stop Motion Studio" />
   <item component="ComponentInfo{com.mobile_infographics_tools.mydrive/com.mobile_infographics_tools.mydrive.activities.IntroActivity}" drawable="storage_analyzer" name="Storage Analyzer" />
   <item component="ComponentInfo{com.mobile_infographics_tools.mydrive/com.mobile_infographics_tools.mydrive.activities.MainActivity}" drawable="storage_analyzer" name="Storage Analyzer" />
   <item component="ComponentInfo{com.mobile_infographics_tools.mydrive/com.mobile_infographics_tools.mydrive.diskinfo.MainActivity}" drawable="storage_analyzer" name="Storage Analyzer" />
@@ -14141,6 +14177,7 @@
   <item component="ComponentInfo{com.brainium.sudoku.free/com.brainium.brainlib.core_android.BrainlibActivityFree}" drawable="sudoku_number_match_game" name="Sudoku: Number Match Game" />
   <item component="ComponentInfo{com.mobilesuica.msb.android/crc64c47217c4afd91a00.SuicaMainActivity}" drawable="suica" name="Suica" />
   <item component="ComponentInfo{com.sukisu.ultra/.ui.MainActivityAlias}" drawable="kernelsu" name="SukiSU Ultra" />
+  <item component="ComponentInfo{com.sukisu.ultra/com.sukisu.ultra.ui.MainActivity}" drawable="kernelsu" name="SukiSU Ultra" />
   <item component="ComponentInfo{com.gustavoas.sumup/com.gustavoas.sumup.SettingsActivity}" drawable="sum_up" name="Sum Up" />
   <item component="ComponentInfo{com.lydia/rtkeggsmr.it}" drawable="sumeria" name="Sumeria" />
   <item component="ComponentInfo{com.lydia/com.lydia.feature.splash.view.SplashActivity}" drawable="sumeria" name="Sumeria" />
@@ -14207,6 +14244,7 @@
   <item component="ComponentInfo{surveytime.io.surveytime_app/surveytime.io.surveytime_app.MainActivity}" drawable="surveytime" name="Surveytime" />
   <item component="ComponentInfo{org.ligi.survivalmanual/org.ligi.survivalmanual.ui.MainActivity}" drawable="survival_manual" name="Survival Manual" />
   <item component="ComponentInfo{com.candyrufusgames.survivalcraft/md51bf51510d2c85d1124ccf5e3fc41736e.EngineActivity}" drawable="survivalcraft" name="Survivalcraft" />
+  <item component="ComponentInfo{com.candyrufusgames.survivalcraft/crc64da6839f08fe39125.EngineActivity}" drawable="survivalcraft" name="Survivalcraft" />
   <item component="ComponentInfo{com.candyrufusgames.survivalcraft2/crc64da6839f08fe39125.EngineActivity}" drawable="survivalcraft_2" name="Survivalcraft 2" />
   <item component="ComponentInfo{com.candyrufusgames.survivalcraft2/com.fiveplay.mod.RMS.Recovery}" drawable="survivalcraft_2" name="Survivalcraft 2" />
   <item component="ComponentInfo{com.destructo.sushi_mal/com.destructo.sushi.ui.auth.LoginActivity}" drawable="sushi" name="Sushi" />
@@ -15088,6 +15126,7 @@
   <item component="ComponentInfo{com.TotalPlay.totalplay/mx.com.totalplay.core2.home.Core2SplashActivity}" drawable="totalplay" name="Totalplay" />
   <item component="ComponentInfo{com.TotalPlay.totalplay/mx.x2b3c7c31.w5de1f4c5.nfb092626.o866eb15b.z8299e07c}" drawable="totalplay" name="Totalplay" />
   <item component="ComponentInfo{com.TotalPlay.totalplay/mx.sb0f1c21c.yf00b9b06.l71c5ee2b.efe01a9ad.e55105f50}" drawable="totalplay" name="Totalplay" />
+  <item component="ComponentInfo{TotalPlay.totalplay/mx.m8a1c45e9.j852aae68.b86b545ae.ufc28f856.r2c7a48d8}" drawable="totalplay" name="Totalplay" />
   <item component="ComponentInfo{mobi.foo.touch/mobi.foo.touch.SplashActivity}" drawable="touch" name="Touch" />
   <item component="ComponentInfo{my.com.tngdigital.ewallet/my.com.tngdigital.ewallet.ui.SplashActivity}" drawable="touch_n_go" name="Touch 'n Go" />
   <item component="ComponentInfo{com.notch.touch/com.notch.touch.ui.Sa}" drawable="touch_the_notch" name="Touch the Notch" />
@@ -15246,6 +15285,7 @@
   <item component="ComponentInfo{com.truist.mobile/com.truist.commonandroid.view.UnauthenticatedActivity}" drawable="truist" name="Truist" />
   <item component="ComponentInfo{com.truist.mobile/com.truist.unauthenticated.view.UnauthenticatedActivity}" drawable="truist" name="Truist" />
   <item component="ComponentInfo{no.norgesgruppen.apps.trumf.trumf/no.norgesgruppen.apps.trumf.LaunchActivity}" drawable="trumf" name="Trumf" />
+  <item component="ComponentInfo{no.norgesgruppen.apps.trumf.trumf/crc647f6b29a63ed85bae.MainActivity}" drawable="trumf" name="Trumf" />
   <item component="ComponentInfo{sg.trust/sg.phoenix.features.splash.SplashActivity}" drawable="trust_bank" name="Trust Bank" />
   <item component="ComponentInfo{sg.trust/sg.phoenix.default}" drawable="trust_bank" name="Trust Bank" />
   <item component="ComponentInfo{com.wallet.crypto.trustapp/com.wallet.crypto.trustapp.ui.app.AppActivity}" drawable="trust_wallet" name="Trust Wallet" />
@@ -15377,6 +15417,7 @@
   <item component="ComponentInfo{com.youdao.hindict/com.youdao.hindict.activity.MainActivity}" drawable="u_dictionary" name="U Dictionary" />
   <item component="ComponentInfo{com.youdao.hindict/com.youdao.hindict.activity.SplashActivity}" drawable="u_dictionary" name="U Dictionary" />
   <item component="ComponentInfo{com.lguplus.mobile.cs/com.lguplus.mobile.cs.activity.main.MainActivity}" drawable="u_plus" name="U+" />
+  <item component="ComponentInfo{com.lguplus.mobile.cs/com.lguplus.mobile.cs.activity.MainActivity}" drawable="u_plus" name="U+" />
   <item component="ComponentInfo{jp.unext.mediaplayer/jp.unext.mediaplayer.main.MainActivity}" drawable="u_next" name="U-NEXT" />
   <item component="ComponentInfo{net.universia.ua/net.universia.features.start.StartActivity}" drawable="uapp" name="UApp" />
   <item component="ComponentInfo{au.com.bank86400/au.com.bank86400.MainActivity}" drawable="ubank" name="Ubank" />
@@ -15817,6 +15858,8 @@
   <item component="ComponentInfo{com.coloros.video/com.oplus.video.SplashActivity}" drawable="generic_player" name="Videos" />
   <item component="ComponentInfo{com.coloros.video/com.oppo.video.VideoListActivity}" drawable="generic_player" name="Videos" />
   <item component="ComponentInfo{com.projectmaterial.videos/com.projectmaterial.videos.activities.NavigationActivity}" drawable="videos" name="Videos" />
+  <item component="ComponentInfo{com.projectmaterial.videos/com.projectmaterial.videos.activities.VideoLibraryActivity}" drawable="videos" name="Videos" />
+  <item component="ComponentInfo{com.projectmaterial.videos/com.projectmaterial.videos.activity.VideoLibraryActivity}" drawable="videos" name="Videos" />
   <item component="ComponentInfo{com.vidio.android/com.vidio.android.splash.SplashScreen}" drawable="vidio" name="Vidio" />
   <item component="ComponentInfo{vidma.screenrecorder.videorecorder.videoeditor.lite/com.atlasv.android.screen.recorder.ui.splash.LaunchActivity}" drawable="vidma_rec" name="Vidma REC" />
   <item component="ComponentInfo{vidma.screenrecorder.videorecorder.videoeditor.pro/com.atlasv.android.screen.recorder.ui.splash.LaunchActivity}" drawable="vidma_record" name="Vidma Record" />
@@ -16772,6 +16815,8 @@
   <item component="ComponentInfo{yetzio.yetcalc/yetzio.yetcalc.MainActivity}" drawable="yetcalc" name="yetCalc" />
   <item component="ComponentInfo{yetzio.yetcalc/yetzio.yetcalc.HomeActivity}" drawable="yetcalc" name="yetCalc" />
   <item component="ComponentInfo{rs.telenor.mymenu/rs.telenor.mymenu.MainActivity}" drawable="yettel" name="Yettel" />
+  <item component="ComponentInfo{bg.telenor.mytelenor/bg.telenor.mytelenor.activities.SplashScreenActivity}" drawable="yettel" name="Yettel" />
+  <item component="ComponentInfo{com.telenor.mytelenor/com.telenor.mytelenor.genesys.SplashActivity}" drawable="yettel" name="Yettel" />
   <item component="ComponentInfo{com.yunyi.smartcamera/com.ants360.yicamera.activity.SplashActivity}" drawable="yi_iot" name="YI IoT" />
   <item component="ComponentInfo{com.yunyi.smartcamera/com.ants360.yicamera.activity.splash.SplashActivity}" drawable="yi_iot" name="YI IoT" />
   <item component="ComponentInfo{com.kapp.youtube.final/com.kapp.youtube.ui.MainActivity}" drawable="ymusic" name="YMusic" />
@@ -16832,6 +16877,7 @@
   <item component="ComponentInfo{anddea.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.rvx.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
+  <item component="ComponentInfo{com.rvx.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{com.android.youtube.premium/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube_premium" name="YouTube Premium" />
   <item component="ComponentInfo{com.google.android.youtube.pro/com.google.android.youtube.pro.MainActivity}" drawable="youtube" name="Youtube Pro" />
   <item component="ComponentInfo{com.gold.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube" name="YouTube Pro" />
@@ -17053,6 +17099,7 @@
   <item component="ComponentInfo{com.zoopla.activity/com.zoopla.activity.MainActivityDefault}" drawable="zoopla" name="Zoopla" />
   <item component="ComponentInfo{com.zoopla.activity/com.zoopla.activity.MainActivity}" drawable="zoopla" name="Zoopla" />
   <item component="ComponentInfo{de.zooplus/de.zooplus.lib.catdog1}" drawable="zooplus" name="zooplus" />
+  <item component="ComponentInfo{de.zooplus/de.zooplus.lib.cat2}" drawable="zooplus" name="zooplus" />
   <item component="ComponentInfo{com.zorinos.zorin_connect/org.kde.kdeconnect.UserInterface.MainActivity}" drawable="zorin_connect" name="Zorin Connect" />
   <item component="ComponentInfo{xyz.deepdaikon.zoysii/xyz.deepdaikon.zoysii.MainActivity}" drawable="zoysii" name="Zoysii" />
   <item component="ComponentInfo{com.zozoplayer/com.zozoplayer.activity.SplashActivity}" drawable="generic_player" name="ZoZo Player" />
@@ -17273,6 +17320,7 @@
   <item component="ComponentInfo{ru.sberbank.investor/ru.sberbank.sberinvestor.NavHostActivity}" drawable="sberinvestments" name="СберИнвестиции ~~ SberInvestments" />
   <item component="ComponentInfo{ru.sibgenco.general/ru.sibgenco.general.ui.activity.LauncherActivity}" drawable="sgk" name="СГК ~~ SGK" />
   <item component="ComponentInfo{ru.citilink/ru.citilink.app.presentation.start.StartActivity}" drawable="citilink" name="Ситилинк ~~ Citilink" />
+  <item component="ComponentInfo{ru.citilink/ru.citilink.app.presentation.mainactivity.MainActivity}" drawable="citilink" name="Ситилинк ~~ Citilink" />
   <item component="ComponentInfo{ru.sportmaster.app/ru.sportmaster.app.activity.MainActivity}" drawable="sportmaster" name="Спортмастер ~~ Sportmaster" />
   <item component="ComponentInfo{ru.sportmaster.app/ru.sportmaster.app.presentation.start.StartActivity}" drawable="sportmaster" name="Спортмастер ~~ Sportmaster" />
   <item component="ComponentInfo{ru.sravni.android.bankproduct/ru.sravni.android.marketplace.SravniMainActivity}" drawable="sravni" name="Сравни ~~ Sravni" />
@@ -17367,6 +17415,7 @@
   <item component="ComponentInfo{com.nahdi.main/com.nahdi.main.presentation.ui.activity.splash.SplashActivity}" drawable="nahdi" name="النهدي ~~ Nahdi" />
   <item component="ComponentInfo{com.nahdi.main/com.nahdi.sirius.staging.MainActivity}" drawable="nahdi" name="النهدي ~~ Nahdi" />
   <item component="ComponentInfo{ir.emalls.app/ir.emalls.app.SplashActivity}" drawable="emalls" name="ایمالز ~~ Emalls" />
+  <item component="ComponentInfo{ir.emalls.app/ir.emalls.app.MainActivity}" drawable="emalls" name="ایمالز ~~ Emalls" />
   <item component="ComponentInfo{com.gostaresh.mobilebank.boilerplate/com.gostaresh.mobilebank.boilerplate.MainActivity}" drawable="baran" name="باران ~~ Baran" />
   <item component="ComponentInfo{ir.bmi.bam.nativeweb/ir.bmi.bam.DefaultIcon}" drawable="bam" name="بام ~~ bam" />
   <item component="ComponentInfo{com.ada.mbank.mehr/com.ada.mbank.component.SplashActivity}" drawable="bank_mehr" name="بانک مهر ~~ Bank Mehr" />
@@ -17413,6 +17462,8 @@
   <item component="ComponentInfo{com.noon.buyerapp/com.noon.buyerapp.MainActivity}" drawable="noon" name="نون ~~ noon" />
   <item component="ComponentInfo{com.ananinja.lava/com.ananinja.MainActivity}" drawable="ninja" name="نينجا ~~ Ninja" />
   <item component="ComponentInfo{com.adpdigital.mbs.ayande/com.adpdigital.mbs.ayande.HamrahCardHomeActivity}" drawable="hamrahcard" name="همراه کارت ~~ HamrahCard" />
+  <item component="ComponentInfo{com.adpdigital.mbs.ayande/com.adpdigital.mbs.authUI.SplashActivity}" drawable="hamrahcard" name="همراه کارت ~~ HamrahCard" />
+  <item component="ComponentInfo{com.adpdigital.mbs.ayande/com.adpdigital.mbs.ayande.ui.startup.StartupActivity}" drawable="hamrahcard" name="همراه کارت ~~ HamrahCard" />
   <item component="ComponentInfo{com.app.wafeer/com.app.wafeer.MainActivity}" drawable="wafeer" name="وفير ~~ Wafeer" />
   <item component="ComponentInfo{com.urpay.consumer/com.urpay.consumer.MainActivity}" drawable="urpay" name="يور باي ~~ urpay" />
   <item component="ComponentInfo{net.capsuleplus.BridgeJump/org.cocos2dx.cpp.AppActivity}" drawable="collectcoin" name="あつめろコイン ~~ CollectCoin" />
@@ -17678,6 +17729,7 @@
   <item component="ComponentInfo{com.mxbc.mxsa/com.mxbc.mxsa.modules.splash.SplashActivity}" drawable="mixue_ice_city" name="蜜雪冰城 ~~ Mixue Ice City" />
   <item component="ComponentInfo{com.shopee.tw/com.shopee.app.ui.home.HomeActivity_}" drawable="shopee" name="蝦皮購物 ~~ Shopee" />
   <item component="ComponentInfo{jp.seibugroup.seiburailway.seibuapp.client/jp.seibugroup.seiburailway.seibuapp.client.view.splash.SplashActivity}" drawable="seibu_line" name="西武線アプリ ~~ Seibu Line" />
+  <item component="ComponentInfo{jp.seibugroup.seiburailway.seibuapp.client/jp.seibugroup.seiburailway.seibuapp.client.view.splash.SplashActivity_}" drawable="seibu_line" name="西武線アプリ ~~ Seibu Line" />
   <item component="ComponentInfo{info.ebstudio.bookviewer.free/info.ebstudio.bookviewer.free.BookViewerActivity}" drawable="readfriend_lite" name="読書尚友 Lite ~~ Readfriend Lite" />
   <item component="ComponentInfo{com.sprd.sprdnote/com.sprd.sprdnote.NoteActivity}" drawable="generic_notes" name="记事本 ~~ Notepad" />
   <item component="ComponentInfo{com.douban.frodo/com.douban.frodo.activity.SplashActivity}" drawable="douban" name="豆瓣 ~~ Douban" />


### PR DESCRIPTION
## Linked
1v1.LOL (`lol.onevone` → `_1v1_lol.svg`)
2dehands (`be.tweedehands.m` → `_2dehands.svg`)
amaysim (`au.com.amaysim.android` → `amaysim.svg`)
Angel One (`com.msf.angelmobile` → `angel_one.svg`)
Antimine (`com.logical.minato` → `antimine.svg`)
Anx Reader (`com.anxcye.anx_reader` → `anx_reader.svg`)
AP News (`mnn.Android` → `ap_news.svg`)
ASUS Themes (`com.asus.themeapp` → `asus_themes.svg`)
BankID (`no.vipps.bankid` → `bankid.svg`)
Bing International (`com.microsoft.bingintl` → `bing.svg`)
c001apk-compose (`com.example.c001apk.compose` → `c001apk.svg`)
c001apk-flutter (`com.example.c001apk.flutter` → `c001apk.svg`)
Canva (`cn.canva.editor` → `canva.svg`)
Cl@ve (`es.aeat.pin24h` → `clave.svg`)
corporate benefits (`at.corporatebenefits.app` → `corporate_benefits.svg`)
corporate benefits (`de.corporatebenefits.app` → `corporate_benefits.svg`)
DekuSMS (`com.afkanerd.deku` → `dekusms.svg`)
DigiPaws (`nethical.digipaws` → `digipaws.svg`)
FINN.no (`no.finn.android` → `finn_no.svg`)
Game Booster + (`com.samsung.android.game.honeyplayplus` → `game_booster_plus.svg`)
HUMANS.uz (`net.humans.fintech_uz` → `humans_uz.svg`)
Identitas Kependudukan Digital (IKD) (`gov.dukcapil.mobile_id` → `identitas_kependudukan_digital_ikd.svg`)
Jiji (`et.jiji.app` → `jiji.svg`)
Magalu (`com.luizalabs.mlapp` → `magalu.svg`)
PAYBACK (`at.payback.client.android` → `payback.svg`)
PAYBACK (`it.payback.client.android` → `payback.svg`)
Pizza Hut (`tr.com.pizzahut` → `pizza_hut.svg`)
Qubo (`m.hero.iot` → `qubo.svg`)
Rush (`com.shub39.rush.play` → `rush.svg`)
Saily eSim (`com.saily.android` → `saily_esim.svg`)
Sajda (`com.raimbekov.android.sajde` → `sajda.svg`)
Shop Apotheke (`shop.shop_apotheke.com.shopapotheke` → `shop_apotheke.svg`)
Sky: Children of the Light (`com.netease.sky` → `sky_children_of_the_light.svg`)
Solar Smash (`Materialcom.paradyme.solarsmash` → `solar_smash.svg`)
Stop Motion Studio (`com.cateater.stopmotionstudio` → `stop_motion_studio.svg`)
SukiSU Ultra (`com.sukisu.ultra` → `kernelsu.svg`)
Survivalcraft (`com.candyrufusgames.survivalcraft` → `survivalcraft.svg`)
Totalplay (`TotalPlay.totalplay` → `totalplay.svg`)
Trumf (`no.norgesgruppen.apps.trumf.trumf` → `trumf.svg`)
U+ (`com.lguplus.mobile.cs` → `u_plus.svg`)
Videos (`com.projectmaterial.videos` → `videos.svg`)
Yettel (`bg.telenor.mytelenor` → `yettel.svg`)
Yettel (`com.telenor.mytelenor` → `yettel.svg`)
YouTube Music ReVanced (`com.rvx.android.apps.youtube.music` → `youtube_music_revanced.svg`)
zooplus (`de.zooplus` → `zooplus.svg`)
Ситилинк ~~ Citilink (`ru.citilink` → `citilink.svg`)
ایمالز ~~ Emalls (`ir.emalls.app` → `emalls.svg`)
همراه کارت ~~ HamrahCard (`com.adpdigital.mbs.ayande` → `hamrahcard.svg`)
西武線アプリ ~~ Seibu Line (`jp.seibugroup.seiburailway.seibuapp.client` → `seibu_line.svg`)