### PR TITLE
+23 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -796,6 +796,7 @@
   <item component="ComponentInfo{braveheart.apps.apkinstaller/braveheart.apps.apkinstaller.StartActivity}" drawable="download_progress_plus_plus" name="Apk Installer" />
   <item component="ComponentInfo{com.mrikso.apkrepacker/com.mrikso.apkrepacker.activity.MainActivity}" drawable="apk_repacker" name="Apk Repacker" />
   <item component="ComponentInfo{org.snowcorp.apps.apkshare/org.snowcorp.apps.apkshare.MainActivity}" drawable="apk_share" name="APK Share" />
+  <item component="ComponentInfo{com.taskmanager.appshare/com.taskmanager.appshare.MainActivity}" drawable="apk_share" name="Apk Share" />
   <item component="ComponentInfo{com.luckydeveloper.apkshare/com.luckydeveloper.apkshare.SplashActivity}" drawable="apk_share_bluetooth" name="Apk Share Bluetooth" />
   <item component="ComponentInfo{com.haibison.apksigner/app.activities.MainActivity}" drawable="settings" name="apk-signer" />
   <item component="ComponentInfo{taco.apkmirror/taco.apkmirror.activities.MainActivity}" drawable="apkmirror" name="APKMirror" />
@@ -1655,6 +1656,7 @@
   <item component="ComponentInfo{sk.azet.bistro/ui.Onboarding}" drawable="just_eat" name="Bistro.sk" />
   <item component="ComponentInfo{com.kebstudios.calc/com.kebstudios.calc.MainActivity}" drawable="generic_calculator_minus_multi_plus_equal" name="BitCalculator" />
   <item component="ComponentInfo{com.bitchat.droid/com.bitchat.android.MainActivity}" drawable="bitchat" name="bitchat" />
+  <item component="ComponentInfo{com.bitchat.android/com.bitchat.android.MainActivity}" drawable="bitchat" name="bitchat" />
   <item component="ComponentInfo{com.bitchute.app/com.bitchute.app.feature.launch.LaunchActivity}" drawable="bitchute" name="BitChute" />
   <item component="ComponentInfo{com.supercrypto.cryptocyrrency/com.supercrypto.cryptocyrrency.MainActivity}" drawable="crypto_prices" name="Bitcoin price" />
   <item component="ComponentInfo{st.brothas.mtgoxwidget/st.brothas.mtgoxwidget.app.activity.GraphActivity}" drawable="crypto_prices" name="Bitcoin Ticker Widget" />
@@ -1989,6 +1991,7 @@
   <item component="ComponentInfo{com.tencent.tmgp.supercell.brawlstars/com.supercell.titan.tencent.GameAppTencent}" drawable="brawl_stars" name="Brawl Stars" />
   <item component="ComponentInfo{com.supercell.brawlstars/com.supercell.brawlstars.GameApp}" drawable="brawl_stars" name="Brawl Stars" />
   <item component="ComponentInfo{air.com.ubisoft.brawl.halla.platform.fighting.action.pvp/air.com.ubisoft.brawl.halla.platform.fighting.action.pvp.AppEntry}" drawable="brawlhalla" name="Brawlhalla" />
+  <item component="ComponentInfo{air.com.ubisoft.brawl.halla.platform.fighting.action.pvp/air.com.ubisoft.brawl.halla.platform.fighting.action.pvp.AIRAppEntry}" drawable="brawlhalla" name="Brawlhalla" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.brazilian/com.anysoftkeyboard.languagepack.brazilian.MainActivity}" drawable="anysoftkeyboard" name="Brazilian Portuguese for AnySoftKeyboard" />
   <item component="ComponentInfo{com.mmazzarolo.breathly/com.mmazzarolo.breathly.SplashActivity}" drawable="breathly" name="Breathly" />
   <item component="ComponentInfo{com.mmazzarolo.breathly/com.mmazzarolo.breathly.MainActivity}" drawable="breathly" name="Breathly" />
