### PR TITLE
+5 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4231,9 +4231,10 @@
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.UnhingedSickLauncher}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.UnhingedCryLauncher}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakSaverLauncher6ExclamationMarksPrefix}" drawable="duolingo" name="Duolingo" />
-  <item component="ComponentInfo{com.duolingo/com.duolingo.app.PreStreakSaver3Launcher}" drawable="duolingo" name="Duolingo" /> 
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.PreStreakSaver3Launcher}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.PreStreakSaver7Launcher}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakSaverLauncher3Siren}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakSaverLauncherInterrobang}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.rstgames.durak/com.rstgames.durak.StartActivity}" drawable="durak_online" name="Durak Online" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.dutch_oss/com.anysoftkeyboard.languagepack.dutch_oss.MainActivity}" drawable="anysoftkeyboard" name="Dutch for AnySoftKeyboard" />
   <item component="ComponentInfo{org.yausername.dvd/org.yausername.dvd.ui.MainActivity}" drawable="dvd" name="dvd" />


### PR DESCRIPTION
The SVG created for Garmin Messenger fits Message+ perfectly.

<img width="864" height="434" alt="Screenshot_20260205-162147" src="https://github.com/user-attachments/assets/4327a2ab-2325-4af9-b971-53804aa03598" />

### +5 links

``com.duolingo/com.duolingo.app.PreStreakSaver3Launcher``,
``com.duolingo/com.duolingo.app.PreStreakSaver7Launcher``,
``com.duolingo/com.duolingo.app.StreakSaverLauncher3Siren``,
``com.duolingo/com.duolingo.app.StreakSaverLauncherInterrobang``
→ ``duolingo.svg``

``com.verizon.messaging.vzmsgs/com.verizon.mms.ui.activity.Provisioning`` → ``garmin_messenger.svg``