### PR TITLE
+22 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1041,6 +1041,7 @@
   <item component="ComponentInfo{com.asus.weathertime/com.asus.weathertime.WeatherTimeSettings}" drawable="asus_weather" name="ASUS Weather" />
   <item component="ComponentInfo{com.ecareme.asuswebstorage/com.ecareme.asuswebstorage.view.common.SplashActivity}" drawable="asus_webstorage" name="ASUS WebStorage" />
   <item component="ComponentInfo{nz.govt.at.atmobile/nz.govt.at.atmobile.MainActivity}" drawable="at_mobile" name="AT Mobile" />
+  <item component="ComponentInfo{com.atpc/com.at.MainActivity}" drawable="generic_player" name="AT Player" />
   <item component="ComponentInfo{com.att.myWireless/com.att.myWireless.RNMainActivity}" drawable="at_and_t" name="AT&amp;T" />
   <item component="ComponentInfo{com.att.miatt/com.comviva.webaxn.ui.WebAxnActivity}" drawable="at_and_t" name="AT&amp;T" />
   <item component="ComponentInfo{com.att.callprotect/com.hiya.aegis.ui.HomeScreenActivity}" drawable="yet_another_call_blocker" name="AT&amp;T Call Protect" />
@@ -1552,8 +1553,10 @@
   <item component="ComponentInfo{com.andromo.dev137436.app249505/com.ryanheise.audioservice.AudioServiceActivity}" drawable="generic_bible" name="Bible (Douay-Rheims Version)" />
   <item component="ComponentInfo{app.bible.lite.offline/youversion.bible.app.MainActivity}" drawable="generic_bible" name="Bible App Lite" />
   <item component="ComponentInfo{com.offline.bible/com.offline.bible.IconDefault}" drawable="generic_bible" name="Bible Offline" />
+  <item component="ComponentInfo{com.bestweatherfor.bibleoffline_pt_ra/com.bestweatherfor.bibleoffline_pt_ra.bibleoffline.splash.Splash}" drawable="generic_bible" name="Bible Offline KJV with Audio" />
   <item component="ComponentInfo{org.bsfinternational.bsfapp/org.bsfinternational.bsfapp.MainActivity}" drawable="bible_study_fellowship" name="Bible Study Fellowship" />
   <item component="ComponentInfo{com.bibleproject/com.bibleproject.MainActivity}" drawable="bibleproject" name="BibleProject" />
+  <item component="ComponentInfo{tepteev.ihar.biblia_takatifu.AOURLCUBZSMVVVVE/king.james.bible.android.activity.LaunchActivity}" drawable="generic_bible" name="Biblia" />
   <item component="ComponentInfo{app.redia.dk.biblioteket/app.redia.dk.biblioteket.MainActivity}" drawable="biblioteket" name="Biblioteket" />
   <item component="ComponentInfo{education.bibliotech.Bibliotech/education.bibliotech.Bibliotech.MainActivity}" drawable="bibliu" name="BibliU" />
   <item component="ComponentInfo{pl.jmpolska.clos0.mojabiedronka/pl.jmpolska.mojabiedronka.presentation.flows.main.MainActivity}" drawable="biedronka" name="Biedronka" />
@@ -1785,11 +1788,14 @@
   <item component="ComponentInfo{me.bluemail.mail/com.trtf.blue.activity.Accounts}" drawable="bluemail" name="BlueMail" />
   <item component="ComponentInfo{xyz.blueskyweb.app/xyz.blueskyweb.app.MainActivity}" drawable="bluesky" name="Bluesky" />
   <item component="ComponentInfo{com.android.bluetooth/com.android.bluetooth.opp.BluetoothOppLauncherActivity}" drawable="bluetooth" name="Bluetooth" />
+  <item component="ComponentInfo{com.rockfort.bluetoothinfo/com.rockfort.bluetoothinfo.activity.PermissionsActivity}" drawable="generic_bluetooth" name="Bluetooth Devices Info" />
   <item component="ComponentInfo{io.appground.blek/io.appground.blek.MainActivity}" drawable="bluetooth_keyboard_and_mouse" name="Bluetooth Keyboard &amp; Mouse" />
   <item component="ComponentInfo{de.simon.dankelmann.bluetoothlespam.debug/de.simon.dankelmann.bluetoothlespam.MainActivity}" drawable="bluetooth_le_spam" name="Bluetooth LE Spam" />
   <item component="ComponentInfo{de.simon.dankelmann.bluetoothlespam/de.simon.dankelmann.bluetoothlespam.MainActivity}" drawable="bluetooth_le_spam" name="Bluetooth LE Spam" />
   <item component="ComponentInfo{com.atharok.btremote/com.atharok.btremote.presentation.activities.MainActivity}" drawable="remote_for_android_tv" name="Bluetooth Remote" />
   <item component="ComponentInfo{com.atharok.btremote.gplay/com.atharok.btremote.presentation.activities.MainActivity}" drawable="remote_for_android_tv" name="Bluetooth Remote" />
