### PR TITLE
+99 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4774,12 +4774,12 @@
   <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppGradientTwilight}" drawable="firefox_beta" name="Firefox Beta" />
   <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppGradientMidnight}" drawable="firefox_beta" name="Firefox Beta" />
   <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppGradientNorthernLights}" drawable="firefox_beta" name="Firefox Beta" />
-  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppRetro2004}" drawable="firefox" name="Firefox Beta" />
-  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppPixelated}" drawable="firefox" name="Firefox Beta" />
-  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppPride}" drawable="firefox" name="Firefox Beta" />
-  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppFlaming}" drawable="firefox" name="Firefox Beta" />
-  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppMinimal}" drawable="firefox" name="Firefox Beta" />
-  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppCool}" drawable="firefox" name="Firefox Beta" />
+  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppRetro2004}" drawable="firefox_beta" name="Firefox Beta" />
+  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppPixelated}" drawable="firefox_beta" name="Firefox Beta" />
+  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppPride}" drawable="firefox_beta" name="Firefox Beta" />
+  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppFlaming}" drawable="firefox_beta" name="Firefox Beta" />
+  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppMinimal}" drawable="firefox_beta" name="Firefox Beta" />
+  <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.AppCool}" drawable="firefox_beta" name="Firefox Beta" />
   <item component="ComponentInfo{org.mozilla.focus/org.mozilla.focus.activity.MainActivity}" drawable="firefox_focus" name="Firefox Focus" />
   <item component="ComponentInfo{org.mozilla.klar/org.mozilla.focus.activity.MainActivity}" drawable="firefox_klar" name="Firefox Klar" />
   <item component="ComponentInfo{mozilla.lockbox/mozilla.lockbox.view.RootActivity}" drawable="firefox_lockwise" name="Firefox Lockwise" />
@@ -4800,12 +4800,12 @@
   <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppGradientTwilight}" drawable="firefox_nightly" name="Firefox Nightly" />
   <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppGradientMidnight}" drawable="firefox_nightly" name="Firefox Nightly" />
   <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppGradientNorthernLights}" drawable="firefox_nightly" name="Firefox Nightly" />
-  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppRetro2004}" drawable="firefox" name="Firefox Nightly" />
-  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppPixelated}" drawable="firefox" name="Firefox Nightly" />
-  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppPride}" drawable="firefox" name="Firefox Nightly" />
-  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppFlaming}" drawable="firefox" name="Firefox Nightly" />
-  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppMinimal}" drawable="firefox" name="Firefox Nightly" />
-  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppCool}" drawable="firefox" name="Firefox Nightly" />
+  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppRetro2004}" drawable="firefox_nightly" name="Firefox Nightly" />
+  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppPixelated}" drawable="firefox_nightly" name="Firefox Nightly" />
+  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppPride}" drawable="firefox_nightly" name="Firefox Nightly" />
+  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppFlaming}" drawable="firefox_nightly" name="Firefox Nightly" />
+  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppMinimal}" drawable="firefox_nightly" name="Firefox Nightly" />
+  <item component="ComponentInfo{org.mozilla.fenix/org.mozilla.fenix.AppCool}" drawable="firefox_nightly" name="Firefox Nightly" />
   <item component="ComponentInfo{com.cube.gdpc.che/com.cube.gdpc.fa.BootActivity}" drawable="erste_hilfe" name="First Aid" />
   <item component="ComponentInfo{com.firstgroup.first.bus/com.firstgroup.splash.controller.SplashActivity}" drawable="first_bus" name="First Bus" />
   <item component="ComponentInfo{com.mcom.firstcitizens/com.q2.app.core.ui.MainActivity}" drawable="first_citizens_bank" name="First Citizens Bank" />


### PR DESCRIPTION
## Icons
<!-- Please specify in the sections below which apps and packages you have worked on.
     Unnecessary sections can be deleted. -->
Quite a while ago Firefox has introduced a staged rollout of an alternative app icon selector.

Here's a screenshot of currently available icons in Firefox:
![Screenshot_Firefox](https://github.com/user-attachments/assets/81e7dc3f-ffe8-413e-9b5b-12edc4859031)

This PR introduces all the **7x** "Solid colors" and **7x** "Gradients" app IDs for Firefox, FF Beta, FF Nightly, Fennec F-Droid, as well as Ironfox. In all of these apps Solid colors and Gradients icons show the app's correct icon (so e.g. Fennec's `.AppSolidRed` correctly shows the Fennec icon).
As of the time of this PR being created, Tor Browser doesn't seem to have that functionality yet. Tor Browser Alpha *does* have this functionality, but it seems to wrongly use Firefox Beta's icon, so I omitted it.

As for the "Featured" icons - these are custom icons and look the same across all apps. I wondered whether they should all be assigned the stable Firefox icon, even if it's not Firefox (e.g. for Fennec). Should they get their own unique icons?
I wanted to bring attention to these, although I'm going to leave them out of this PR.

### Linked
<!-- New app packages for existing icons. -->
- **14x** Fennec (`org.mozilla.fennec_fdroid` → `fennec.svg`)  
- **14x** Firefox (`org.mozilla.firefox` → `firefox.svg`)  
- **13x** Firefox Beta (`org.mozilla.firefox_beta` → `firefox_beta.svg`)
_1 icon less, because `.AppGradientNorthernLights` has already been added in 92a7c40_  
- **14x** Firefox Nightly (`org.mozilla.fenix` → `firefox_nightly.svg`)  
- **14x** IronFox (`org.ironfoxoss.ironfox` → `ironfox.svg`)  
