### PR TITLE
+66 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -94,9 +94,14 @@
   <item component="ComponentInfo{com.ketchapp.play2048/com.unity3d.player.UnityPlayerActivity}" drawable="_2048" name="2048" />
   <item component="ComponentInfo{com.s2apps.game2048/com.s2apps.game2048.MainActivity}" drawable="_2048" name="2048" />
   <item component="ComponentInfo{com.tpcstld.twozerogame/com.tpcstld.twozerogame.MainActivity}" drawable="_2048" name="2048" />
+  <item component="ComponentInfo{com.alexblackapps.game2048/com.alexblackapps.game2048.Game}" drawable="_2048" name="2048" />
   <item component="ComponentInfo{org.secuso.privacyfriendly2048/org.secuso.privacyfriendly2048.activities.SplashActivity}" drawable="_2048" name="2048 (Privacy Friendly)" />
+  <item component="ComponentInfo{com.fastsoft.game2048w/com.fastsoft.game2048w.Game2048}" drawable="_2048" name="2048 for smart watch" />
+  <item component="ComponentInfo{merge.blocks.drop.number.puzzle.games/merge.blocks.drop.number.puzzle.games.MainActivity}" drawable="_2048" name="2048 Merge Games - M2 Blocks" />
   <item component="ComponentInfo{org.andstatus.game2048/org.andstatus.game2048.MainActivity}" drawable="_2048" name="2048 Open Fun Game" />
   <item component="ComponentInfo{org.andstatus.game2048/org.andstatus.game2048.MyMainActivity}" drawable="_2048" name="2048 Open Fun Game" />
+  <item component="ComponentInfo{com.spring.bird.game2048plus/com.spring.bird.game2048plus.MainActivity}" drawable="_2048" name="2048 Plus" />
+  <item component="ComponentInfo{io.github.aleksdev.g2048/io.github.aleksdev.g2048.SplashScreenActivity}" drawable="_2048" name="2048: Drop And Merge" />
   <item component="ComponentInfo{lv.pigu/lt.pigu.ui.common.activity.LauncherActivity}" drawable="_220_lv" name="220.lv" />
   <item component="ComponentInfo{com.twentythreeandme.app/com.twentythreeandme.app.nux.NuxIntroductionActivity}" drawable="_23andme" name="23andMe" />
   <item component="ComponentInfo{com.twentythreeandme.app/com.twentythreeandme.app.start.StartActivity}" drawable="_23andme" name="23andMe" />
@@ -109,6 +114,8 @@
   <item component="ComponentInfo{com.twofasapp/com.twofasapp.start.ui.start.StartActivity}" drawable="_2fa_authenticator_2fas" name="2FA Authenticator (2FAS)" />
   <item component="ComponentInfo{com.twofasapp/com.twofasapp.features.start.StartActivity}" drawable="_2fa_authenticator_2fas" name="2FA Authenticator (2FAS)" />
   <item component="ComponentInfo{com.twofasapp/com.twofasapp.ui.main.StartActivity}" drawable="_2fa_authenticator_2fas" name="2FA Authenticator (2FAS)" />
+  <item component="ComponentInfo{com.LoopGames.game2048/com.google.firebase.MessagingUnityPlayerActivity}" drawable="_2048" name="2k48 - 4 puzzle modes" />
+  <item component="ComponentInfo{com.estoty.game2048/com.estoty.game2048.AppActivity}" drawable="_2048" name="2K48 - Number 2048 puzzle game" />
   <item component="ComponentInfo{ru.dublgis.dgismobile4preview/ru.dublgis.dgismobile.GrymMobileActivity}" drawable="_2gis_beta" name="2ГИС beta ~~ 2GIS beta" />
   <item component="ComponentInfo{ru.dublgis.dgismobile/ru.dublgis.dgismobile.GrymMobileActivity}" drawable="_2gis" name="2ГИС ~~ 2GIS" />
   <item component="ComponentInfo{ca.qc.quebec.ville.espacecitoyen311/ca.qc.quebec.ville.espacecitoyen311.MainActivity}" drawable="_311" name="311 Ville de Québec" />
@@ -605,6 +612,7 @@
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.au/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.b2w.americanas/com.b2w.main.activity.MainActivity}" drawable="americanas" name="Americanas" />
   <item component="ComponentInfo{com.vitorpamplona.amethyst/com.vitorpamplona.amethyst.ui.MainActivity}" drawable="amethyst" name="Amethyst" />
+  <item component="ComponentInfo{com.americanexpress.android.acctsvcs.nl/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="Amex" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.at/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="Amex Österreich" />
   <item component="ComponentInfo{br.com.amil.beneficiarios/crc64a96f27a76d70e953.SplashActivity}" drawable="amil" name="Amil" />
   <item component="ComponentInfo{com.narvii.amino.master/com.narvii.master.MasterActivity}" drawable="amino" name="Amino" />
@@ -773,6 +781,7 @@
   <item component="ComponentInfo{jbtech.com.apkgenerator/jbtech.com.apkgenerator.activity.SplashActivity}" drawable="app_apk_extractor" name="APK Extractor" />
   <item component="ComponentInfo{com.iraavanan.apkextractor/com.iraavanan.apkextractor.v2.activity.MainActivity}" drawable="app_apk_extractor" name="Apk Extractor" />
   <item component="ComponentInfo{com.toralabs.apkextractor/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="app_apk_extractor" name="Apk Extractor" />
+  <item component="ComponentInfo{com.iamnbty.apkextractor/com.iamnbty.apkextractor.activity.MainActivity}" drawable="generic_shell" name="APK Extractor" />
   <item component="ComponentInfo{com.wt.apkinfo/com.wt.apkinfo.activities.StartActivity}" drawable="apk_info" name="APK Info" />
   <item component="ComponentInfo{com.uptodown.installer/com.uptodown.installer.activity.SplashActivity}" drawable="apk_installer" name="APK Installer" />
   <item component="ComponentInfo{braveheart.apps.apkinstaller/braveheart.apps.apkinstaller.StartActivity}" drawable="download_progress_plus_plus" name="Apk Installer" />
@@ -1324,6 +1333,7 @@
   <item component="ComponentInfo{com.barclays.android.barclaysmobilebanking/com.barclays.android.barclaysmobilebanking.af}" drawable="barclays_bank" name="Barclays Bank" />
   <item component="ComponentInfo{com.barclays.android.barclaysmobilebanking/com.barclays.android.registration.NRegSplashActivity}" drawable="barclays_bank" name="Barclays Bank" />
   <item component="ComponentInfo{com.barclaycard.germany/com.veripark.barclaycard.screen.main.activities.MainActivity}" drawable="barclays_bank" name="Barclays Bank" />
+  <item component="ComponentInfo{com.barclaycardus/com.barclaycardus.login.SplashActivity}" drawable="barclays_bank" name="Barclays Bank" />
   <item component="ComponentInfo{barcodegenerator.barcodecreator.barcodemaker.barcodescanner/com.superfast.barcode.activity.SplashActivity}" drawable="generic_qr_reader" name="Barcode Generator &amp; Scanner" />
   <item component="ComponentInfo{com.google.zxing.client.android/com.google.zxing.client.android.CaptureActivity}" drawable="generic_qr_reader" name="Barcode Scanner" />
   <item component="ComponentInfo{com.mobileappsshop.barcode/com.mobileappsshop.MainActivity}" drawable="generic_qr_reader" name="Barcode Scanner" />
@@ -1404,6 +1414,7 @@
   <item component="ComponentInfo{com.bbva.nxt_argentina/com.bbva.glomohybrid.splash.presentation.view.SplashActivity}" drawable="bbva" name="BBVA" />
   <item component="ComponentInfo{com.bbva.italy/com.bbva.woody.app.modules.initial.splash.view.SplashActivity}" drawable="bbva" name="BBVA" />
   <item component="ComponentInfo{co.com.bbva.mb/com.bbva.glomohybrid.splash.presentation.view.SplashActivity}" drawable="bbva" name="BBVA" />