+  <item component="ComponentInfo{com.shawal.sender/com.shawal.sender.activities.SplashActivity}" drawable="generic_bluetooth" name="Bluetooth Sender" />
+  <item component="ComponentInfo{com.metris.xposed.bluetoothToolkitFree/com.metris.xposed.bluetoothToolkitFree.Alias}" drawable="generic_bluetooth" name="Bluetooth ToolKit [XPOSED]" />
   <item component="ComponentInfo{com.pixelapestudios.bluk/com.pixelapestudios.bluk.RunnerActivity}" drawable="bluk" name="BLUK" />
   <item component="ComponentInfo{com.indigomadina.bluric/com.indigomadina.bluric.activities.MainActivity}" drawable="bluric" name="Bluric" />
   <item component="ComponentInfo{com.indigomadina.bluric/com.indigomadina.bluric.activities.SplashActivity}" drawable="bluric" name="Bluric" />
@@ -2197,6 +2203,7 @@
   <item component="ComponentInfo{co.id.bankbsi.superapp/co.id.bankbsi.superapp.screen.splashscreen.SplashScreenActivity}" drawable="byond" name="BYOND" />
   <item component="ComponentInfo{com.bzzzapp/com.bzzzapp.ux.MainActivity}" drawable="bz_reminder" name="BZ Reminder" />
   <item component="ComponentInfo{com.bzzzapp.pro/com.bzzzapp.ux.MainActivity}" drawable="bz_reminder_pro" name="BZ Reminder PRO" />
+  <item component="ComponentInfo{com.fullcodex.bible.abdj/com.fullcodex.bible.abdj.ui.SplashScreenActivity}" drawable="generic_bible" name="Bíblia de Jerusalém" />
   <item component="ComponentInfo{com.labmcs.freebibliastrong/com.labsmcs.freebibliastrong.main.MainActivity}" drawable="biblia_strong" name="Bíblia Strong" />
   <item component="ComponentInfo{com.radinc.csharpshell/crc6435a96f15045e045c.MainActivity}" drawable="c_sharp_shell_dot_net_ide" name="C# Shell .NET IDE" />
   <item component="ComponentInfo{com.radinc.csharpshell/crc6483cd2bca369317c1.MainActivity}" drawable="c_sharp_shell_dot_net_ide" name="C# Shell .NET IDE" />
@@ -3357,6 +3364,7 @@
   <item component="ComponentInfo{air.com.RustyLake.CubeEscapeCollection/air.com.RustyLake.CubeEscapeCollection.AIRAppEntry}" drawable="cube_escape_collection" name="Cube Escape Collection" />
   <item component="ComponentInfo{air.com.RustyLake.CubeEscapeParadox/air.com.RustyLake.CubeEscapeParadox.AIRAppEntry}" drawable="cube_escape_collection" name="Cube Escape: Paradox" />
   <item component="ComponentInfo{com.jeffprod.cubesolver/com.jeffprod.cubesolver.MainActivity}" drawable="cube_solver" name="Cube Solver" />
+  <item component="ComponentInfo{com.aseemsalim.puzzlesolver.rcs/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="cube_solver" name="Cube Solver" />
   <item component="ComponentInfo{com.avelsoft.cubetimer/com.avelsoft.cubetimer.CubeTimerActivity}" drawable="remixlive" name="Cube Timer" />
   <item component="ComponentInfo{org.cuberite.android/org.cuberite.android.MainActivity}" drawable="cuberite" name="Cuberite" />
   <item component="ComponentInfo{com.manojbhatt.cubiks/com.unity3d.player.UnityPlayerActivity}" drawable="cube_solver" name="Cubik's" />
