### PR TITLE
+20 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -401,6 +401,7 @@
   <item component="ComponentInfo{com.akbank.android.apps.akbank_direkt/com.akbank.feature.login.splash.presentation.SplashActivity}" drawable="akbank" name="Akbank" />
   <item component="ComponentInfo{com.craxic.akebifree/com.craxic.akebifree.activities.AkebiActivity}" drawable="akebi" name="Akebi" />
   <item component="ComponentInfo{com.digidust.elokence.akinator.freemium/com.digidust.elokence.akinator.activities.SplashscreenActivity}" drawable="akinator" name="Akinator" />
+  <item component="ComponentInfo{no.akt.aktbillett/no.ruter.mobile.activity.SplashActivity}" drawable="akt_reise" name="AKT Billett" />
   <item component="ComponentInfo{no.bouvet.routeplanner.akt/no.bouvet.routeplanner.common.activity.SplashActivity}" drawable="akt_reise" name="AKT Reise" />
   <item component="ComponentInfo{at.aktionsfinder.app/at.aktionsfinder.app.MainActivity}" drawable="aktionsfinder" name="Aktionsfinder" />
   <item component="ComponentInfo{io.silvrr.installment/io.silvrr.installment.module.startup.SplashActivity}" drawable="akulaku" name="Akulaku" />
@@ -1586,6 +1587,7 @@
   <item component="ComponentInfo{com.binance.us/com.binance.dev.SplashActivity}" drawable="binance" name="Binance" />
   <item component="ComponentInfo{de.markusfisch.android.binaryeye/de.markusfisch.android.binaryeye.activity.SplashActivity}" drawable="binary_eye" name="Binary Eye" />
   <item component="ComponentInfo{com.tmsoft.whitenoise.generator.beats/com.tmsoft.whitenoise.generator.MainActivity}" drawable="binaural_beats_generator" name="Binaural Beats Generator" />
+  <item component="ComponentInfo{me.itejo443.bindhosts/me.itejo443.bindhosts.MainActivity}" drawable="blockerx" name="Bind Hosts" />
   <item component="ComponentInfo{com.microsoft.bing/com.google.android.archive.ReactivateActivity}" drawable="bing" name="Bing" />
   <item component="ComponentInfo{com.microsoft.bing/com.microsoft.sapphire.app.main.SplashActivity}" drawable="bing" name="Bing" />
   <item component="ComponentInfo{com.microsoft.bing/com.microsoft.sapphire.app.activities.SplashActivity}" drawable="bing" name="Bing" />
@@ -2571,6 +2573,7 @@
   <item component="ComponentInfo{com.konylabs.capitalone/com.konylabs.capitalone.EnterpriseMobileBanking.LaunchActivity}" drawable="capital_one" name="Capital One" />
   <item component="ComponentInfo{com.ie.capitalone.uk/capitalone.com.comobileapp.startup.StartupActivity}" drawable="capital_one" name="Capital One" />
   <item component="ComponentInfo{com.ie.capitalone.uk/capitalone.com.comobileapp.startup.defaultIcon}" drawable="capital_one" name="Capital One" />
+  <item component="ComponentInfo{ca.capitalone.enterprisemobilebanking/com.capitalone.mobile.wallet.launch.SplashActivity}" drawable="capital_one" name="Capital One" />
   <item component="ComponentInfo{capitec.acuity.mobile.prod/capitec.acuity.mobile.prod.MainActivity}" drawable="capitec_bank" name="Capitec Bank" />
   <item component="ComponentInfo{capitec.acuity.mobile.prod/capitec.acuity.mobile.MainActivity}" drawable="capitec_bank" name="Capitec Bank" />
   <item component="ComponentInfo{eu.darken.capod/eu.darken.capod.main.ui.MainActivity}" drawable="capod" name="CAPod" />