+  <item component="ComponentInfo{com.bbva.glomo.uy/com.bbva.glomohybrid.splash.presentation.view.SplashActivity}" drawable="bbva" name="BBVA" />
   <item component="ComponentInfo{com.totaltexto.bancamovil/com.bbva.buzz.modules.startup.StartActivity}" drawable="bbva" name="BBVA Provinet" />
   <item component="ComponentInfo{ca.bc.gov.id.servicescard/ca.bc.gov.id.servicescard.screens.splash.SplashActivity}" drawable="bc_services_card" name="BC Services Card" />
   <item component="ComponentInfo{ca.bc.gov.vaxcheck/ca.bc.gov.vaxcheck.SplashActivity}" drawable="bc_vaccine_card_verifier" name="BC Vaccine Card Verifier" />
@@ -1628,6 +1639,7 @@
   <item component="ComponentInfo{com.candywriter.bitlife/com.unity3d.player.UnityPlayerActivity}" drawable="bitlife" name="BitLife" />
   <item component="ComponentInfo{com.candywriter.bitlife/com.google.firebase.MessagingUnityPlayerActivity}" drawable="bitlife" name="BitLife" />
   <item component="ComponentInfo{com.goodgamestudios.bitlife.es.espanol.simulador.de.vida/com.unity3d.player.UnityPlayerActivity}" drawable="bitlife" name="BitLife" />
+  <item component="ComponentInfo{com.goodgamestudios.bitlife.br.portugues.simulacao.de.vida/com.unity3d.player.UnityPlayerActivity}" drawable="bitlife" name="BitLife" />
   <item component="ComponentInfo{com.subhamsaha.bitlit/com.subhamsaha.bitlit.MainActivity}" drawable="bitlit" name="BitLit" />
   <item component="ComponentInfo{com.bitly.app/com.bitly.app.activity.LandingActivity}" drawable="bitly" name="Bitly" />
   <item component="ComponentInfo{se.leap.bitmaskclient/se.leap.bitmaskclient.base.StartActivity}" drawable="bitmask" name="Bitmask" />
@@ -2883,6 +2895,10 @@
   <item component="ComponentInfo{com.citiuat/com.citiuat.mobeix}" drawable="citibank" name="Citibank" />
   <item component="ComponentInfo{com.citiuat/com.citiuat.mobeix.MainActivity}" drawable="citibank" name="Citibank" />
   <item component="ComponentInfo{com.citiuat/nf6090be3.gcfbef292.x16acc17b.m19deca7d}" drawable="citibank" name="Citibank" />
+  <item component="ComponentInfo{com.citibank.mobile.au/com.citi.mobile.pt3.starter.authentication.view.activity.LoginActivity}" drawable="citibank" name="Citibank" />
+  <item component="ComponentInfo{com.citibank.mobile.sg/com.citi.mobile.pt3.starter.authentication.view.activity.LoginActivity}" drawable="citibank" name="Citibank" />
+  <item component="ComponentInfo{com.citi.mobile.cdbe/com.citi.mobile.cdbe.SplashActivity}" drawable="citibank" name="CitiDirect" />
+  <item component="ComponentInfo{com.citi.mobile.ccc/com.citi.mobile.ccc.MainActivity}" drawable="citibank" name="CitiManager" />
   <item component="ComponentInfo{air.com.cititrans.birdev02/air.com.cititrans.birdev02.MainActivity}" drawable="cititrans" name="Cititrans" />
   <item component="ComponentInfo{sp0n.citizen/sp0n.citizen.splash.SplashActivity}" drawable="citizen" name="Citizen" />
   <item component="ComponentInfo{org.citra.citra_emu/org.citra.citra_emu.ui.main.MainActivity}" drawable="citra" name="Citra" />
@@ -3252,6 +3268,8 @@
   <item component="ComponentInfo{tw.com.costco/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{com.costco.mx/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{intl.costco.com.mobile.japan/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
+  <item component="ComponentInfo{intl.costco.com.mobile.australia/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
+  <item component="ComponentInfo{intl.costco.com.mobile.uk/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{com.jupli.countdowntoanything/com.jupli.countdowntoanything.MainActivity}" drawable="countdown_to_anything" name="Countdown To Anything" />
   <item component="ComponentInfo{me.gira.widget.countdown/me.gira.widget.countdown.MainActivity}" drawable="countdown_widget" name="Countdown Widget" />
   <item component="ComponentInfo{me.gira.widget.countdown/me.gira.widget.countdown.activities.SplashActivity}" drawable="countdown_widget" name="Countdown Widget" />
@@ -3328,6 +3346,7 @@
   <item component="ComponentInfo{com.amazon.csapp/com.amazon.csapp.activity.CSLandingActivity}" drawable="generic_shell" name="CSAppFireTV" />
   <item component="ComponentInfo{com.cscsw.cscgo/com.mycscgo.laundry.general.ui.MainActivity}" drawable="go_taxi" name="CSC GO Laundry" />
   <item component="ComponentInfo{com.csfloat.app/com.csfloat.app.MainActivity}" drawable="csfloat" name="CSFloat" />
+  <item component="ComponentInfo{cz.lastaapps.menza/cz.lastaapps.menza.MainActivity}" drawable="generic_silverware" name="CTU Menza" />
   <item component="ComponentInfo{air.com.RustyLake.CubeEscapeCollection/air.com.RustyLake.CubeEscapeCollection.AIRAppEntry}" drawable="cube_escape_collection" name="Cube Escape Collection" />
   <item component="ComponentInfo{air.com.RustyLake.CubeEscapeParadox/air.com.RustyLake.CubeEscapeParadox.AIRAppEntry}" drawable="cube_escape_collection" name="Cube Escape: Paradox" />
   <item component="ComponentInfo{com.jeffprod.cubesolver/com.jeffprod.cubesolver.MainActivity}" drawable="cube_solver" name="Cube Solver" />
@@ -3534,6 +3553,7 @@
   <item component="ComponentInfo{com.denizbank.mobildeniz/com.denizbank.mobildeniz.mainactivity.MainActivity}" drawable="denizbank" name="DenizBank" />
   <item component="ComponentInfo{sk.dennikn.dennikn/com.dennikn.android.dennikn.MainActivity}" drawable="dennik_n" name="Denník N" />
   <item component="ComponentInfo{com.dmholdings.DenonAVRRemote/com.dmholdings.remoteapp.Startup}" drawable="denon_avr_remote" name="Denon AVR Remote" />
+  <item component="ComponentInfo{com.dmholdings.denonremoteapp/com.dmholdings.remoteapp.Startup}" drawable="just_player" name="Denon Remote" />
   <item component="ComponentInfo{fr.orqual.monortho/com.tns.NativeScriptActivity}" drawable="dentapoche" name="Dentapoche" />
   <item component="ComponentInfo{com.deploygate/com.deploygate.activity.MainActivity}" drawable="deploygate" name="DeployGate" />
   <item component="ComponentInfo{com.depop/com.depop._v2.splash.app.SplashActivity}" drawable="depop" name="Depop" />
@@ -3564,6 +3584,7 @@
   <item component="ComponentInfo{flar2.devcheck/flar2.devcheck.MainActivity}" drawable="devcheck" name="DevCheck" />
   <item component="ComponentInfo{flar2.devcheck/flar2.devcheck.SplashActivity}" drawable="devcheck" name="DevCheck" />
   <item component="ComponentInfo{com.singlebyte.devshortcut/com.singlebyte.devshortcut.MainActivity}" drawable="generic_braces" name="Developer Options Shortcut" />
+  <item component="ComponentInfo{org.aospstudio.devoptions/com.aospstudio.shortcuts.MainActivity}" drawable="generic_braces" name="Developer Options Shortcut" />
   <item component="ComponentInfo{io.dvlt.blaze/io.dvlt.blaze.StartActivity}" drawable="devialet" name="Devialet" />
   <item component="ComponentInfo{io.dvlt.tap/io.dvlt.tap.onboarding.activity.SplashScreenActivity}" drawable="devialet_gemini" name="Devialet Gemini" />
   <item component="ComponentInfo{io.dvlt.tap/io.dvlt.tap.bootstrap.routing.RoutingActivity}" drawable="devialet_gemini" name="Devialet Gemini" />
@@ -3594,6 +3615,8 @@
   <item component="ComponentInfo{com.alifewithallah.app/com.ryanheise.audioservice.AudioServiceActivity}" drawable="dhikr_and_dua" name="Dhikr &amp; Dua" />
   <item component="ComponentInfo{mv.com.dhiraagu.app/mv.com.dhiraagu.dhiraagu.SplashActivity}" drawable="dhiraagu" name="Dhiraagu" />
   <item component="ComponentInfo{com.rosan.dhizuku/com.rosan.dhizuku.ui.activity.SettingsActivity}" drawable="dhizuku" name="Dhizuku" />