@@ -4202,6 +4210,7 @@
   <item component="ComponentInfo{com.kin.easynotes/com.kin.easynotes.presentation.MainActivity}" drawable="easy_notes" name="Easy Notes" />
   <item component="ComponentInfo{me.easyapps.easynotes/com.kin.easynotes.presentation.MainActivity}" drawable="easy_notes" name="Easy Notes" />
   <item component="ComponentInfo{easynotes.notes.notepad.notebook.privatenotes.note/notes.easy.android.mynotes.ui.activities.SplashActivity}" drawable="easy_notes" name="Easy Notes" />
+  <item component="ComponentInfo{com.simpler.dialer/com.simpler.ui.activities.ContactsAppActivity}" drawable="generic_dialer" name="Easy Phone" />
   <item component="ComponentInfo{net.schueller.instarepost/net.schueller.instarepost.activities.MainActivity}" drawable="easy_repost" name="Easy Repost" />
   <item component="ComponentInfo{com.kitasoft.screenrec2/com.kitasoft.screenrec2.Launch}" drawable="kimcy_screen_recorder" name="Easy Screen Recorder 2" />
   <item component="ComponentInfo{ir.easytrader.orbis.m.twa/ir.easytrader.orbis.m.twa.LauncherActivity}" drawable="easy_trader" name="Easy Trader" />
@@ -4736,6 +4745,7 @@
   <item component="ComponentInfo{com.huawei.hidisk/.filemanager.FileManager}" drawable="generic_files" name="Files" />
   <item component="ComponentInfo{com.marc.files/nl.marc_apps.files.MainActivity}" drawable="generic_files" name="Files" />
   <item component="ComponentInfo{com.google.android.go.documentsui/com.android.documentsui.LauncherActivity}" drawable="generic_files" name="Files" />
+  <item component="ComponentInfo{com.folderv.gofiles/com.folderv.gofiles.GoFilesActivity}" drawable="generic_files" name="Files" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.FilesShortcut}" drawable="generic_files" name="Files (Google Shortcuts Launcher)" />
   <item component="ComponentInfo{com.google.android.apps.nbu.files/com.google.android.apps.nbu.files.home.HomeActivity}" drawable="files_by_google" name="Files by Google" />
   <item component="ComponentInfo{com.google.android.apps.nbu.files/.home.HomeActivity}" drawable="files_by_google" name="Files by Google" />
@@ -6411,6 +6421,7 @@
   <item component="ComponentInfo{com.ovelin.guitartuna/com.unity.purchasing.googleplay.VRPurchaseActivity}" drawable="guitartuna" name="GuitarTuna" />
   <item component="ComponentInfo{com.ovelin.guitartuna/com.ovelin.guitartuna.GuitarTunaActivity}" drawable="guitartuna" name="GuitarTuna" />
   <item component="ComponentInfo{com.ovelin.guitartuna/com.yousician.yousiciannative.GuitarTunaActivity}" drawable="guitartuna" name="GuitarTuna" />
+  <item component="ComponentInfo{com.ovelin.guitartuna/com.yousician.GuitarTunaActivity}" drawable="guitartuna" name="GuitarTuna" />
   <item component="ComponentInfo{com.ak.ta.divya.bhaskar.activity/com.dainikbhaskar.ui.MainActivity}" drawable="hindi_news" name="Gujarati News" />
   <item component="ComponentInfo{com.gumtree.android/com.gumtree.android.MainActivity}" drawable="gumtree" name="Gumtree" />
   <item component="ComponentInfo{com.ebay.gumtree.au/com.ebay.app.common.startup.SplashScreenActivity}" drawable="gumtree" name="Gumtree" />
@@ -6631,6 +6642,7 @@
   <item component="ComponentInfo{com.TeamCherry.HollowKnight/com.unity3d.player.UnityPlayerActivity}" drawable="hollow_knight" name="Hollow Knight" />
   <item component="ComponentInfo{me.garfieldhan.holmes/me.garfieldhan.holmes.MainActivity}" drawable="generic_shell" name="Holmes" />
   <item component="ComponentInfo{com.cover_corp.holoplus/com.cover_corp.holoplus.MainActivity}" drawable="holoplus" name="holoplus" />
+  <item component="ComponentInfo{br.biblia/br.biblia.SplashScreen}" drawable="generic_bible" name="Holy Bible" />
   <item component="ComponentInfo{com.solvus_lab.android.BibleEN_kjv/com.solvus_lab.android.BibleEN_kjv.IntroActivity}" drawable="generic_bible" name="Holy Bible (KJV)" />
   <item component="ComponentInfo{io.homeassistant.companion.android/io.homeassistant.companion.android.launch.LaunchActivity}" drawable="home_assistant" name="Home Assistant" />
   <item component="ComponentInfo{io.homeassistant.companion.android.minimal/io.homeassistant.companion.android.launch.LaunchActivity}" drawable="home_assistant" name="Home Assistant" />