@@ -4411,6 +4414,7 @@
   <item component="ComponentInfo{com.everycircuit.free/com.everycircuit.HomeLauncher}" drawable="everycircuit" name="EveryCircuit" />
   <item component="ComponentInfo{com.everycircuit.free/com.everycircuit.Explorer}" drawable="everycircuit" name="EveryCircuit" />
   <item component="ComponentInfo{com.woolworths.rewards/au.com.woolworths.rewards.Launcher}" drawable="everyday_rewards" name="Everyday Rewards" />
+  <item component="ComponentInfo{de.jepfa.personaltasklogger/de.jepfa.personaltasklogger.MainActivity}" drawable="google_tasks" name="Everyday Tasks" />
   <item component="ComponentInfo{com.evilinsult/com.evilinsult.activities.MainActivity}" drawable="evil_insult_generator" name="Evil Insult Generator" />
   <item component="ComponentInfo{br.com.evino.android/br.com.evino.android.LoginSplashActivity}" drawable="evino" name="Evino" />
   <item component="ComponentInfo{net.vonforst.evmap/net.vonforst.evmap.MapsActivity}" drawable="evmap" name="EVMap" />
@@ -4813,6 +4817,7 @@
   <item component="ComponentInfo{com.jazibkhan.equalizer/com.jazibkhan.equalizer.ui.activities.MainActivity}" drawable="flat_equalizer" name="Flat Equalizer" />
   <item component="ComponentInfo{com.flat.evo.iconpack/com.flat.evo.iconpack.activities.SplashActivity}" drawable="generic_shell" name="Flat Evo Icons" />
   <item component="ComponentInfo{com.bocharov.xposed.fscb/com.bocharov.xposed.fscb.settings.Main}" drawable="flat_style_colored_bars" name="Flat Style Colored Bars" />
+  <item component="ComponentInfo{de.xcom.flatexat/de.xcom.flatexat.ui.SplashActivity}" drawable="flatexsecure" name="flatex next AT" />
   <item component="ComponentInfo{de.xcom.flatex.ptan/de.xcom.android.ptancore.SplashActivity}" drawable="flatexsecure" name="flateXSecure" />
   <item component="ComponentInfo{mobi.appplus.calculator.plus/appplus.mobi.calcflat.MainActivity}" drawable="generic_calculator_plus_minus_multi_equal" name="FlexCalc" />
   <item component="ComponentInfo{com.presley.flexify/com.presley.flexify.MainActivity}" drawable="flexify" name="Flexify" />
@@ -6594,6 +6599,7 @@
   <item component="ComponentInfo{us.hsbc.hsbcus/com.hsbc.mobilebanking.prelogon.splash.SplashActivity}" drawable="hsbc" name="HSBC" />
   <item component="ComponentInfo{tr.com.hsbc.hsbcturkey/tr.com.hsbc.hsbcturkey.DEFAULT}" drawable="hsbc" name="HSBC" />
   <item component="ComponentInfo{in.hsbc.hsbcindia/com.hsbc.mobilebanking.splash.SplashActivity}" drawable="hsbc" name="HSBC" />
+  <item component="ComponentInfo{my.com.hsbc.hsbcmalaysia/com.hsbc.mobilebanking.splash.SplashActivity}" drawable="hsbc" name="HSBC" />
   <item component="ComponentInfo{com.hsbc.expat.hsbcexpat/com.hsbc.mobilebanking.splash.SplashActivity}" drawable="hsbc" name="HSBC Expat" />
   <item component="ComponentInfo{com.htc.pitroad/com.htc.pitroad.landingpage.activity.LandingPageActivity}" drawable="htc_boost_plus" name="HTC Boost+" />
   <item component="ComponentInfo{com.qamar.editor.html/com.alif.app.AppActivity}" drawable="html_editor" name="Html Editor" />
@@ -7045,6 +7051,7 @@
   <item component="ComponentInfo{com.transsion.insync/com.transsion.insync.FlashActivity}" drawable="insync" name="InSync" />
   <item component="ComponentInfo{com.transsion.insync.life/com.transsion.insync.life.FlashActivity}" drawable="insync" name="InSync" />
   <item component="ComponentInfo{com.intel.mde/com.screenovate.webphone.app.mde.MainActivity}" drawable="intel_unison" name="Intel Unison" />