+  <item component="ComponentInfo{com.dhlparcel.nl/com.dhlparcel.MainActivity}" drawable="dhl" name="DHL" />
+  <item component="ComponentInfo{com.dhl.exp.dhlmobile/com.dhl.exp.dhlmobile.MainActivity}" drawable="dhl" name="DHL Express" />
   <item component="ComponentInfo{com.android.contacts/com.android.contacts.activities.TwelveKeyDialer}" drawable="generic_dialer" name="Dialer" />
   <item component="ComponentInfo{com.motorola.dialer/com.motorola.dialer.CallLogShortcut}" drawable="generic_dialer" name="Dialer" />
   <item component="ComponentInfo{com.motorola.dialer/com.motorola.dialer.DialtactsContactsEntryActivity}" drawable="generic_dialer" name="Dialer" />
@@ -3789,6 +3812,7 @@
   <item component="ComponentInfo{com.docx.reader.word.docx.document.office.free.viewer/com.trustedapp.pdfreader.ui.splash.SplashActivity}" drawable="google_docs" name="Doc Reader" />
   <item component="ComponentInfo{com.docx.reader.word.docx.document.office.free.viewer/com.trustedapp.pdfreader.view.activity.SplashActivity}" drawable="google_docs" name="Doc Reader" />
   <item component="ComponentInfo{be.ixor.doccle.android/be.ixor.doccle.android.main.launcher.LauncherActivity_}" drawable="doccle" name="Doccle" />
+  <item component="ComponentInfo{docsreader.fileopener.word.office.offlineviewer/docsreader.fileopener.word.office.offlineviewer.Activities.WelcomeScreen}" drawable="google_docs" name="Docs Reader" />
   <item component="ComponentInfo{fr.doctolib.www/fr.doctolib.www.MainActivity}" drawable="doctolib" name="Doctolib" />
   <item component="ComponentInfo{br.com.doctoralia/com.app.MainActivity}" drawable="doctoralia" name="Doctoralia" />
   <item component="ComponentInfo{mx.com.doctoralia/com.app.MainActivity}" drawable="doctoralia" name="Doctoralia" />
@@ -3800,6 +3824,8 @@
   <item component="ComponentInfo{com.docusign.ink/com.google.android.archive.ReactivateActivity}" drawable="docusign" name="Docusign" />
   <item component="ComponentInfo{com.os.docvault/com.coloros.oppodocvault.views.ftu.ui.FTUWelcomeActivity}" drawable="docvault" name="DocVault" />
   <item component="ComponentInfo{word.office.docxviewer.document.docx.reader/word.office.docxviewer.document.docx.reader.ui.WelcomeAct}" drawable="google_docs" name="Docx Reader" />
+  <item component="ComponentInfo{com.skydot.docxreader.docx.docxviewer.document.doc.office.viewer.reader.word/com.skydot.docxreader.ui.ActivityMain}" drawable="google_docs" name="Docx Reader" />
+  <item component="ComponentInfo{com.skydot.docxreader.docx.docxviewer.document.doc.office.viewer.reader.word/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="google_docs" name="Docx Reader" />
   <item component="ComponentInfo{com.dodo.app.twa/com.dodo.app.twa.LauncherActivity}" drawable="dodo" name="Dodo" />
   <item component="ComponentInfo{ru.dodopizza.app/ru.dodopizza.app.presentation.main.MainActivity}" drawable="dodo_pizza" name="Dodo Pizza" />
   <item component="ComponentInfo{ru.dodopizza.app/ru.dodopizza.app.presentation.splash.SplashActivity}" drawable="dodo_pizza" name="Dodo Pizza" />
@@ -4132,6 +4158,7 @@
   <item component="ComponentInfo{nl.woningnet.dak/nl.woningnet.dak.MainActivity}" drawable="dak" name="DĀK" />
   <item component="ComponentInfo{com.etisalat/com.etisalat.view.splash.SplashActivity}" drawable="eand" name="e&amp;" />
   <item component="ComponentInfo{com.Etisalat.ETIDA/com.etisalat.etida.composerevamp.splash.presentation.SplashActivity}" drawable="eand" name="e&amp;" />
+  <item component="ComponentInfo{com.etisalat.ewallet/com.etisalat.ewallet.ui.splash.SplashActivity}" drawable="eand" name="e&amp;" />
   <item component="ComponentInfo{jp.konami.eam.link/jp.konami.eam.link.MainActivity}" drawable="e_amusement" name="e-amusement" />
   <item component="ComponentInfo{gov.epf.employer/gov.epf.views.home.MainActivity}" drawable="iakaun" name="e-Caruman" />
   <item component="ComponentInfo{cn.gov.pbc.dcep/com.alipay.mobile.quinox.LauncherActivity}" drawable="e_cny" name="e-CNY" />
@@ -4866,6 +4893,8 @@
   <item component="ComponentInfo{net.offlinefirst.flamy/net.offlinefirst.flamy.MainActivity}" drawable="flamy" name="Flamy" />
   <item component="ComponentInfo{com.dotgears.flappybird/com.dotgears.flappy.SplashScreen}" drawable="flappy_bird" name="Flappy Bird" />
   <item component="ComponentInfo{epic.org.flappybird/com.unity3d.player.UnityPlayerActivity}" drawable="flappy_bird" name="Flappy Bird" />
+  <item component="ComponentInfo{com.flappybird.game/android.app.NativeActivity}" drawable="flappy_bird" name="Flappy Bird" />
+  <item component="ComponentInfo{com.flappybird.recreation/com.flappybird.recreation.GearslogoActivity}" drawable="flappy_bird" name="Flappy Bird" />
   <item component="ComponentInfo{app.useflash.teller/app.useflash.teller.MainActivity}" drawable="flash" name="Flash" />
   <item component="ComponentInfo{com.my.newproject15/com.my.newproject15.MainActivity}" drawable="generic_shell" name="FLASH" />
   <item component="ComponentInfo{flashcards.words.words/flashcards.words.words.ui.base.SplashActivity}" drawable="flashcards_world" name="Flashcards World" />
@@ -5739,6 +5768,7 @@
   <item component="ComponentInfo{com.lexsuperior.app/com.lexsuperior.app.MainActivity}" drawable="gesetze_io" name="gesetze.io" />
   <item component="ComponentInfo{com.conena.navigation.gesture.control/com.conena.navigation.gesture.control.StartPageActivity}" drawable="gesture_control" name="Gesture Control" />
   <item component="ComponentInfo{dk.appdictive.getcurrentwallpaper/dk.appdictive.getcurrentwallpaper.MainActivity}" drawable="get_current_wallpaper" name="Get Current Wallpaper" />
+  <item component="ComponentInfo{com.pictext.followersedit/com.pictext.followersedit.ui.activ.LaunchActivity}" drawable="generic_heart" name="Get Followers Likes For Ins" />
   <item component="ComponentInfo{name.seguri.android.getforegroundactivity/name.seguri.android.getforegroundactivity.MainActivity}" drawable="get_foreground_activity" name="Get Foreground Activity" />
   <item component="ComponentInfo{jp.yusukey.getsauce/jp.yusukey.getsauce.MainActivity}" drawable="generic_search" name="Get Sauce" />
   <item component="ComponentInfo{com.xiaomi.market/com.xiaomi.market.ui.MarketTabActivity}" drawable="getapps" name="GetApps" />
@@ -6197,6 +6227,7 @@
   <item component="ComponentInfo{ph.com.gotyme/com.tyme.digital.NewYear}" drawable="gotyme_bank" name="GoTyme Bank" />
   <item component="ComponentInfo{ph.com.gotyme/com.tymex.splashScreen.presentation.Default}" drawable="gotyme_bank" name="GoTyme Bank" />
   <item component="ComponentInfo{ph.com.gotyme/com.tymex.splashScreen.resources.Default}" drawable="gotyme_bank" name="GoTyme Bank" />