@@ -5615,6 +5618,7 @@
   <item component="ComponentInfo{com.fujifilm.xapp/com.fujifilm.xapp.MainActivity}" drawable="fujifilm_xapp" name="FUJIFILM XApp" />
   <item component="ComponentInfo{net.slions.fulguris.full.fdroid/fulguris.activity.SplashActivity}" drawable="fulguris" name="Fulguris" />
   <item component="ComponentInfo{net.slions.fulguris.full.fdroid/acr.browser.lightning.SplashActivity}" drawable="fulguris" name="Fulguris" />
+  <item component="ComponentInfo{net.slions.fulguris.full.fdroid/fulguris.activity.IncognitoActivity}" drawable="fulguris" name="Fulguris" />
   <item component="ComponentInfo{apps.syrupy.fullbatterychargealarm/apps.syrupy.fullbatterychargealarm.MainActivity}" drawable="battery_calibration" name="Full Battery Charge Alarm" />
   <item component="ComponentInfo{com.agooday.fullscreengestures/com.agooday.fullscreengestures.MainActivity}" drawable="full_screen_gestures" name="Full Screen Gestures" />
   <item component="ComponentInfo{com.fun.mxw/io.dcloud.PandoraEntry}" drawable="fun_print" name="Fun Print" />
@@ -6327,6 +6331,7 @@
   <item component="ComponentInfo{net.goout.app/net.goout.app.feature.all.ui.activity.LauncherActivity}" drawable="goout" name="GoOut" />
   <item component="ComponentInfo{com.gojek.gopay/com.gojek.gopay.MainActivity}" drawable="gopay" name="GoPay" />
   <item component="ComponentInfo{com.gopeed/com.gopeed.MainActivity}" drawable="gopeed" name="Gopeed" />
+  <item component="ComponentInfo{com.gopeed.gopeed/com.gopeed.gopeed.MainActivity}" drawable="gopeed" name="Gopeed" />
   <item component="ComponentInfo{br.com.goread.android/br.com.goread.android.MainActivity}" drawable="goread" name="GoRead" />
   <item component="ComponentInfo{ru.gazprombank.gorodpay/ru.gazprombank.gorodpay.presentation.main.MainActivity}" drawable="gorodpay" name="GorodPay" />
   <item component="ComponentInfo{com.go.sharpener/com.go.sharpener.MainActivity}" drawable="gosharpener" name="GoSharpener" />
@@ -7911,6 +7916,7 @@
   <item component="ComponentInfo{pl.koleo/pl.astarium.koleo.ui.main.MainActivity}" drawable="koleo" name="KOLEO" />
   <item component="ComponentInfo{com.chooloo.www.koler/com.chooloo.www.koler.ui.main.MainActivity}" drawable="generic_dialer" name="Koler" />
   <item component="ComponentInfo{no.kolumbus.kolumbusbillett/no.ruter.mobile.activity.SplashActivity}" drawable="kolumbus" name="Kolumbus" />
+  <item component="ComponentInfo{Kolumbus.Sanntid.Android/no.netpower.kolumbus_sanntid.MainActivity}" drawable="kolumbus" name="Kolumbus" />
   <item component="ComponentInfo{app.komikku/eu.kanade.tachiyomi.ui.main.MainActivity}" drawable="komiku" name="Komiku" />
   <item component="ComponentInfo{org.komiku.appv3/org.komiku.appv3.ui.splash.SplashActivity}" drawable="komiku" name="Komiku" />
   <item component="ComponentInfo{de.komoot.android/de.komoot.android.app.CardListActivity}" drawable="komoot" name="komoot" />
@@ -8627,6 +8633,7 @@
   <item component="ComponentInfo{com.manga.client/com.manga.client.ui.main.MainActivity}" drawable="manga_slayer" name="Manga Slayer" />
   <item component="ComponentInfo{ru.mangalib.lite/ru.libapp.ui.main.MainActivity}" drawable="mangalib" name="MangaLib" />
   <item component="ComponentInfo{ru.libappc/ru.libapp.feature.main.ui.MainActivity}" drawable="mangalib" name="MangaLib" />