+  <item component="ComponentInfo{de.k3b.android.intentintercept/uk.co.ashtonbrsc.intentexplode.StartupActivity}" drawable="apk_info" name="Intent Intercept" />
   <item component="ComponentInfo{br.com.intermedium/br.com.intermedium.SplashActivity}" drawable="inter" name="Inter" />
   <item component="ComponentInfo{br.com.intermedium/br.com.intermedium.splash.SplashActivity}" drawable="inter" name="Inter" />
   <item component="ComponentInfo{br.com.Inter.CDPro/br.com.intermedium.splash.SplashActivity}" drawable="inter" name="Inter Empresas" />
@@ -7946,6 +7953,8 @@
   <item component="ComponentInfo{app.pinya.lime/app.pinya.lime.ui.view.activity.MainActivity}" drawable="lime_launcher" name="Lime Launcher" />
   <item component="ComponentInfo{com.shopping.limeroad/com.shopping.limeroad.Launcher2Activity}" drawable="limeroad" name="LimeRoad" />
   <item component="ComponentInfo{jp.naver.line.android/jp.naver.line.android.activity.SplashActivity}" drawable="line" name="LINE" />
+  <item component="ComponentInfo{jp.naver.line.android/jp.naver.line.android.basic_1}" drawable="line" name="LINE" />
+  <item component="ComponentInfo{jp.naver.line.android/jp.naver.line.android.design_cherry_blossom}" drawable="line" name="LINE" />
   <item component="ComponentInfo{id.co.linebank/com.linebank.feature.MainActivity}" drawable="line_bank" name="LINE Bank" />
   <item component="ComponentInfo{com.linecorp.linemanth/net.appsynth.lineman.view.splash.SplashActivity}" drawable="line_man" name="LINE MAN" />
   <item component="ComponentInfo{jp.linecorp.linemusic.android/com.linecorp.linemusic.android.contents.BridgeActivity}" drawable="line_music" name="LINE MUSIC" />
@@ -8160,6 +8169,7 @@
   <item component="ComponentInfo{io.yarsa.games.ludo/com.unity3d.player.UnityPlayerActivity}" drawable="ludo_king" name="Ludo" />
   <item component="ComponentInfo{com.ludo.king/com.unity3d.player.UnityPlayerActivity}" drawable="ludo_king" name="Ludo King" />
   <item component="ComponentInfo{com.ludo.king/com.google.firebase.MessagingUnityPlayerActivity}" drawable="ludo_king" name="Ludo King" />
+  <item component="ComponentInfo{com.ludo.king/com.unity3d.player.FoldablePlayerActivity}" drawable="ludo_king" name="Ludo King" />
   <item component="ComponentInfo{com.superking.ludo.star/org.cocos2dx.cpp.AppActivity}" drawable="ludo_star" name="Ludo STAR" />
   <item component="ComponentInfo{com.lukoil.b2b.mk/com.lukoil.b2b.mk.MainActivity}" drawable="lukoil" name="LUKOIL BUSINESS" />
   <item component="ComponentInfo{co.com.lulobank.production/com.lulobank.droid.app.presentation.modules.splash.view.SplashActivity}" drawable="lulo" name="Lulo" />
@@ -9026,6 +9036,7 @@
   <item component="ComponentInfo{ai.moises/ai.moises.ui.splashscreen.SplashScreen}" drawable="moises" name="Moises" />
   <item component="ComponentInfo{in.mohalla.video/in.mohalla.sharechat.splash.SplashActivity}" drawable="moj" name="Moj" />
   <item component="ComponentInfo{in.mohalla.video/in.mohalla.sharechat.mojvideoplayer.MojVideoPlayerActivity}" drawable="moj" name="Moj" />