+  <item component="ComponentInfo{ph.com.gotyme/com.tymex.splashScreen.resources.Christmas}" drawable="gotyme_bank" name="GoTyme Bank" />
   <item component="ComponentInfo{uk.co.gousto.gousto/uk.co.gousto.splash.presentation.RoutingActivity}" drawable="gousto" name="Gousto" />
   <item component="ComponentInfo{br.gov.meugovbr/com.google.android.archive.ReactivateActivity}" drawable="gov_br" name="gov.br" />
   <item component="ComponentInfo{br.gov.meugovbr/br.gov.meugovbr.MainActivity}" drawable="gov_br" name="gov.br" />
@@ -6568,6 +6599,7 @@
   <item component="ComponentInfo{com.funnmedia.hit_the_island/com.unity3d.player.UnityPlayerActivity}" drawable="hit_the_island" name="Hit The Island" />
   <item component="ComponentInfo{uk.co.centrica.hive/uk.co.centrica.hive.ui.splash.SplashScreenActivity}" drawable="hive" name="Hive" />
   <item component="ComponentInfo(org.hiveinc.TheHive.android/org.hiveinc.thehive.android.MainActivity)" drawable="hive_social" name="Hive Social" />
+  <item component="ComponentInfo{org.hiveinc.TheHive.android/org.hiveinc.thehive.android.MainActivity}" drawable="hive_social" name="Hive Social" />
   <item component="ComponentInfo{com.hiwaifu.app/com.example.waifu_flutter.MainActivity}" drawable="hiwaifu" name="HiWaifu" />
   <item component="ComponentInfo{com.legend.hiwatchpro.app/xfkj.fitpro.activity.SplashActivity}" drawable="hiwatchpro" name="HiWatchPro" />
   <item component="ComponentInfo{uk.co.hiyacar/uk.co.hiyacar.ui.splashScreen.IntroActivity}" drawable="hiyacar" name="Hiyacar" />
@@ -6822,6 +6854,7 @@
   <item component="ComponentInfo{net.i2p.android.router/net.i2p.android.I2PActivity}" drawable="i2p" name="I2P" />
   <item component="ComponentInfo{org.purplei2p.i2pd/org.purplei2p.i2pd.I2PDPermsAskerActivity}" drawable="i2pd" name="i2pd" />
   <item component="ComponentInfo{com.imotionconsulting.iacalaboratorios/com.imotionconsulting.iacalaboratorios.MainActivity}" drawable="iaca_laboratorios" name="IACA Laboratorios" />
+  <item component="ComponentInfo{top.ltfan.notdeveloper/top.ltfan.notdeveloper.ui.activity.MainActivity}" drawable="generic_shell" name="IAmNotADeveloper" />
   <item component="ComponentInfo{com.clover.ibetter/com.clover.ibetter.ui.activity.MainActivity}" drawable="ibetter" name="iBetter" />
   <item component="ComponentInfo{jp.ne.ibis.ibispaint.app/jp.ne.ibis.ibispaintx.app.market.MarketAuthenticationActivity}" drawable="ibis_paint" name="ibis Paint" />
   <item component="ComponentInfo{jp.ne.ibis.ibispaint.app/jp.ne.ibis.ibispaintx.app.InitializeCheckActivity}" drawable="ibis_paint" name="ibis Paint" />
@@ -6894,6 +6927,7 @@
   <item component="ComponentInfo{mobi.ifunny/mobi.ifunny.splash.SplashActivity}" drawable="ifunny" name="iFunny" />
   <item component="ComponentInfo{com.clearchannel.iheartradio.controller/com.iheart.activities.NavDrawerActivity}" drawable="iheart" name="iHeart" />
   <item component="ComponentInfo{org.exarhteam.iitc_mobile/org.exarhteam.iitc_mobile.IITC_Mobile}" drawable="iitc" name="IITC" />
+  <item component="ComponentInfo{com.pmmmwh.iitc/com.pmmmwh.iitc.MainActivity}" drawable="iitc" name="IITC" />
   <item component="ComponentInfo{org.exarhteam.iitc_mobile.beta/org.exarhteam.iitc_mobile.IITC_Mobile}" drawable="iitc_beta" name="IITC Beta" />
   <item component="ComponentInfo{com.ingka.ikea.app/com.google.android.archive.ReactivateActivity}" drawable="ikea" name="IKEA" />
   <item component="ComponentInfo{hk.ikea.android/hk.com.ikea.flutter.hong_kong_native_flutter.MainActivity}" drawable="ikea" name="IKEA" />
@@ -7411,6 +7445,7 @@
   <item component="ComponentInfo{com.vibo.jsontool/com.vibo.jsontool.MainActivity}" drawable="generic_braces" name="JSON &amp; XML Tool" />
   <item component="ComponentInfo{com.vibo.jsontool.premium/com.vibo.jsontool.MainActivity}" drawable="generic_braces" name="JSON &amp; XML Tool" />
   <item component="ComponentInfo{com.tuyware.jsongenie/com.tuyware.jsoneditor.Activities.MainActivity}" drawable="json_genie" name="Json Genie" />
+  <item component="ComponentInfo{com.qamar.ide.java/com.alif.app.AppActivity}" drawable="generic_braces" name="JStudio" />
   <item component="ComponentInfo{com.facebook.katanb/com.facebook.katanb.LoginActivity}" drawable="facebook" name="JTFacebook" />
   <item component="ComponentInfo{at.techbee.jtx/at.techbee.jtx.MainActivity}" drawable="jtx_board" name="jtx Board" />
   <item component="ComponentInfo{at.techbee.jtx/at.techbee.jtx.MainActivity2}" drawable="jtx_board" name="jtx Board" />
@@ -8075,6 +8110,7 @@
   <item component="ComponentInfo{jp.naver.line.android/jp.naver.line.android.basic_1}" drawable="line" name="LINE" />
   <item component="ComponentInfo{jp.naver.line.android/jp.naver.line.android.design_cherry_blossom}" drawable="line" name="LINE" />
   <item component="ComponentInfo{id.co.linebank/com.linebank.feature.MainActivity}" drawable="line_bank" name="LINE Bank" />
+  <item component="ComponentInfo{com.linebank.tw/com.linebank.feature.MainActivity}" drawable="line_bank" name="LINE Bank" />
   <item component="ComponentInfo{com.linecorp.linemanth/net.appsynth.lineman.view.splash.SplashActivity}" drawable="line_man" name="LINE MAN" />
   <item component="ComponentInfo{jp.linecorp.linemusic.android/com.linecorp.linemusic.android.contents.BridgeActivity}" drawable="line_music" name="LINE MUSIC" />
   <item component="ComponentInfo{jp.linecorp.linemusic.android/com.naver.vibe.SplashActivity}" drawable="line_music" name="LINE MUSIC" />
@@ -8266,6 +8302,7 @@
   <item component="ComponentInfo{theredspy15.ltecleanerfoss/theredspy15.ltecleanerfoss.controllers.MainActivity}" drawable="lte_cleaner" name="LTE Cleaner" />
   <item component="ComponentInfo{net.simplyadvanced.ltediscovery/com2020.ltediscovery.ui.LtedMainActivity}" drawable="lte_discovery" name="LTE Discovery" />
   <item component="ComponentInfo{rs.ltt.android/rs.ltt.android.ui.activity.MainActivity}" drawable="generic_email" name="Ltt.rs" />
+  <item component="ComponentInfo{com.alif.ide.lua/com.alif.app.AppActivity}" drawable="generic_braces" name="LuaDroid" />
   <item component="ComponentInfo{com.lucidchart.android.chart/com.lucidchart.android.chart.MainActivity}" drawable="lucidchart" name="Lucidchart" />
   <item component="ComponentInfo{com.lucidspark.android.spark/com.lucidchart.android.chart.MainActivity}" drawable="lucidspark" name="Lucidspark" />
   <item component="ComponentInfo{com.duk.kerala.gst.luckybill/com.duk.kerala.gst.luckybill.ui.components.activities.StarterActivity}" drawable="lucky_bill" name="Lucky Bill" />
@@ -8836,6 +8873,8 @@
   <item component="ComponentInfo{es.gob.carpeta/com.sgad.android.carpeta.presentation.RootActivity}" drawable="mi_carpeta_ciudadana" name="Mi Carpeta Ciudadana" />
   <item component="ComponentInfo{ar.com.claro.android/ar.com.claro.android.LauncherActivity}" drawable="mi_claro" name="Mi Claro" />
   <item component="ComponentInfo{com.claro.pe.miclaro/com.everis.miclaro.view.activity.SplashScreenActivity}" drawable="mi_claro" name="Mi Claro" />