@@ -7865,6 +7877,7 @@
   <item component="ComponentInfo{com.smartstudio.koki/com.smartstudio.koki.MainActivity}" drawable="koki" name="KÖKI" />
   <item component="ComponentInfo{fr.laposte.idn/fr.laposte.idn.entrypoints.LauncherEntrypoint}" drawable="lidentite_numerique_la_poste" name="L'Identité Numérique La Poste" />
   <item component="ComponentInfo{lequipe.fr/lequipe.fr.newhome.MainActivity}" drawable="lequipe" name="L'Équipe" />
+  <item component="ComponentInfo{biblia.para.mujeres.diaria/king.james.bible.android.activity.LaunchActivity}" drawable="generic_bible" name="La Biblia" />
   <item component="ComponentInfo{com.laboutiqueofficielle.app/com.ikomobi.lbo.main.MainActivity}" drawable="la_boutique_officielle" name="La Boutique Officielle" />
   <item component="ComponentInfo{fr.cityway.maas.lepilote/fr.cityway.product.presentation.view.activity.SplashScreenActivity}" drawable="la_metropole" name="La Métropole" />
   <item component="ComponentInfo{fr.laposte.lapostemobile/fr.laposte.lapostemobile.SplashScreenLauncher}" drawable="la_poste" name="La Poste" />
@@ -9637,6 +9650,7 @@
   <item component="ComponentInfo{com.telstra.mobile.android.mytelstra/com.telstra.mobile.android.mytelstra.activities.SplashActivity}" drawable="my_telstra" name="My Telstra" />
   <item component="ComponentInfo{com.vzw.hss.myverizon/com.vzw.hss.myverizon.main.activity.WidgetMainActivity}" drawable="my_verizon" name="My Verizon" />
   <item component="ComponentInfo{com.vzw.hss.myverizon/com.vzw.hss.myverizon.ui.activities.LauncherActivity}" drawable="my_verizon" name="My Verizon" />
+  <item component="ComponentInfo{com.vzw.hss.myverizon/com.vzw.mobilefirst.setup.views.activity.SetUpActivity}" drawable="my_verizon" name="My Verizon" />
   <item component="ComponentInfo{com.vttm.vietteldiscovery/com.vttm.myviettelV2.activity.NFirstUserActivity}" drawable="my_viettel" name="My Viettel" />
   <item component="ComponentInfo{com.vna.service.vvm/com.tmobile.vvm.application.activity.setup.WelcomeActivity}" drawable="my_visual_voicemail" name="My Visual Voicemail" />
   <item component="ComponentInfo{com.vna.service.vvm/com.vna.service.vvm.activity.setup.WelcomeActivity}" drawable="my_visual_voicemail" name="My Visual Voicemail" />
@@ -11038,6 +11052,7 @@
   <item component="ComponentInfo{net.one97.paytm/net.one97.paytm.landingpage.activity.AJRMainActivity}" drawable="paytm" name="Paytm" />
   <item component="ComponentInfo{net.one97.paytm/net.one97.paytm.PaytmActivity}" drawable="paytm" name="Paytm" />
   <item component="ComponentInfo{net.one97.paytm/net.one97.paytm.SplashActivity}" drawable="paytm" name="Paytm" />
+  <item component="ComponentInfo{net.one97.paytm/net.one97.paytm.alias_icon_stage2}" drawable="paytm" name="Paytm" />
   <item component="ComponentInfo{in.insider.consumer/in.insider.activity.SplashScreenActivity}" drawable="paytm_insider" name="Paytm Insider" />
   <item component="ComponentInfo{com.paytmmoney/com.paytmmoney.ui.splash.BaseSplashActivity}" drawable="paytm_money" name="Paytm Money" />
   <item component="ComponentInfo{com.hdfcbank.payzapp/com.apollorncontainer.activities.SplashActivity}" drawable="payzapp" name="PayZapp" />