+  <item component="ComponentInfo{ru.libapp/ru.libapp.ui.main.MainActivity}" drawable="mangalib" name="MangaLib" />
   <item component="ComponentInfo{com.manipal.manipalhospitals/com.manipal.manipalhospitals.authentication.LoginActivity}" drawable="manipal_hospitals" name="Manipal Hospitals" />
   <item component="ComponentInfo{com.manipal.manipalhospitals/com.manipal.manipalhospitals.home.HomeActivity}" drawable="manipal_hospitals" name="Manipal Hospitals" />
   <item component="ComponentInfo{com.manipal.manipalhospitals/com.manipal.manipalhospitals.splash.SplashActivity}" drawable="manipal_hospitals" name="Manipal Hospitals" />
@@ -9765,6 +9772,7 @@
   <item component="ComponentInfo{com.google.android.apps.tips/com.google.android.apps.tips.fortnite.base}" drawable="my_pixel" name="My Pixel" />
   <item component="ComponentInfo{com.google.android.apps.tips/com.google.android.apps.tips.fortnite.p7}" drawable="my_pixel" name="My Pixel" />
   <item component="ComponentInfo{com.google.android.apps.tips/com.google.android.apps.tips.fortnite.p9f}" drawable="my_pixel" name="My Pixel" />
+  <item component="ComponentInfo{com.google.android.apps.tips/com.google.android.apps.tips.fortnite.p9a}" drawable="my_pixel" name="My Pixel" />
   <item component="ComponentInfo{com.rayadams.myqr/com.rayadams.myqr.MainActivity}" drawable="generic_qr_reader" name="My QR" />
   <item component="ComponentInfo{myradio.radio.fmradio.liveradio.radiostation/radio.fm.onlineradio.views.activity.ActivityMain}" drawable="generic_fm_radio" name="My Radio" />
   <item component="ComponentInfo{com.renault.myrenault.one.fr/com.accenture.myrenault.activities.splashscreen.SplashScreenActivity}" drawable="my_renault" name="My Renault" />
@@ -10792,9 +10800,11 @@
   <item component="ComponentInfo{pl.onet.poczta/pl.onet.poczta.PrivacyActivity}" drawable="onet_poczta" name="Onet Poczta" />
   <item component="ComponentInfo{com.jndapp.oneui.widgets.pack/com.jndapp.oneui.widgets.pack.MainActivity}" drawable="oneui_widgets" name="OneUI Widgets" />
   <item component="ComponentInfo{com.pashapuma.oneyou.icons/com.pashapuma.oneyou.icons.activities.MainActivity}" drawable="oneyou_icons" name="OneYou Icons" />
+  <item component="ComponentInfo{com.pashapuma.oneyou.icons/com.pashapuma.oneyou.icons.activities.SplashActivity}" drawable="oneyou_icons" name="OneYou Icons" />
   <item component="ComponentInfo{pk.com.onic/com.circles.selfcare.v2.splash.LaunchActivity}" drawable="onic" name="Onic" />
   <item component="ComponentInfo{pk.com.onic/com.circles.selfcare.v2.splash.SplashActivity}" drawable="onic" name="Onic" />
   <item component="ComponentInfo{org.onionshare.android.fdroid/org.onionshare.android.ui.MainActivity}" drawable="onionshare" name="OnionShare" />
+  <item component="ComponentInfo{org.onionshare.android/org.onionshare.android.ui.MainActivity}" drawable="onionshare" name="OnionShare" />
   <item component="ComponentInfo{com.onlyone.onlyonestarter/com.onlyone.onlyonestarter.MainActivity}" drawable="only_one" name="Only One" />
   <item component="ComponentInfo{com.onlyone.onlyonestarter/com.oneseries.starter.MainActivity}" drawable="only_one" name="Only One" />
   <item component="ComponentInfo{com.onlyoffice.documents/app.editors.manager.ui.activities.main.MainActivity}" drawable="onlyoffice_documents" name="ONLYOFFICE Documents" />