+  <item component="ComponentInfo{com.claro.miclaro/com.claro.miclaro.view.SplashKTVC}" drawable="mi_claro" name="Mi Claro" />
+  <item component="ComponentInfo{com.claroecuador.miclaro/com.claroecuador.miclaro.view.SplashKTVC}" drawable="mi_claro" name="Mi Claro" />
   <item component="ComponentInfo{com.mi.global.bbs/com.mi.global.bbs.ui.SplashActivity}" drawable="mi_community" name="Mi Community" />
   <item component="ComponentInfo{com.mi.global.bbs/com.mi.global.bbslib.headlines.ui.SplashActivity}" drawable="mi_community" name="Mi Community" />
   <item component="ComponentInfo{com.treydev.micontrolcenter/com.treydev.shades.activities.MainActivity}" drawable="mi_control_center" name="Mi Control Center" />
@@ -8862,6 +8901,7 @@
   <item component="ComponentInfo{com.miui.playerlite/com.miui.player.ui.MusicBrowserActivity}" drawable="mi_music" name="Mi Music" />
   <item component="ComponentInfo{com.miui.notes/com.miui.notes.ui.NotesListActivity}" drawable="generic_notes" name="Mi Notes" />
   <item component="ComponentInfo{com.miui.notes/.ui.NotesListActivity}" drawable="generic_notes" name="Mi Notes" />
+  <item component="ComponentInfo{com.orange.miorange/com.orange.MainActivity}" drawable="moj_orange" name="Mi Orange" />
   <item component="ComponentInfo{com.mipay.wallet.in/com.mipay.home.ui.SplashActivity}" drawable="mi_pay" name="Mi Pay" />
   <item component="ComponentInfo{com.mipay.wallet.in/com.mipay.home.ui.HomeEntryActivity}" drawable="mi_pay" name="Mi Pay" />
   <item component="ComponentInfo{com.mipay.in.wallet/com.mipay.home.ui.SplashActivity}" drawable="mi_pay" name="Mi Pay" />
@@ -9563,6 +9603,7 @@
   <item component="ComponentInfo{com.oplus.vip/com.platform.usercenter.vip.UCVIPMainActivity}" drawable="my_oppo" name="My OPPO" />
   <item component="ComponentInfo{com.oplus.vip/com.platform.usercenter.vip.ui.splash.VipMainActivity}" drawable="my_oppo" name="My OPPO" />
   <item component="ComponentInfo{com.oppo.usercenter/com.platform.usercenter.vip.ui.splash.VipMainActivity}" drawable="my_oppo" name="My OPPO" />
+  <item component="ComponentInfo{com.orange.myorange.omd/com.orange.omnis.main.ui.MainActivity}" drawable="moj_orange" name="My Orange" />
   <item component="ComponentInfo{com.google.android.apps.tips/com.google.android.apps.tips.fortnite.base}" drawable="my_pixel" name="My Pixel" />
   <item component="ComponentInfo{com.google.android.apps.tips/com.google.android.apps.tips.fortnite.p7}" drawable="my_pixel" name="My Pixel" />
   <item component="ComponentInfo{com.rayadams.myqr/com.rayadams.myqr.MainActivity}" drawable="generic_qr_reader" name="My QR" />
@@ -9666,6 +9707,7 @@
   <item component="ComponentInfo{net.omobio.dialogsc/net.omobio.dialogsc.MainActivity}" drawable="my_robi" name="MyDialog" />
   <item component="ComponentInfo{com.digi.portal.mobdev.android/com.digi.portal.mobdev.android.MainActivity}" drawable="mydigi" name="MyDigi" />
   <item component="ComponentInfo{com.digicel.selfcare.mobile/com.example.mda.MainActivity}" drawable="mydigicel" name="MyDigicel" />
+  <item component="ComponentInfo{com.digicelpacific.selfcare.mobile/com.example.mda.MainActivity}" drawable="mydigicel" name="MyDigicel" />
   <item component="ComponentInfo{com.mydramalist.app/com.mydramalist.app.MainActivity}" drawable="mydramalist" name="MyDramaList" />
   <item component="ComponentInfo{com.edenred.eq.myedenred/com.edenred.eq.myedenred.MainActivity}" drawable="edenred" name="MyEdenred" />
   <item component="ComponentInfo{com.edenred.eq.myedenred/crc64e4c9e84ae407dfca.SplashActivity}" drawable="edenred" name="MyEdenred" />
@@ -9738,6 +9780,7 @@
   <item component="ComponentInfo{ua.raiffeisen.myraif/ua.raiffeisen.myraif.main.MainActivity}" drawable="raiffeisen_bank" name="MyRaif" />
   <item component="ComponentInfo{id.net.myrepublic/id.net.myrepublic.MainActivity}" drawable="myrep" name="MyRep" />
   <item component="ComponentInfo{com.fivemobile.myaccount/com.rogers.genesis.ui.splash.SplashActivity}" drawable="myrogers" name="MyRogers" />
+  <item component="ComponentInfo{de.santander.presentation/de.santander.presentation.launcher_831074a3b7d145936d0f5f6bd9d22c4dab85da4fe3b97b6d3be4262839725fb1}" drawable="santander" name="MySantander" />
   <item component="ComponentInfo{my.gov.onegovappstore.mysejahtera/my.gov.onegovappstore.mysejahtera.MainActivity}" drawable="mysejahtera" name="MySejahtera" />
   <item component="ComponentInfo{com.slt.selfcare/com.slt.selfcare.SplashActivity}" drawable="mobitel_selfcare" name="MySLT" />
   <item component="ComponentInfo{com.solaredge.homeowner/com.solaredge.homeowner.ui.SplashScreenActivity}" drawable="mysolaredge" name="mySolarEdge" />
@@ -9953,6 +9996,7 @@
   <item component="ComponentInfo{com.netease.cloudmusic/com.squareup.leakcanary.internal.DisplayLeakActivity}" drawable="netease_music" name="NetEase Music" />
   <item component="ComponentInfo{com.netease.cloudmusic/com.netease.cloudmusic.activity.IconChangeDefaultAlias}" drawable="netease_music" name="NetEase Music" />
   <item component="ComponentInfo{com.netease.cloudmusic/com.netease.cloudmusic.activity.LoadingActivity}" drawable="netease_music" name="NetEase Music" />
+  <item component="ComponentInfo{com.moneybookers.skrillpayments.neteller/com.moneybookers.skrillpayments.v2.ui.launcher.LauncherActivity}" drawable="paysafecard" name="Neteller" />
   <item component="ComponentInfo{com.netflix.mediaclient/com.piyush.music.activities.main.MainActivity}" drawable="netflix" name="Netflix" />
   <item component="ComponentInfo{com.netflix.mediaclient/com.battlenet.showguide.SplashActivity}" drawable="netflix" name="Netflix" />
   <item component="ComponentInfo{com.netflix.mediaclient/com.netflix.mediaclient.ui.launch.UIWebViewActivity}" drawable="netflix" name="Netflix" />
@@ -10249,6 +10293,7 @@
   <item component="ComponentInfo{com.bskyb.nowtv.beta/com.nowtv.startup.StartupActivity}" drawable="now" name="NOW" />
   <item component="ComponentInfo{com.nowtv.it/com.nowtv.startup.StartupActivity}" drawable="now" name="NOW" />
   <item component="ComponentInfo{com.bskyb.nowtv.beta/com.peacocktv.legacy.monolith.main.MainActivity}" drawable="now" name="NOW" />
+  <item component="ComponentInfo{irheral.edge.nowplaying/edge.irheral.nowplaying.MainActivity}" drawable="generic_player" name="Now Playing for Edge Screen" />
   <item component="ComponentInfo{com.js.nowakelock/com.js.nowakelock.ui.mainActivity.MainActivity}" drawable="nowakelock" name="NoWakeLock" />
   <item component="ComponentInfo{sg.edu.np.npgo/sg.edu.np.npgo.MainActivity}" drawable="np_go" name="NP Go" />
   <item component="ComponentInfo{com.wn.app.np/player.normal.np.activity.NPMainActivity}" drawable="np_manager" name="NP Manager" />