@@ -11308,6 +11323,7 @@
   <item component="ComponentInfo{com.android.phone/com.mediatek.settings.PhoneRecoderSettings}" drawable="google_phone" name="Phone" />
   <item component="ComponentInfo{com.weartools.phonebattcomp/com.weartools.phonebattcomp.MainActivity}" drawable="phone_battery_complication" name="Phone Battery Complication" />
   <item component="ComponentInfo{myfiles.filemanager.fileexplorer.cleaner/myfiles.filemanager.fileexplorer.cleaner.view.activities.SplashActivity}" drawable="phone_cleaner" name="Phone Cleaner" />
+  <item component="ComponentInfo{myfiles.filemanager.fileexplorer.cleaner/myfiles.filemanager.fileexplorer.cleaner.view.activities.PreSplashActivity}" drawable="phone_cleaner" name="Phone Cleaner" />
   <item component="ComponentInfo{com.hicloud.android.clone/com.huawei.android.clone.activity.sender.ChooseRecevieSendActivity}" drawable="phone_clone" name="Phone Clone" />
   <item component="ComponentInfo{com.hicloud.android.clone/com.huawei.android.clone.activity.sender.ChooseReceiveSendActivity}" drawable="phone_clone" name="Phone Clone" />
   <item component="ComponentInfo{com.coloros.phonemanager/com.oplus.phonemanager.FakeActivity}" drawable="phone_manager" name="Phone Manager" />
@@ -11863,6 +11879,7 @@
   <item component="ComponentInfo{com.prism.live/com.prism.live.screen.login.activity.LoginActivity}" drawable="prism_live" name="PRISM Live" />
   <item component="ComponentInfo{br.com.sisteplant.prismanetmobile/br.com.sisteplant.prismanetmobile.MainActivity}" drawable="prism_net_mobile_vivo" name="Prism@Net Mobile Vivo" />
   <item component="ComponentInfo{com.neuralprisma/com.prisma.starter.StarterActivity}" drawable="prisma" name="Prisma" />
+  <item component="ComponentInfo{com.neuralprisma/com.google.android.archive.ReactivateActivity}" drawable="prisma" name="Prisma" />
   <item component="ComponentInfo{com.prisma3D.prisma3D/com.prisma.prismaplugin.UnityPlayerActivityStatusBar}" drawable="prisma3d" name="Prisma3D" />
   <item component="ComponentInfo{com.codigames.idle.prison.empire.manager.tycoon/com.google.firebase.MessagingUnityPlayerActivity}" drawable="prison_empire_tycoon" name="Prison Empire Tycoon" />
   <item component="ComponentInfo{com.kaleedtc.privacium/com.kaleedtc.privacium.MainActivity}" drawable="privacium" name="Privacium" />
@@ -13308,6 +13325,7 @@
   <item component="ComponentInfo{app.shosetsu.android.fdroid/app.shosetsu.android.activity.MainActivity}" drawable="shosetsu" name="Shosetsu" />
   <item component="ComponentInfo{com.zoho.show.app/com.zoho.zohoshow.anzs.ShowListingActivity}" drawable="show" name="Show" />
   <item component="ComponentInfo{com.jesperh.showyoutubedislikes/com.jesperh.showyoutubedislikes.MainActivity}" drawable="show_youtube_dislikes" name="Show Youtube Dislikes" />
+  <item component="ComponentInfo{com.allinone.callerid/com.allinone.callerid.start.StartActivity}" drawable="generic_dialer" name="Showcaller" />
   <item component="ComponentInfo{com.wirelessalien.android.moviedb/com.wirelessalien.android.moviedb.activity.MainActivity}" drawable="showcase" name="ShowCase" />
   <item component="ComponentInfo{com.michaldrabik.showly2/com.michaldrabik.showly2.ui.main.MainActivity}" drawable="showly" name="Showly" />
   <item component="ComponentInfo{com.michaldrabik.showly_oss/com.michaldrabik.showly_oss.ui.main.MainActivity}" drawable="showly" name="Showly OSS" />
@@ -14027,6 +14045,7 @@
   <item component="ComponentInfo{com.snapchat.android/com.snap.mushroom.MushroomMainActivity}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/.LandingPageActivity}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.JokerAlias}" drawable="snapchat" name="Snapchat" />
+  <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.LavaAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivity}" drawable="snapdeal" name="Snapdeal" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivityDefault}" drawable="snapdeal" name="Snapdeal" />
   <item component="ComponentInfo{com.fmsys.snapdrop/com.google.android.archive.ReactivateActivity}" drawable="snapdrop" name="Snapdrop" />