@@ -11490,6 +11500,7 @@
   <item component="ComponentInfo{com.phonepe.app.business/com.google.android.archive.ReactivateActivity}" drawable="phonepe" name="PhonePe Business" />
   <item component="ComponentInfo{net.eneiluj.nextcloud.phonetrack/net.eneiluj.nextcloud.phonetrack.android.activity.LogjobsListViewActivity}" drawable="phonetrack" name="PhoneTrack" />
   <item component="ComponentInfo{com.phonewalls.stockwallpapers/com.phonewalls.stockwallpapers.MainActivity}" drawable="phonewalls" name="PhoneWalls" />
+  <item component="ComponentInfo{com.phonewalls.stockwallpapers/com.phonewalls.stockwallpapers.SplashActivity}" drawable="phonewalls" name="PhoneWalls" />
   <item component="ComponentInfo{com.kabouzeid.gramophone/com.kabouzeid.gramophone.ui.activities.MainActivity}" drawable="phonograph_music_player" name="Phonograph Music Player" />
   <item component="ComponentInfo{player.phonograph.plus/player.phonograph.ui.activities.MainActivity}" drawable="phonograph_music_player" name="Phonograph Plus" />
   <item component="ComponentInfo{player.phonograph.plus/player.phonograph.ui.activities.LauncherActivity}" drawable="phonograph_music_player" name="Phonograph Plus" />
@@ -11746,6 +11757,7 @@
   <item component="ComponentInfo{com.pinkfroot.planefinderfree/com.pinkfroot.planefinderfree.PlaneFinderMain}" drawable="plane_finder" name="Plane Finder" />
   <item component="ComponentInfo{com.pinkfroot.planefinderfree/com.pinkfroot.planefinder.ui.MainActivity}" drawable="plane_finder" name="Plane Finder" />
   <item component="ComponentInfo{com.ltfs.d2c/com.ltfs.d2c.AppzillonMainScreen}" drawable="planet" name="PLANET" />
+  <item component="ComponentInfo{com.ltfs.d2c/com.example.planet.MainActivity}" drawable="planet" name="Planet" />
   <item component="ComponentInfo{com.freevpnplanet/com.freevpnplanet.presentation.splash.view.SplashActivity}" drawable="planet_vpn" name="Planet VPN" />
   <item component="ComponentInfo{com.freevpnplanet/com.vpnapp.MainActivity}" drawable="planet_vpn" name="Planet VPN" />
   <item component="ComponentInfo{com.planitypublic/com.planitypublic.MainActivity}" drawable="planity" name="Planity" />
@@ -12260,6 +12272,7 @@
   <item component="ComponentInfo{com.imagetotext.qrcodescanner/com.imagetotext.qrcodescanner.MainActivity}" drawable="generic_qr_reader" name="QR Scanner" />
   <item component="ComponentInfo{com.sweak.qralarm/com.sweak.qralarm.MainActivity}" drawable="qralarm" name="QRAlarm" />
   <item component="ComponentInfo{com.sweak.qralarm/com.sweak.qralarm.app.MainActivity}" drawable="qralarm" name="QRAlarm" />
+  <item component="ComponentInfo{com.sweak.qralarm/com.sweak.qralarm.app.activity.MainActivity}" drawable="qralarm" name="QRAlarm" />
   <item component="ComponentInfo{net.qrbot/net.qrbot.ui.main.MainActivity}" drawable="generic_qr_reader" name="QRbot" />
   <item component="ComponentInfo{com.nextstar.qrcodegenie/com.nextstar.qrcodegenie.MainActivity}" drawable="qrky" name="QRCodeGenie" />
   <item component="ComponentInfo{com.trifellas.qrgenerator/com.trifellas.qrgenerator.app.presentation.screens.splash.SplashActivity}" drawable="qrky" name="QRky" />
@@ -12415,6 +12428,7 @@
   <item component="ComponentInfo{com.lucky_apps.RainViewer/com.lucky_apps.rainviewer.root.ui.RootActivity}" drawable="rainviewer" name="RainViewer" />
   <item component="ComponentInfo{it.rainet/it.rainet.playrai.activity.SplashActivity}" drawable="raiplay" name="RaiPlay" />
   <item component="ComponentInfo{it.rainet/it.rainet.ui.splash.SplashActivity}" drawable="raiplay" name="RaiPlay" />