@@ -10348,6 +10393,8 @@
   <item component="ComponentInfo{cz.o2.moje/o2.app.system.MainActivity}" drawable="o2" name="O2" />
   <item component="ComponentInfo{com.goldengekko.o2pm/com.goldengekko.o2pm.presentation.launch.LaunchActivity}" drawable="o2" name="O2" />
   <item component="ComponentInfo{OCTech.Mobile.Applications.TouchScan/octech.mobile.applications.touchscan.MainActivity}" drawable="generic_engine" name="OBD Fusion" />
+  <item component="ComponentInfo{OCTech.Mobile.Applications.TouchScan/crc642308c43e766bd67c.MainActivity}" drawable="generic_engine" name="OBD Fusion" />
+  <item component="ComponentInfo{com.chaoyue.obdpro/com.chaoyue.obdpro.app.SplashActivity}" drawable="generic_engine" name="OBD Home" />
   <item component="ComponentInfo{com.elm.elm327.obd2.eobd.obd.car.scanner.diagnostics.tool.dashboard.doctor.check.engine.torque.speed.trouble.codes.mary/com.scanner.obd.ui.activity.MainActivity}" drawable="generic_engine" name="Obd Mary" />
   <item component="ComponentInfo{com.obedience/com.obedience.settings.DefaultAlias}" drawable="obedience" name="Obedience" />
   <item component="ComponentInfo{com.obedience/com.obedience.DefaultAlias}" drawable="obedience" name="Obedience" />
@@ -10855,6 +10902,7 @@
   <item component="ComponentInfo{com.palmonas/com.palmonas.MainActivity}" drawable="palmonas" name="Palmonas" />
   <item component="ComponentInfo{com.transsnet.palmpay/com.transsnet.palmpay.ui.activity.SplashActivity}" drawable="palmpay" name="PalmPay" />
   <item component="ComponentInfo{com.pandavideocompressor/com.pandavideocompressor.infrastructure.splash.SplashScreenActivity}" drawable="panda_video_compressor" name="Panda Video Compressor" />
+  <item component="ComponentInfo{com.pandavideocompressor/com.pandavideocompressor.ui.splash.SplashScreenActivity}" drawable="panda_video_compressor" name="Panda Video Compressor" />
   <item component="ComponentInfo{com.pandora.android/com.pandora.android.Main}" drawable="pandora" name="Pandora" />
   <item component="ComponentInfo{com.pandora.android/com.pandora.android.LauncherActivity}" drawable="pandora" name="Pandora" />
   <item component="ComponentInfo{ru.alarmtrade.pandora/ru.alarmtrade.pandora.ui.LoginActivity_}" drawable="pandora_online" name="Pandora Online" />
@@ -11384,6 +11432,7 @@
   <item component="ComponentInfo{com.jaween.paint/com.jaween.paint.MainActivity}" drawable="pixel_brush" name="Pixel Brush" />
   <item component="ComponentInfo{twelve.clock.mibrahim/twelve.clock.mibrahim.MainActivity}" drawable="pixel_clock_widgets" name="Pixel Clock Widgets" />
   <item component="ComponentInfo{twelve.clock.mibrahim/twelve.clock.mibrahim.Thebase}" drawable="pixel_clock_widgets" name="Pixel Clock Widgets" />
+  <item component="ComponentInfo{com.mkm.pew/com.mkm.pew.MainActivity}" drawable="tgmonet_theme" name="Pixel Emoji Wallpaper" />
   <item component="ComponentInfo{ru.pt.iconpack.pixel/ru.pt.iconpack.pixel.activities.MainActivity}" drawable="pixel_icons" name="Pixel Icons" />
   <item component="ComponentInfo{ru.pt.iconpack.pixel/ru.pt.iconpack.pixel.activities.Check_GDPR}" drawable="pixel_icons" name="Pixel Icons" />
   <item component="ComponentInfo{dev.bluehouse.enablevolte/dev.bluehouse.enablevo}" drawable="pixel_ims" name="Pixel IMS" />
@@ -11516,8 +11565,10 @@
   <item component="ComponentInfo{com.play.playnow/com.n7mobile.playnow.ui.MainActivity}" drawable="play_now" name="PLAY NOW" />
   <item component="ComponentInfo{ch.srgssr.playsuisse.tv/ch.srgssr.playsuisse.tv.LaunchActivity}" drawable="play_suisse" name="Play Suisse" />
   <item component="ComponentInfo{ch.srgssr.playsuisse.tv/ch.srgssr.playsuisse.tv.MainActivity}" drawable="play_suisse" name="Play Suisse" />
+  <item component="ComponentInfo{com.mta.videotube.playtube/com.video.playtube.SplashActivity}" drawable="generic_player" name="Play Tube" />
   <item component="ComponentInfo{com.play.play24m/com.miquido.play360.activity.EntryActivity}" drawable="play24" name="Play24" />
   <item component="ComponentInfo{com.androxus.playback/com.androxus.playback.presentation.SplashActivity}" drawable="just_player" name="PlayBack" />
+  <item component="ComponentInfo{com.androxus.playback/com.androxus.playback.presentation.main_activity_2.MainActivity2}" drawable="just_player" name="Playback" />
   <item component="ComponentInfo{com.tbig.playerprotrial/com.tbig.playerprotrial.MusicBrowserActivityy}" drawable="generic_player" name="PlayerPro Music Player" />
   <item component="ComponentInfo{com.tbig.playerpro/com.tbig.playerpro.MusicBrowserActivity}" drawable="generic_player_pro" name="PlayerPro Music Player (Pro)" />
   <item component="ComponentInfo{com.teamhub.playhub/com.teamhub.playhub.MaiPop}" drawable="playhub" name="PlayHUB" />
@@ -11583,6 +11634,9 @@
   <item component="ComponentInfo{com.sodexo.consumers.chile/com.sodexo.consumers.SplashActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{agency.equilibrio.sodexomexico/agency.equilibrio.sodexomexico.MainActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{pl.sodexo.dlaciebie2.app/pl.sodexo.dlaciebie2.app.ui.login.LoginActivity}" drawable="pluxee" name="Pluxee" />
+  <item component="ComponentInfo{com.sodexo.app.pt/es.alt10.project.android.MainAppActivity}" drawable="pluxee" name="Pluxee" />
+  <item component="ComponentInfo{com.sodexo.consumers.colombia/com.sodexo.consumers.SplashActivity}" drawable="pluxee" name="Pluxee" />
+  <item component="ComponentInfo{com.sodexo.flexogift/com.sodexo.flexogift.MainActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{com.Version1/com.Version1.Version1}" drawable="pnb_one" name="PNB ONE" />
   <item component="ComponentInfo{in.pnb.pnbparivaar/in.pnb.pnbparivaar.MainActivity}" drawable="pnb_one" name="PNB Parivar" />
   <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.pnc.mbl.android.application.legacy.ui.MainActivity}" drawable="pnc" name="PNC" />
@@ -12014,6 +12068,7 @@
   <item component="ComponentInfo{com.teskann.quax/com.teskann.quax.MainActivity}" drawable="quax" name="QuaX" />
   <item component="ComponentInfo{com.hero.iot/com.hero.iot.ui.splash.LoadingActivity}" drawable="qubo" name="Qubo" />
   <item component="ComponentInfo{m.hero.iot/com.hero.iot.ui.splash.LoadingActivity}" drawable="qubo" name="Qubo" />
+  <item component="ComponentInfo{com.qubotracker.iot/app.qubotracker.iot.ui.splash.SplashActivity}" drawable="qubo" name="Qubo Go" />
   <item component="ComponentInfo{com.querodelivery/com.querodelivery.MainActivity}" drawable="quero_delivery" name="quero delivery" />
   <item component="ComponentInfo{com.querodelivery/com.querodelivery.SplashActivity}" drawable="quero_delivery" name="quero delivery" />
   <item component="ComponentInfo{br.com.queropassagem/br.com.queropassagem.MainActivity}" drawable="quero_passagem" name="Quero Passagem" />