@@ -14409,6 +14428,7 @@
   <item component="ComponentInfo{wasaver.downloadstatus.videosaver.wasticker.downloader/wasaver.downloadstatus.videosaver.wasticker.downloader.ui.splash.SplashActivity}" drawable="status_saver" name="Status Saver" />
   <item component="ComponentInfo{recover.deleted.messages.messagesrestore/recover.deleted.messages.messagesrestore.view.activities.NewSplashActivity}" drawable="download_progress_plus_plus" name="Status Saver" />
   <item component="ComponentInfo{com.playfake.utility.instadownloader/com.playfake.utility.instadownloader.SplashActivity}" drawable="download_twitter_videos" name="Status Saver" />
+  <item component="ComponentInfo{com.lazygeniouz.saveit/com.lazygeniouz.saveit.ui.activities.main.SplashCompatActivity}" drawable="status_download" name="Status, Sticker Saver" />
   <item component="ComponentInfo{org.hatapps.stayawake/com.example.myapplication2.MainActivity}" drawable="stay_awake" name="Stay Awake" />
   <item component="ComponentInfo{ro.stayfit/ro.stayfit.MainActivity}" drawable="stay_fit_gym" name="Stay Fit Gym" />
   <item component="ComponentInfo{sa.com.stcpay/sa.com.stcpay.launcher_d2bb6544d0c7607f9e371c3f8be743ad2954f8102a2c7f7665390b1561acfb47}" drawable="stc_pay" name="stc pay" />
@@ -15614,6 +15634,7 @@
   <item component="ComponentInfo{com.bnyro.translate/com.bnyro.translate.ui.MainActivity}" drawable="translate_you" name="Translate You" />
   <item component="ComponentInfo{com.example.translatemaster/com.example.translatemaster.MainActivity}" drawable="monocles_translator" name="TranslateMaster" />
   <item component="ComponentInfo{dev.davidv.translator/dev.davidv.translator.MainActivity}" drawable="monocles_translator" name="Translator" />
+  <item component="ComponentInfo{com.danddstudios.translatorforwearos/com.danddstudios.translatorforwearos.Activities.SplashActivity}" drawable="monocles_translator" name="Translator for Wear OS" />
   <item component="ComponentInfo{com.mdv.TranslinkCompanion/com.mdv.TranslinkCompanion.MainActivity}" drawable="translink_ni" name="Translink NI" />
   <item component="ComponentInfo{au.gov.wa.pta.transperth/au.gov.wa.pta.transperth.MainActivity}" drawable="transperth" name="Transperth" />
   <item component="ComponentInfo{de.grobox.liberario/de.grobox.transportr.map.MainActivity}" drawable="transportr" name="Transportr" />
@@ -16165,9 +16186,9 @@
   <item component="ComponentInfo{com.ventrachicago.riderapp/com.cmtventra.MainActivity}" drawable="ventra" name="Ventra" />
   <item component="ComponentInfo{com.whatever.verifit/com.example.verifit.MainActivity}" drawable="verifit" name="Verifit" />
   <item component="ComponentInfo{com.whatever.verifit/com.example.verifit.ui.MainActivity}" drawable="verifit" name="Verifit" />
-  <item component="ComponentInfo{com.vzw.ecid/com.cequint.hs.client.frontend.WebShell}" drawable="verizon_call_filter" name="Verizon Call Filter" />
-  <item component="ComponentInfo{com.vzw.ecid/com.cequint.callfilter.MainActivity}" drawable="verizon_call_filter" name="Verizon Call Filter" />
-  <item component="ComponentInfo{com.vcast.mediamanager/com.vcast.mediamanager.gui.activities.SplashLogoActivity}" drawable="verizon_call_filter" name="Verizon Cloud" />
+  <item component="ComponentInfo{com.vzw.ecid/com.cequint.hs.client.frontend.WebShell}" drawable="my_verizon" name="Verizon Call Filter" />
+  <item component="ComponentInfo{com.vzw.ecid/com.cequint.callfilter.MainActivity}" drawable="my_verizon" name="Verizon Call Filter" />
+  <item component="ComponentInfo{com.vcast.mediamanager/com.vcast.mediamanager.gui.activities.SplashLogoActivity}" drawable="my_verizon" name="Verizon Cloud" />
   <item component="ComponentInfo{com.securityandprivacy.android.verizon.vms/com.mcafee.vzwmms.activity.VZWBaseActivity}" drawable="verizon_protect" name="Verizon Protect" />
   <item component="ComponentInfo{com.securityandprivacy.android.verizon.vms/com.mcafee.app.LauncherDelegateActivity}" drawable="verizon_protect" name="Verizon Protect" />
   <item component="ComponentInfo{com.securityandprivacy.android.verizon.vms/com.verizon.neon.ui.activities.NeonMainActivity}" drawable="verizon_protect" name="Verizon Protect" />