+  <item component="ComponentInfo{it.rainet/com.raiplayv2.MainActivity}" drawable="raiplay" name="RaiPlay" />
   <item component="ComponentInfo{it.rai.digital.yoyo/it.rai.digital.yoyo.ui.activity.splash.SplashActivity}" drawable="raiplay_yoyo" name="RaiPlay Yoyo" />
   <item component="ComponentInfo{io.floornfts/io.floornfts.MainActivity_Floor}" drawable="rally" name="Rally" />
   <item component="ComponentInfo{com.glgjing.captain/com.glgjing.captain.HomeActivity}" drawable="ram_memory_monitor" name="RAM Memory Monitor" />
@@ -14022,6 +14036,7 @@
   <item component="ComponentInfo{com.joytunes.simplypiano/com.joytunes.simplypiano.ui.SplashScreen}" drawable="simply_piano" name="Simply Piano" />
   <item component="ComponentInfo{com.simplywallst.app/com.simplywallst.app.MainActivity}" drawable="simply_wall_st" name="Simply Wall St" />
   <item component="ComponentInfo{sg.com.transitlink/com.thoughtworks.ezlink.workflows.main.SplashActivity}" drawable="simplygo" name="SimplyGo" />
+  <item component="ComponentInfo{sg.com.transitlink/sg.com.transitlink.main.activity.SplashActivity}" drawable="simplygo" name="SimplyGo" />
   <item component="ComponentInfo{com.simplytranslate_mobile/com.simplytranslate_mobile.MainActivity}" drawable="simplytranslate" name="SimplyTranslate" />
   <item component="ComponentInfo{com.maxrave.simpmusic/com.maxrave.simpmusic.ui.MainActivity}" drawable="simpmusic" name="SimpMusic" />
   <item component="ComponentInfo{com.maxrave.simpmusic/com.maxrave.simpmusic.MainActivity}" drawable="simpmusic" name="SimpMusic" />
@@ -14158,6 +14173,7 @@
   <item component="ComponentInfo{com.transsion.scanningrecharger/com.transsion.scanningrecharger.view.activity.SplashActivity}" drawable="scanner" name="Smart Scanner" />
   <item component="ComponentInfo{com.transsion.scanningrecharger/com.transsion.scanningrecharger.view.activity.textrecognized.TextRecognizedActivity}" drawable="scanner" name="Smart Scanner" />
   <item component="ComponentInfo{app.smart.timetable/app.smart.timetable.MainActivity}" drawable="smart_timetable" name="Smart Timetable" />
+  <item component="ComponentInfo{app.smart.timetables/app.smart.timetables.MainActivity}" drawable="smart_timetable" name="Smart Timetable" />
   <item component="ComponentInfo{com.rsupport.rs.activity.rsupport.aas2/com.rsupport.rs.activity.edit.IntroActivity}" drawable="smart_tutor" name="Smart Tutor" />
   <item component="ComponentInfo{com.andrwq.recorder/com.andrwq.recorder.RecorderActivity}" drawable="smart_voice_recorder" name="Smart Voice Recorder" />
   <item component="ComponentInfo{com.smart_id/com.stagnationlab.sk.MainActivity}" drawable="smart_id" name="Smart-ID" />
@@ -14539,6 +14555,7 @@
   <item component="ComponentInfo{com.standardnotes/com.standardnotes.MainActivity}" drawable="standard_notes" name="Standard Notes" />
   <item component="ComponentInfo{br.com.zetabit.ios_standby/br.com.zetabit.ios_standby.MainActivity}" drawable="standby_mode" name="StandBy Mode" />
   <item component="ComponentInfo{com.axlebolt.standoff2/com.google.firebase.MessagingUnityPlayerActivity}" drawable="standoff_2" name="Standoff 2" />