+  <item component="ComponentInfo{pl.mojdhl.app/pl.mojdhl.app.MainActivity}" drawable="dhl" name="Moj DHL" />
   <item component="ComponentInfo{com.transart_media.novotel_app/com.transart_media.novotel_app.MainActivity}" drawable="moj_novotel" name="Moj novotel" />
   <item component="ComponentInfo{rs.Raiffeisen.mobile/eu.newfrontier.iBanking.mobile.raiffeisen.activities.RzbSplashScreenActivity}" drawable="raiffeisen_bank" name="Moja mBanka" />
   <item component="ComponentInfo{co.infinum.rba.eva/co.infinum.rba.eva.ui.splash.SplashActivity}" drawable="raiffeisen_bank" name="mojaRBA" />
@@ -9493,6 +9504,7 @@
   <item component="ComponentInfo{com.zong.customercare/com.zong.customercare.SplashActivity}" drawable="my_zong" name="My Zong" />
   <item component="ComponentInfo{ie.months.my48/ie.app48months.ui.SplashActivity}" drawable="my48" name="My48" />
   <item component="ComponentInfo{ie.months.my48/ie.months.my48.MainActivity}" drawable="my48" name="My48" />
+  <item component="ComponentInfo{my.com.sevenelevenmy.app/my.com.seveneleven.presentation.activity.SplashActivity}" drawable="_7_eleven" name="My7E" />
   <item component="ComponentInfo{com.aakash.myaakashapp/com.aakash.myaakashapp.splashscreen.activity.SplashActivity}" drawable="myaakash" name="myAakash" />
   <item component="ComponentInfo{ro.telekom.myaccount/com.telekom.oneapp.launcher.components.launcher.LauncherActivity}" drawable="t_mobile" name="MyAccount Telekom" />
   <item component="ComponentInfo{com.resmed.myair/com.resmed.mon.AliasDefaultActivity}" drawable="myair" name="myAir" />
@@ -9826,6 +9838,7 @@
   <item component="ComponentInfo{app.netpractice.app/app.netpractice.app.MainActivity}" drawable="netpractice" name="NetPractice" />
   <item component="ComponentInfo{com.edumobile3/com.edumobile3.MainActivity}" drawable="netschool" name="NetSchool" />
   <item component="ComponentInfo{br.com.netshoes.app/netshoes.com.napps.splash.SplashScreenActivity_}" drawable="netshoes" name="Netshoes" />
+  <item component="ComponentInfo{br.com.netshoes.app/netshoes.com.napps.splash.SplashScreenActivity}" drawable="netshoes" name="Netshoes" />
   <item component="ComponentInfo{com.nisargjhaveri.netspeed/com.nisargjhaveri.netspeed.settings.SettingsActivity}" drawable="netspeed_indicator" name="NetSpeed Indicator" />
   <item component="ComponentInfo{com.valuephone.vpnetto/de.netto.b2c.activity.FragmentActivity}" drawable="netto" name="Netto" />
   <item component="ComponentInfo{net.techet.netanalyzerlite.an/net.techet.netanalyzerlite.an.activity.MainActivity}" drawable="network_analyzer" name="Network Analyzer" />
@@ -11429,6 +11442,7 @@
   <item component="ComponentInfo{agency.equilibrio.sodexomexico/agency.equilibrio.sodexomexico.MainActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{pl.sodexo.dlaciebie2.app/pl.sodexo.dlaciebie2.app.ui.login.LoginActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{com.Version1/com.Version1.Version1}" drawable="pnb_one" name="PNB ONE" />
+  <item component="ComponentInfo{in.pnb.pnbparivaar/in.pnb.pnbparivaar.MainActivity}" drawable="pnb_one" name="PNB Parivar" />
   <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.pnc.mbl.android.application.legacy.ui.MainActivity}" drawable="pnc" name="PNC" />
   <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.pnc.mbl.ui.AppConfigActivity}" drawable="pnc" name="PNC" />
   <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.pnc.ecommerce.mobile.PncMobileActivity}" drawable="pnc" name="PNC" />