@@ -16542,6 +16563,7 @@
   <item component="ComponentInfo{com.infrasoft.uboi/com.infrasoft.uboi.UBIMADPJULVyom}" drawable="vyom" name="Vyom" />
   <item component="ComponentInfo{com.infrasoft.uboi/com.infrasoft.uboi.UBIMADP}" drawable="vyom" name="Vyom" />
   <item component="ComponentInfo{com.infrasoft.uboi/com.infrasoft.uboi.UBIMADPCUGVyom}" drawable="vyom" name="Vyom" />
+  <item component="ComponentInfo{com.infrasoft.uboi/com.ubimobileapp.MainActivity}" drawable="vyom" name="VYOM" />
   <item component="ComponentInfo{com.koushikdutta.vysor/com.koushikdutta.vysor.StartActivity}" drawable="vysor" name="Vysor" />
   <item component="ComponentInfo{hu.vagyaid.mobil/hu.vagyaid.mobil.MainActivity}" drawable="eromodo" name="Vágyaid ~~ Eromodo" />
   <item component="ComponentInfo{jp.co.ccc.Tsite/jp.co.ccc.tapps.SplashActivity}" drawable="v_point" name="Vポイント ~~ V Point" />

--- a/svgs/my_verizon.svg
+++ b/svgs/my_verizon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none"><path stroke="#000" stroke-linejoin="round" stroke-width="12" d="M160 22h-24L78 144l-22-42H32l35 68h21z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none"><path stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12" d="M74 164 22 30h44l30 77.308M74 164h44l52-134h-44l-30 77.308M74 164l22-56.692"/></svg>

--- a/svgs/verizon_call_filter.svg
+++ b/svgs/verizon_call_filter.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none"><path stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12" d="M74 164 22 30h44l30 77.308M74 164h44l52-134h-44l-30 77.308M74 164l22-56.692"/></svg>


### PR DESCRIPTION
## Linked
AT Player (`com.atpc` → `generic_player.svg`)
Bible Offline KJV with Audio (`com.bestweatherfor.bibleoffline_pt_ra` → `generic_bible.svg`)
Biblia (`tepteev.ihar.biblia_takatifu.AOURLCUBZSMVVVVE` → `generic_bible.svg`)
Bíblia de Jerusalém (`com.fullcodex.bible.abdj` → `generic_bible.svg`)
Bluetooth Devices Info (`com.rockfort.bluetoothinfo` → `generic_bluetooth.svg`)
Bluetooth Sender (`com.shawal.sender` → `generic_bluetooth.svg`)
Bluetooth ToolKit [XPOSED] (`com.metris.xposed.bluetoothToolkitFree` → `generic_bluetooth.svg`)
Cube Solver (`com.aseemsalim.puzzlesolver.rcs` → `cube_solver.svg`)
Easy Phone (`com.simpler.dialer` → `generic_dialer.svg`)
Files (`com.folderv.gofiles` → `generic_files.svg`)
GuitarTuna (`com.ovelin.guitartuna` → `guitartuna.svg`)
Holy Bible (`br.biblia` → `generic_bible.svg`)
La Biblia (`biblia.para.mujeres.diaria` → `generic_bible.svg`)
My Verizon (`com.vzw.hss.myverizon` → `my_verizon.svg`)
Paytm (`net.one97.paytm` → `paytm.svg`)
Phone Cleaner (`myfiles.filemanager.fileexplorer.cleaner` → `phone_cleaner.svg`)
Prisma (`com.neuralprisma` → `prisma.svg`)
Showcaller (`com.allinone.callerid` → `generic_dialer.svg`)
Snapchat (`com.snapchat.android` → `snapchat.svg`)
Status, Sticker Saver (`com.lazygeniouz.saveit` → `status_download.svg`)
Translator for Wear OS (`com.danddstudios.translatorforwearos` → `monocles_translator.svg`)
VYOM (`com.infrasoft.uboi` → `vyom.svg`)