+  <item component="ComponentInfo{com.axlebolt.standoff2.huawei/com.google.firebase.MessagingUnityPlayerActivity}" drawable="standoff_2" name="Standoff 2" />
   <item component="ComponentInfo{com.kusamaru.standroid/com.kusamaru.standroid.MainActivity}" drawable="standroid" name="StanDroid" />
   <item component="ComponentInfo{fr.xgouchet.packageexplorer/fr.xgouchet.packageexplorer.applist.AppListActivity}" drawable="generic_shell" name="Stanley" />
   <item component="ComponentInfo{com.music.star.startag/com.music.star.tag.MainActivity}" drawable="star_music_tag_editor" name="Star Music Tag Editor" />
@@ -15642,6 +15659,7 @@
   <item component="ComponentInfo{com.gabrielittner.timetable/com.gabrielittner.timetable.ui.MainActivity}" drawable="timetable" name="Timetable" />
   <item component="ComponentInfo{com.asdoi.timetable/com.ulan.timetable.activities.MainActivity}" drawable="timetable_foss" name="TimeTable FOSS" />
   <item component="ComponentInfo{works.jubilee.timetree/works.jubilee.timetree.ui.SplashActivity}" drawable="timetree" name="TimeTree" />
+  <item component="ComponentInfo{works.jubilee.timetree/works.jubilee.timetree.app.ui.SplashActivity}" drawable="timetree" name="TimeTree" />
   <item component="ComponentInfo{com.teegloyalty.timezone/com.teegloyalty.timezone.ui.splash.SplashActivity}" drawable="timezone_fun" name="Timezone Fun" />
   <item component="ComponentInfo{com.tinder/com.tinder.activities.ActivityLogin}" drawable="tinder" name="Tinder" />
   <item component="ComponentInfo{com.tinder/com.tinder.activities.ActivitySplash_}" drawable="tinder" name="Tinder" />
@@ -16714,6 +16732,7 @@
   <item component="ComponentInfo{app.maslanka.volumee/app.maslanka.volumee.ui.SplashActivity}" drawable="volumee" name="Volumee" />
   <item component="ComponentInfo{com.klee.volumelockr/com.klee.volumelockr.ui.MainActivity}" drawable="generic_lock" name="VolumeLockr" />
   <item component="ComponentInfo{volumio.browser.Volumio/volumio.volumio.LoadingActivity}" drawable="volumio" name="Volumio" />
+  <item component="ComponentInfo{volumio.browser.Volumio/volumio.browser.volumio.MainActivity}" drawable="volumio" name="Volumio" />
   <item component="ComponentInfo{hu.mavszk.vonatinfo/hu.mavszk.vonatinfo2.gui.activity.SplashActivity}" drawable="vonatinfo" name="Vonatinfó" />
   <item component="ComponentInfo{com.nebulatech.voocvpnpro/com.dzboot.ovpn.activities.IntroActivity}" drawable="voocvpn_pro" name="VoocVPN Pro" />
   <item component="ComponentInfo{com.tv.v18.viola/com.tv.v18.viola.views.activities.RSHomeActivity}" drawable="voot" name="Voot" />
@@ -16993,6 +17012,8 @@
   <item component="ComponentInfo{com.weward/com.weward.MainActivityDefault}" drawable="weward" name="WeWard" />
   <item component="ComponentInfo{com.transsion.wezone/com.transsion.wezone.ui.splash.SplashActivity}" drawable="wezone" name="WeZone" />
   <item component="ComponentInfo{com.zaneschepke.wireguardautotunnel/com.zaneschepke.wireguardautotunnel.MainActivity}" drawable="wg_tunnel" name="WG Tunnel" />
+  <item component="ComponentInfo{com.zaneschepke.wireguardautotunnel/com.zaneschepke.wireguardautotunnel.ui.MainActivity}" drawable="wg_tunnel" name="WG Tunnel" />
+  <item component="ComponentInfo{com.zaneschepke.wireguardautotunnel/com.zaneschepke.wireguardautotunnel.ui.SplashActivity}" drawable="wg_tunnel" name="WG Tunnel" />
   <item component="ComponentInfo{de.wger.flutter/de.wger.flutter.MainActivity}" drawable="wger" name="wger" />
   <item component="ComponentInfo{cz.webprovider.whatismyipaddress/cz.webprovider.whatismyipaddress.MainActivity}" drawable="what_is_my_ip_address" name="What is my IP address" />
   <item component="ComponentInfo{air.com.bartbonte.thebox/air.com.bartbonte.thebox.AIRAppEntry}" drawable="whats_inside_the_box" name="What's inside the box?" />