@@ -11467,6 +11481,7 @@
   <item component="ComponentInfo{com.nimblebit.pocketplanes/com.unity3d.player.UnityPlayerActivity}" drawable="pocket_planes" name="Pocket Planes" />
   <item component="ComponentInfo{com.obreey.reader/com.obreey.reader.StartActivity}" drawable="pocketbook" name="PocketBook" />
   <item component="ComponentInfo{com.mi.android.globallauncher/com.miui.home.launcher.SplashActivity}" drawable="poco_launcher" name="POCO Launcher" />
+  <item component="ComponentInfo{pl.interia.poczta_next/pl.interia.poczta.activity.NextLauncherDefaultAlias}" drawable="au_mail" name="Poczta Interia" />
   <item component="ComponentInfo{ai.pod.colleges/ai.pod.colleges.MainActivity}" drawable="pod_ai" name="pod.ai" />
   <item component="ComponentInfo{com.bambuna.podcastaddict/com.bambuna.podcastaddict.activity.PodcastListActivity}" drawable="podcast_addict" name="Podcast Addict" />
   <item component="ComponentInfo{com.itunestoppodcastplayer.app/com.itunestoppodcastplayer.app.StartupActivity}" drawable="podcast_republic" name="Podcast Republic" />
@@ -14290,6 +14305,7 @@
   <item component="ComponentInfo{sudoku.puzzle.free.game.brain/sudoku.puzzle.free.game.brain.MainActivity}" drawable="sudoku" name="Sudoku" />
   <item component="ComponentInfo{com.thesuncat.sudoku/com.thesuncat.sudoku.MainActivity}" drawable="sudoku" name="SUDOKU" />
   <item component="ComponentInfo{com.zeeron.sudoku.puzzle/com.godot.game.GodotApp}" drawable="sudoku" name="Sudoku" />
+  <item component="ComponentInfo{de.dlyt.yanndroid.sudoku/de.dlyt.yanndroid.sudoku.SplashActivity}" drawable="sudoku" name="Sudoku" />
   <item component="ComponentInfo{org.secuso.privacyfriendlysudoku/org.secuso.privacyfriendlysudoku.ui.SplashActivity}" drawable="sudoku" name="Sudoku (PFA)" />
   <item component="ComponentInfo{com.gamovation.sudoku/com.unity3d.player.UnityPlayerActivity}" drawable="sudoku" name="Sudoku Game" />
   <item component="ComponentInfo{com.mathbrain.sudoku/org.cocos2dx.javascript.AppActivity}" drawable="sudoku" name="Sudoku Master!" />
@@ -14745,6 +14761,8 @@
   <item component="ComponentInfo{com.and.games505.Terraria/com.unity3d.player.UnityPlayerActivity}" drawable="terraria" name="Terraria (Trial)" />
   <item component="ComponentInfo{territorial.io/com.example.territorialio.MainActivity}" drawable="territorial_io" name="Territorial.io" />
   <item component="ComponentInfo{com.tesco.grocery.view/com.tesco.mobile.titan.splash.view.SplashActivity}" drawable="tesco_grocery" name="Tesco Grocery" />
+  <item component="ComponentInfo{cz.anywhere.itesco/com.tesco.mobile.titan.splash.view.SplashActivity}" drawable="tesco_grocery" name="Tesco Online" />
+  <item component="ComponentInfo{hu.bitnet.tesco/com.tesco.mobile.titan.splash.view.SplashActivity}" drawable="tesco_grocery" name="Tesco Online" />
   <item component="ComponentInfo{com.teslamotors.tesla/com.teslamotors.tesla.LoginActivity}" drawable="tesla" name="Tesla" />
   <item component="ComponentInfo{com.teslamotors.tesla/com.tesla.privacy.PrivacyPolicyActivity}" drawable="tesla" name="Tesla" />
   <item component="ComponentInfo{com.teslamotors.tesla/com.teslamotors.TeslaApp.MainActivity}" drawable="tesla" name="Tesla" />