@@ -12402,6 +12457,7 @@
   <item component="ComponentInfo{com.retroarch/com.retroarch.browser.mainmenu.MainMenuActivity}" drawable="retroarch" name="RetroArch" />
   <item component="ComponentInfo{com.retroarch.aarch64/com.retroarch.browser.mainmenu.MainMenuActivity}" drawable="retroarch" name="RetroArch Plus" />
   <item component="ComponentInfo{com.thomsonreuters.reuters/com.thomsonreuters.reuters.MainActivity}" drawable="reuters" name="Reuters" />
+  <item component="ComponentInfo{anddea.yrf.tube/com.google.android.youtube.app.honeycomb.Shell}" drawable="revanced_extended" name="Revanced Advanced" />
   <item component="ComponentInfo{anddea.yrf.tube/com.google.android.youtube.app.honeycomb.Shell}" drawable="revanced_extended" name="Revanced Advanced" />
   <item component="ComponentInfo{yt.rvx.noname.exe/com.google.android.youtube.app.honeycomb.Shell}" drawable="revanced_extended" name="ReVanced Extended" />
   <item component="ComponentInfo{yt.rvx.noname.exe/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="revanced_extended" name="ReVanced Extended" />
@@ -12828,6 +12884,7 @@
   <item component="ComponentInfo{es.bancosantander.apps/es.bancosantander.apps.mobile.android.activities.PublicActivity}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{cl.santander.smartphone/cl.santander.smartphone.SplashActivity}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{uy.com.Santander/uy.com.infocorp.icbanking.MainActivity}" drawable="santander" name="Santander" />
+  <item component="ComponentInfo{com.sovereign.santander/com.santander.us.splash.view.SplashActivity}" drawable="santander" name="Santander" />
   <item component="ComponentInfo{com.saq.android/com.saq.android.splash.SplashActivity}" drawable="saq" name="SAQ" />
   <item component="ComponentInfo{com.saq.android/com.saq.android.main.MainActivity}" drawable="saq" name="SAQ" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.sardinian/com.anysoftkeyboard.languagepack.sardinian.MainActivity}" drawable="anysoftkeyboard" name="Sardinian for AnySoftKeyboard" />
@@ -12988,6 +13045,7 @@
   <item component="ComponentInfo{com.zwo.seestar/com.zwo.seestar.SplashActivity}" drawable="seestar" name="Seestar" />
   <item component="ComponentInfo{com.ninebot.segway/cn.ninebot.ninebot.mainshell.SplashActivity}" drawable="segway_mobility" name="Segway Mobility" />
   <item component="ComponentInfo{cn.ninebot.ninebot/cn.ninebot.ninebot.mainshell.SplashActivity}" drawable="segway_mobility" name="Segway Mobility" />
+  <item component="ComponentInfo{com.segway.orv/com.segway.orv.SplashActivity}" drawable="segway_mobility" name="Segway Powersports" />
   <item component="ComponentInfo{saurabhrao.selfattendance/saurabhrao.selfattendance.MainActivity}" drawable="self_attendance" name="Self Attendance" />
   <item component="ComponentInfo{edu.senati.app/edu.senati.app.MainActivity}" drawable="senati" name="SENATI" />
   <item component="ComponentInfo{com.estmob.android.sendanywhere/com.estmob.paprika4.activity.SplashActivity}" drawable="send_anywhere" name="Send Anywhere" />
@@ -13667,6 +13725,7 @@
   <item component="ComponentInfo{com.streema.simpleradio/com.streema.simpleradio.MainActivity}" drawable="simple_radio" name="Simple Radio" />
   <item component="ComponentInfo{simple.reboot.com/simple.reboot.com.MainActivity}" drawable="simple_reboot" name="Simple Reboot" />
   <item component="ComponentInfo{com.simplescan.scanner/com.simpleapp.tinyscanfree.Activity_Start}" drawable="simple_scan" name="Simple Scan" />
+  <item component="ComponentInfo{de.tobiasbielefeld.searchbar/de.tobiasbielefeld.searchbar.ui.MainActivity}" drawable="generic_search" name="Simple Search" />
   <item component="ComponentInfo{com.simplemobiletools.smsmessenger/com.simplemobiletools.smsmessenger.activities.SimplePhSplashActivity.Orange}" drawable="messages" name="Simple SMS Messenger" />
   <item component="ComponentInfo{com.simplemobiletools.smsmessenger/com.simplemobiletools.smsmessenger.activities.SplashActivity.Amber}" drawable="messages" name="Simple SMS Messenger" />
   <item component="ComponentInfo{com.simplemobiletools.smsmessenger/com.simplemobiletools.smsmessenger.activities.SplashActivity.Blue}" drawable="messages" name="Simple SMS Messenger" />
@@ -13842,6 +13901,7 @@
   <item component="ComponentInfo{air.com.hypah.io.slither/air.com.hypah.io.slither.AIRAppEntry}" drawable="slither_io" name="slither.io" />
   <item component="ComponentInfo{org.herrlado.ask.languagepack.slovak/org.herrlado.ask.languagepack.slovak.MainActivity}" drawable="anysoftkeyboard" name="Slovak for AnySoftKeyboard" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.slovene/com.anysoftkeyboard.languagepack.slovene.MainActivity}" drawable="anysoftkeyboard" name="Slovene for AnySoftKeyboard" />
+  <item component="ComponentInfo{com.proframeapps.videoframeplayer/com.proframeapps.videoframeplayer.ui.MainActivity}" drawable="just_player" name="Slow Motion Frame Video Player" />
   <item component="ComponentInfo{com.slowlyapp/com.slowlyapp.MainActivity}" drawable="slowly" name="Slowly" />
   <item component="ComponentInfo{com.smallcase.android/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="smallcase" name="smallcase" />
   <item component="ComponentInfo{com.smallcase.android/com.smallcase.android.MainActivity}" drawable="smallcase" name="smallcase" />
@@ -15176,6 +15236,7 @@
   <item component="ComponentInfo{com.nytimes.android/com.nytimes.android.activity.MainActivity}" drawable="the_new_york_times" name="The New York Times" />
   <item component="ComponentInfo{com.nytimes.android/com.nytimes.android.activity.MainActivity_}" drawable="the_new_york_times" name="The New York Times" />
   <item component="ComponentInfo{com.nytimes.android/com.nytimes.android.MainActivity}" drawable="the_new_york_times" name="The New York Times" />
+  <item component="ComponentInfo{com.nytimes.cn/com.nytimes.cn.MainActivity}" drawable="the_new_york_times" name="The New York Times" />
   <item component="ComponentInfo{com.theracemadialtd.therace/crc643f8e59ff9f999875.SplashActivity}" drawable="the_race" name="The Race" />
   <item component="ComponentInfo{com.ea.gp.simsmobile/com.ea.gp.simsmobile.TSMActivity}" drawable="the_sims" name="The Sims" />
   <item component="ComponentInfo{com.ea.games.simsfreeplay_row/com.ea.games.simsfreeplay.GameActivity}" drawable="the_sims" name="The Sims FreePlay" />
@@ -15626,6 +15687,7 @@
   <item component="ComponentInfo{com.tui.tda.dk/com.tui.tda.activities.LauncherActivity}" drawable="tui" name="TUI" />
   <item component="ComponentInfo{de.tui.tuicom/com.tui.tda.activities.LauncherActivity}" drawable="tui" name="TUI" />
   <item component="ComponentInfo{com.thomson.mythomson/com.tui.tda.activities.LauncherActivity}" drawable="tui" name="TUI" />
+  <item component="ComponentInfo{com.softhis.tui/pl.tui.app.main.MainActivity}" drawable="tui" name="TUI" />
   <item component="ComponentInfo{com.tumblr/com.tumblr.ui.activity.RootActivity}" drawable="tumblr" name="Tumblr" />
   <item component="ComponentInfo{com.tumblr/com.tumblr.ui.activity.JumpoffActivity}" drawable="tumblr" name="Tumblr" />
   <item component="ComponentInfo{org.transhelp.bykerr/org.transhelp.bykerr.uiRevamp.ui.activities.SplashActivity}" drawable="tummoc" name="Tummoc" />
@@ -16996,6 +17058,8 @@
   <item component="ComponentInfo{com.lonelycatgames.Xplore/com.lonelycatgames.Xplore.Browser}" drawable="x_plore" name="X-plore" />
   <item component="ComponentInfo{com.security.xvpn.z35kb/com.security.xvpn.z35kb.LaunchActivity}" drawable="x_vpn" name="X-VPN" />
   <item component="ComponentInfo{com.security.xvpn.z35kb/com.security.xvpn.z35kb.SplashActivity}" drawable="x_vpn" name="X-VPN" />