@@ -17215,6 +17236,7 @@
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.splash.SplashActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.vpn.splash.SplashActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.vpn.ui.activities.EntryPointActivity}" drawable="windscribe" name="Windscribe" />
+  <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.ui.AppStartActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windyty.android/com.windyty.android.MainActivity}" drawable="windy" name="Windy" />
   <item component="ComponentInfo{com.windyty.android/com.windyty.android.Standard}" drawable="windy" name="Windy" />
   <item component="ComponentInfo{com.wingos.wingcamera/com.wingos.wingcamera.Camera}" drawable="generic_camera" name="WingOS Camera" />
@@ -17645,6 +17667,7 @@
   <item component="ComponentInfo{com.zing.zalo/com.zing.zalo.ui.SplashActivity}" drawable="zalo" name="Zalo" />
   <item component="ComponentInfo{vn.com.vng.zalopay/vn.com.vng.zalopay.splashscreen.presentation.SplashScreenActivityV2}" drawable="zalopay" name="ZaloPay" />
   <item component="ComponentInfo{vn.com.vng.zalopay/vn.com.vng.zalopay.ui.activity.SplashScreenActivity}" drawable="zalopay" name="ZaloPay" />
+  <item component="ComponentInfo{vn.com.vng.zalopay/vn.com.vng.zalopay.DefaultXmasIconStep6}" drawable="zalopay" name="Zalopay" />
   <item component="ComponentInfo{com.beint.zangi/com.beint.project.MainActivity}" drawable="zangi_private_messenger" name="Zangi Private Messenger" />
   <item component="ComponentInfo{zank.remote/zank.remote.MainActivity}" drawable="zank_remote" name="Zank Remote" />
   <item component="ComponentInfo{de.christinecoenen.code.zapp/de.christinecoenen.code.zapp.app.MainActivity}" drawable="zapp" name="Zapp" />


### PR DESCRIPTION
## Linked
Apk Share (`com.taskmanager.appshare` → `apk_share.svg`)
bitchat (`com.bitchat.android` → `bitchat.svg`)
Brawlhalla (`air.com.ubisoft.brawl.halla.platform.fighting.action.pvp` → `brawlhalla.svg`)
Fulguris (`net.slions.fulguris.full.fdroid` → `fulguris.svg`)
Gopeed (`com.gopeed.gopeed` → `gopeed.svg`)
Kolumbus (`Kolumbus.Sanntid.Android` → `kolumbus.svg`)
MangaLib (`ru.libapp` → `mangalib.svg`)
My Pixel (`com.google.android.apps.tips` → `my_pixel.svg`)
OneYou Icons (`com.pashapuma.oneyou.icons` → `oneyou_icons.svg`)
OnionShare (`org.onionshare.android` → `onionshare.svg`)
PhoneWalls (`com.phonewalls.stockwallpapers` → `phonewalls.svg`)
Planet (`com.ltfs.d2c` → `planet.svg`)
QRAlarm (`com.sweak.qralarm` → `qralarm.svg`)
RaiPlay (`it.rainet` → `raiplay.svg`)
SimplyGo (`sg.com.transitlink` → `simplygo.svg`)
Smart Timetable (`app.smart.timetables` → `smart_timetable.svg`)
Standoff 2 (`com.axlebolt.standoff2.huawei` → `standoff_2.svg`)
TimeTree (`works.jubilee.timetree` → `timetree.svg`)
Volumio (`volumio.browser.Volumio` → `volumio.svg`)
WG Tunnel (`com.zaneschepke.wireguardautotunnel` → `wg_tunnel.svg`)
Windscribe (`com.windscribe.vpn` → `windscribe.svg`)
Zalopay (`vn.com.vng.zalopay` → `zalopay.svg`)