@@ -16178,6 +16196,7 @@
   <item component="ComponentInfo{io.xato.voicereverser/io.xato.voicereverser.MainActivity}" drawable="voice_reverser" name="Voice Reverser" />
   <item component="ComponentInfo{com.DevExtras.VoiceTools/crc6424aa7cfad14660ae.SplashActivity}" drawable="generic_voice_recorder_microphone" name="Voice Tools" />
   <item component="ComponentInfo{gpt.voice.chatgpt/gpt.voice.chatgpt.MainActivity}" drawable="voicegpt" name="VoiceGPT" />
+  <item component="ComponentInfo{de.telekom.mds.mbp/de.telekom.tpd.fmc.MainActivity}" drawable="t_mobile_visual_voicemail" name="Voicemail" />
   <item component="ComponentInfo{net.voicemod.soundboard/net.voicemod.soundboard.app.MainActivity}" drawable="voicemod" name="Voicemod" />
   <item component="ComponentInfo{network.voicy/network.voicy.MainActivity}" drawable="voicy" name="Voicy" />
   <item component="ComponentInfo{de.volkswagen.mediacontrol/de.volkswagen.mediacontrol.FirstLaunchActivity}" drawable="volkswagen_media_control" name="Volkswagen Media Control" />
@@ -17290,6 +17309,7 @@
   <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.b2c.presentation.welcome.WelcomeActivity}" drawable="zappka" name="żappka" />
   <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.apb2c.ui.ZappkaActivityWinterSeason}" drawable="zappka" name="żappka" />
   <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.apb2c.ui.ZappkaActivityDefault}" drawable="zappka" name="żappka" />
+  <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.app.ui.ZappkaActivityDefault}" drawable="zappka" name="żappka" />
   <item component="ComponentInfo{com.kvt.ziogas/com.ziogas.MainActivity}" drawable="ziogas" name="Žiogas" />
   <item component="ComponentInfo{ru.aviasales/ru.aviasales.ui.activity.MainActivity}" drawable="aviasales" name="Авиасейлс ~~ Aviasales" />
   <item component="ComponentInfo{com.avito.android/com.avito.android.Launcher}" drawable="avito" name="Авито ~~ Avito" />


### PR DESCRIPTION
## Linked
AKT Billett (`no.akt.aktbillett` → `akt_reise.svg`)
Bind Hosts (`me.itejo443.bindhosts` → `blockerx.svg`)
Capital One (`ca.capitalone.enterprisemobilebanking` → `capital_one.svg`)
Everyday Tasks (`de.jepfa.personaltasklogger` → `google_tasks.svg`)
flatex next AT (`de.xcom.flatexat` → `flatexsecure.svg`)
HSBC (`my.com.hsbc.hsbcmalaysia` → `hsbc.svg`)
Intent Intercept (`de.k3b.android.intentintercept` → `apk_info.svg`)
LINE (`jp.naver.line.android` → `line.svg`)
Ludo King (`com.ludo.king` → `ludo_king.svg`)
Moj DHL (`pl.mojdhl.app` → `dhl.svg`)
My7E (`my.com.sevenelevenmy.app` → `_7_eleven.svg`)
Netshoes (`br.com.netshoes.app` → `netshoes.svg`)
PNB Parivar (`in.pnb.pnbparivaar` → `pnb_one.svg`)
Poczta Interia (`pl.interia.poczta_next` → `au_mail.svg`)
Sudoku (`de.dlyt.yanndroid.sudoku` → `sudoku.svg`)
Tesco Online (`cz.anywhere.itesco` → `tesco_grocery.svg`)
Tesco Online (`hu.bitnet.tesco` → `tesco_grocery.svg`)
Voicemail (`de.telekom.mds.mbp` → `t_mobile_visual_voicemail.svg`)
żappka (`pl.zabka.apb2c` → `zappka.svg`)