+  <item component="ComponentInfo{com.inspiredsquare.blocks/com.unity3d.player.UnityPlayerActivity}" drawable="_2048" name="X2 Blocks: 2048 Number Game" />
+  <item component="ComponentInfo{com.unicostudio.x2number/com.unity3d.player.UnityPlayerActivity}" drawable="_2048" name="X2 Puzzle: Number Merge 2048" />
   <item component="ComponentInfo{com.xrpllabs.xumm/com.xrpllabs.xumm.MainActivity}" drawable="xaman_wallet" name="Xaman Wallet" />
   <item component="ComponentInfo{com.gsm.customer/com.gsm.customer.ui.splash.SplashActivity}" drawable="xanh_sm" name="Xanh SM" />
   <item component="ComponentInfo{com.gsm.customer/com.emddicustomer.MainActivity}" drawable="xanh_sm" name="Xanh SM" />
@@ -17870,6 +17934,7 @@
   <item component="ComponentInfo{com.example.businesshall/com.mc10086.cmcc.base.StartPageActivity}" drawable="china_mobile" name="中国移动浙江 ~~ China Mobile Zhejiang" />
   <item component="ComponentInfo{com.sinovatech.unicom.ui/com.sinovatech.unicom.basic.ui.activity.WelcomeClient}" drawable="china_unicom" name="中国联通 ~~ China Unicom" />
   <item component="ComponentInfo{com.chinamworld.bocmbci/com.boc.bocsoft.mobile.bocmobile.buss.system.splash.SplashActivity}" drawable="bank_of_china" name="中国银行 ~~ Bank of China" />
+  <item component="ComponentInfo{com.boc.bocsoft.bocmbovsa.buss/com.boc.bocsoft.bocmbovsa.buss.system.splash.activity.SplashActivity}" drawable="bank_of_china" name="中国银行 ~~ Bank of China" />
   <item component="ComponentInfo{com.bjetc.mobile/com.bjetc.mobile.ui.splash.SplashActivity}" drawable="bjetc" name="乐速通 ~~ BJETC" />
   <item component="ComponentInfo{com.miHoYo.cloudgames.hkrpg/com.mihoyo.cloudgame.ui.SplashActivity}" drawable="honkai_star_rail_cloud" name="云·星穹铁道 ~~ Honkai: Star Rail · Cloud" />
   <item component="ComponentInfo{com.ruanmei.yunrili/com.ruanmei.yunrili.ui.MainActivity}" drawable="yunrili" name="云日历 ~~ Yunrili" />


### PR DESCRIPTION
## Linked
2048 (`com.alexblackapps.game2048` → `_2048.svg`)
2048 for smart watch (`com.fastsoft.game2048w` → `_2048.svg`)
2048 Merge Games - M2 Blocks (`merge.blocks.drop.number.puzzle.games` → `_2048.svg`)
2048 Plus (`com.spring.bird.game2048plus` → `_2048.svg`)
2048: Drop And Merge (`io.github.aleksdev.g2048` → `_2048.svg`)
2k48 - 4 puzzle modes (`com.LoopGames.game2048` → `_2048.svg`)
2K48 - Number 2048 puzzle game (`com.estoty.game2048` → `_2048.svg`)
Amex (`com.americanexpress.android.acctsvcs.nl` → `american_express_amex.svg`)
APK Extractor (`com.iamnbty.apkextractor` → `generic_shell.svg`)
Barclays Bank (`com.barclaycardus` → `barclays_bank.svg`)
BBVA (`com.bbva.glomo.uy` → `bbva.svg`)
BitLife (`com.goodgamestudios.bitlife.br.portugues.simulacao.de.vida` → `bitlife.svg`)
Citibank (`com.citibank.mobile.au` → `citibank.svg`)
Citibank (`com.citibank.mobile.sg` → `citibank.svg`)
CitiDirect (`com.citi.mobile.cdbe` → `citibank.svg`)
CitiManager (`com.citi.mobile.ccc` → `citibank.svg`)
Costco (`intl.costco.com.mobile.australia` → `costco.svg`)
Costco (`intl.costco.com.mobile.uk` → `costco.svg`)
CTU Menza (`cz.lastaapps.menza` → `generic_silverware.svg`)
Denon Remote (`com.dmholdings.denonremoteapp` → `just_player.svg`)
Developer Options Shortcut (`org.aospstudio.devoptions` → `generic_braces.svg`)
DHL (`com.dhlparcel.nl` → `dhl.svg`)
DHL Express (`com.dhl.exp.dhlmobile` → `dhl.svg`)
Docs Reader (`docsreader.fileopener.word.office.offlineviewer` → `google_docs.svg`)
Docx Reader (`com.skydot.docxreader.docx.docxviewer.document.doc.office.viewer.reader.word` → `google_docs.svg`)
e&amp; (`com.etisalat.flous` → `eand.svg`)
e&amp; (`com.etisalat.ewallet` → `eand.svg`)
Flappy Bird (`com.flappybird.game` → `flappy_bird.svg`)
Flappy Bird (`com.flappybird.recreation` → `flappy_bird.svg`)
Get Followers Likes For Ins (`com.pictext.followersedit` → `generic_heart.svg`)
GoTyme Bank (`ph.com.gotyme` → `gotyme_bank.svg`)
Hive Social (`org.hiveinc.TheHive.android` → `hive_social.svg`)
IAmNotADeveloper (`top.ltfan.notdeveloper` → `generic_shell.svg`)
IITC (`com.pmmmwh.iitc` → `iitc.svg`)
JStudio (`com.qamar.ide.java` → `generic_braces.svg`)
LINE Bank (`com.linebank.tw` → `line_bank.svg`)
LuaDroid (`com.alif.ide.lua` → `generic_braces.svg`)
Mi Claro (`com.claro.miclaro` → `mi_claro.svg`)
Mi Claro (`com.claroecuador.miclaro` → `mi_claro.svg`)
Mi Orange (`com.orange.miorange` → `moj_orange.svg`)
My Orange (`com.orange.myorange.omd` → `moj_orange.svg`)
MyDigicel (`com.digicelpacific.selfcare.mobile` → `mydigicel.svg`)
MySantander (`de.santander.presentation` → `santander.svg`)
Neteller (`com.moneybookers.skrillpayments.neteller` → `paysafecard.svg`)
Now Playing for Edge Screen (`irheral.edge.nowplaying` → `generic_player.svg`)
OBD Fusion (`OCTech.Mobile.Applications.TouchScan` → `generic_engine.svg`)
OBD Home (`com.chaoyue.obdpro` → `generic_engine.svg`)
Panda Video Compressor (`com.pandavideocompressor` → `panda_video_compressor.svg`)
Pixel Emoji Wallpaper (`com.mkm.pew` → `tgmonet_theme.svg`)
Play Tube (`com.mta.videotube.playtube` → `generic_player.svg`)
Playback (`com.androxus.playback` → `just_player.svg`)
Pluxee (`com.sodexo.app.pt` → `pluxee.svg`)
Pluxee (`com.sodexo.consumers.colombia` → `pluxee.svg`)
Pluxee (`com.sodexo.flexogift` → `pluxee.svg`)
Qubo Go (`com.qubotracker.iot` → `qubo.svg`)
Revanced Advanced (`anddea.yrf.tube` → `revanced_extended.svg`)
Santander (`com.sovereign.santander` → `santander.svg`)
Segway Powersports (`com.segway.orv` → `segway_mobility.svg`)
Simple Search (`de.tobiasbielefeld.searchbar` → `generic_search.svg`)
Slow Motion Frame Video Player (`com.proframeapps.videoframeplayer` → `just_player.svg`)
The New York Times (`com.nytimes.cn` → `the_new_york_times.svg`)
TUI (`com.softhis.tui` → `tui.svg`)
X2 Blocks: 2048 Number Game (`com.inspiredsquare.blocks` → `_2048.svg`)
X2 Puzzle: Number Merge 2048 (`com.unicostudio.x2number` → `_2048.svg`)
中国银行 ~~ Bank of China (`com.boc.bocsoft.bocmbovsa.buss` → `bank_of_china.svg`)