### PR TITLE
+44 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -328,6 +328,7 @@
   <item component="ComponentInfo{xyz.aethersx2.android/xyz.aethersx2.android.MainActivity}" drawable="aethersx2" name="AetherSX2" />
   <item component="ComponentInfo{app.affine.pro/app.affine.pro.MainActivity}" drawable="affine" name="AFFiNE" />
   <item component="ComponentInfo{com.affirm.central/com.affirm.central.RootActivity}" drawable="affirm" name="Affirm" />
+  <item component="ComponentInfo{com.affirm.central/com.affirm.central.MainActivity}" drawable="affirm" name="Affirm" />
   <item component="ComponentInfo{com.lilithgame.hgame.gp/sh.lilithgame.hgame.AppActivity}" drawable="afk_arena" name="AFK Arena" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.afrikaans_oss/com.anysoftkeyboard.languagepack.afrikaans_oss.MainActivity}" drawable="anysoftkeyboard" name="Afrikaans for AnySoftKeyboard" />
   <item component="ComponentInfo{com.ndemiccreations.afterinc/com.unity3d.player.UnityPlayerActivity}" drawable="after_inc" name="After Inc." />
@@ -371,6 +372,7 @@
   <item component="ComponentInfo{com.aimp.player/com.aimp.player.ui.activities.main.MainActivity}" drawable="aimp" name="AIMP" />
   <item component="ComponentInfo{ru.execbit.aiolauncher/ru.execbit.aiolauncher.ui.MainActivity}" drawable="aio_launcher" name="AIO Launcher" />
   <item component="ComponentInfo{com.streamdev.aiostreamer/com.streamdev.aiostreamer.lock.MainActivity}" drawable="jiotv" name="AIO Streamer" />
+  <item component="ComponentInfo{com.streamdev.aiostreamer/com.streamdev.aiostreamer.mobile.ui.lock.MainActivity}" drawable="jiotv" name="AIO Streamer" />
   <item component="ComponentInfo{jp.co.aiphone.ixgsystem/jp.co.aiphone.ixgsystem.SplashActivity}" drawable="aiphone_ixg" name="AIPHONE IXG" />
   <item component="ComponentInfo{com.airfrance.android.dinamoprd/com.airfrance.android.totoro.ui.activity.main.MainActivity}" drawable="air_france" name="Air France" />
   <item component="ComponentInfo{com.airfrance.android.dinamoprd/com.airfrance.android.totoro.homepage.activity.MainActivity}" drawable="air_france" name="Air France" />
@@ -2118,6 +2120,7 @@
   <item component="ComponentInfo{com.rrapplabs.bsnldatausage/com.rrapplabs.bsnldatausage.MainActivity}" drawable="bsnl_ftth_usage" name="BSNL FTTH Usage" />
   <item component="ComponentInfo{com.digital.bsnl.selfcare/com.digital.bsnl.selfcare.MainActivity}" drawable="bsnl_selfcare" name="BSNL Selfcare" />
   <item component="ComponentInfo{com.digital.bsnl.selfcare/com.selfcare.mybsnl.activities.SplashActivity}" drawable="bsnl_selfcare" name="BSNL Selfcare" />
+  <item component="ComponentInfo{com.bstar.intl/tv.danmaku.bili.MainActivityV2}" drawable="bilibili" name="Bstation" />
   <item component="ComponentInfo{com.bt.mail.btprod/com.synchronoss.messaging.whitelabelmail.ui.bootstrap.BootstrapActivity}" drawable="qqmail" name="BT Mail" />
   <item component="ComponentInfo{tv.twitch.bttvandroid.app/tv.twitch.android.app.core.LandingActivity}" drawable="twitch" name="bttv-android" />
   <item component="ComponentInfo{org.woheller69.level/org.woheller69.level.Level}" drawable="generic_bubble_level" name="Bubble" />
@@ -2313,6 +2316,7 @@
   <item component="ComponentInfo{com.bybit.app/com.bybit.pro.MainActivity}" drawable="bybit" name="Bybit" />
   <item component="ComponentInfo{io.github.romanvht.byedpi/io.github.dovecoteescapee.byedpi.activities.MainActivity}" drawable="byebyedpi" name="ByeByeDPI" />
   <item component="ComponentInfo{io.github.romanvht.byedpi/io.github.romanvht.byedpi.activities.MainActivity}" drawable="byebyedpi" name="ByeByeDPI" />
+  <item component="ComponentInfo{io.github.romanvht.byedpi/io.github.romanvht.byedpi.activities.MainActivity}" drawable="byebyedpi" name="ByeByeDPI" />
   <item component="ComponentInfo{io.github.dovecoteescapee.byedpi/io.github.dovecoteescapee.byedpi.activities.MainActivity}" drawable="byedpi" name="ByeDPI" />
   <item component="ComponentInfo{io.github.dovecoteescapee.byedpi/io.github.dovecoteescapee.byedpi.activities.Main}" drawable="byedpi" name="ByeDPI" />
   <item component="ComponentInfo{co.id.bankbsi.superapp/co.id.bankbsi.superapp.screen.splashscreen.SplashScreenActivity}" drawable="byond" name="BYOND" />
@@ -2338,8 +2342,13 @@
   <item component="ComponentInfo{com.github.bmx666.appcachecleaner/com.github.bmx666.appcachecleaner.ui.activity.LauncherActivity}" drawable="cache_cleaner" name="Cache Cleaner" />
   <item component="ComponentInfo{com.ifs.banking.fiid1454/com.banking.bankinglibrary.activities.SplashActivity}" drawable="cacu" name="CACU" />
   <item component="ComponentInfo{one4studio.iconpack.caelusadaptive/com.candybar.dev.activities.SplashActivity}" drawable="caelus_adaptive_material_icons" name="Caelus Adaptive Material Icons" />
+  <item component="ComponentInfo{one4studio.iconpack.caelusadaptive/com.one4studio.iconpack.MainActivity}" drawable="caelus_adaptive_material_icons" name="Caelus Adaptive Material Icons" />
   <item component="ComponentInfo{studio14.application.caelusblack/com.candybar.dev.activities.SplashActivity}" drawable="caelus_icons" name="Caelus Black Icons" />
+  <item component="ComponentInfo{studio14.application.caelusblack/com.one4studio.iconpack.MainActivity}" drawable="caelus_icons" name="Caelus Black Icons" />
+  <item component="ComponentInfo{one4studio.iconpack.caelusduotone/com.one4studio.iconpack.MainActivity}" drawable="caelus_icons" name="Caelus Duotone" />
   <item component="ComponentInfo{studio14.application.caelus/com.candybar.dev.activities.SplashActivity}" drawable="caelus_icons" name="Caelus Icons" />
+  <item component="ComponentInfo{studio14.application.caelus/com.one4studio.iconpack.MainActivity}" drawable="caelus_icons" name="Caelus Icons" />
+  <item component="ComponentInfo{studio14.application.caeluswhite/com.one4studio.iconpack.MainActivity}" drawable="caelus_icons" name="Caelus White" />
   <item component="ComponentInfo{moe.zhs.caffeine/moe.zhs.caffeine.MainActivity}" drawable="caffeine" name="Caffeine" />
   <item component="ComponentInfo{moe.zhs.caffeine/moe.zhs.caffeine.SettingsActivity}" drawable="caffeine" name="Caffeine" />
   <item component="ComponentInfo{br.com.gabba.Caixa/br.gov.caixa.internetbankingmobile.ui.start.StartActivity}" drawable="caixa" name="CAIXA" />
@@ -3492,6 +3501,7 @@
   <item component="ComponentInfo{com.cricbuzz.android/com.cricbuzz.android.lithium.app.view.activity.NyitoActivity}" drawable="cricbuzz" name="Cricbuzz" />
   <item component="ComponentInfo{com.cricfy.tv/com.android.vending.tv.activities.Splash}" drawable="cricfy_tv" name="CRICFy TV" />
   <item component="ComponentInfo{com.cricfy.tv/com.android.vending.activities.Splash}" drawable="cricfy_tv" name="CRICFy TV" />
+  <item component="ComponentInfo{com.cricfytv.sports/com.android.vending.activities.Splash}" drawable="cricfy_tv" name="CRICFy TV" />
   <item component="ComponentInfo{au.com.cricket/au.com.cricket.ui.SplashActivity}" drawable="cricket_australia_live" name="Cricket Australia Live" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.croatian/com.anysoftkeyboard.languagepack.croatian.MainActivity}" drawable="anysoftkeyboard" name="Croatian for AnySoftKeyboard" />
   <item component="ComponentInfo{org.cromite.cromite/com.google.android.apps.chrome.Main}" drawable="cromite" name="Cromite" />
@@ -3970,6 +3980,7 @@
   <item component="ComponentInfo{com.discoverfinancial.mobile/m59ecfafe.xe89a468b.a4db68a37.d9fd62662}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/fqYeJ1.mfCeE0.h5f7L4.jmS7k2}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/uRbNV8.kX3yE6.tF9Vl0.uPzRk4}" drawable="discover" name="Discover" />
+  <item component="ComponentInfo{com.discoverfinancial.mobile/peibp9.tegzM9.y16Zu2.wfTIy0}" drawable="discover" name="Discover" />
   <item component="ComponentInfo{com.discoverapp/com.discoverapp.DiscoverSplashActivity}" drawable="discover_from_facebook" name="Discover from Facebook" />
   <item component="ComponentInfo{com.kieronquinn.app.discoverkiller/com.kieronquinn.app.discoverkiller.ui.activities.MainActivity}" drawable="discover_killer" name="Discover Killer" />
   <item component="ComponentInfo{com.discovery.dplay/com.discovery.app.LaunchActivity}" drawable="discovery_plus" name="discovery+" />
@@ -4062,6 +4073,7 @@
   <item component="ComponentInfo{co.aospa.dolby.oplus/co.aospa.dolby.oplus.DolbyActivity}" drawable="dolby" name="Dolby Atmos" />
   <item component="ComponentInfo{com.ontim.dolby.dolbyui.ui/com.ontim.dolby.dolbyui.ui.LauncherActivity}" drawable="dolby" name="Dolby Atmos" />
   <item component="ComponentInfo{org.lunaris.dolby/org.lunaris.dolby.ui.DolbyActivity}" drawable="dolby" name="Dolby Atmos" />
+  <item component="ComponentInfo{co.aospa.dolby.xiaomi/co.aospa.dolby.xiaomi.DolbySettingsActivity}" drawable="dolby" name="Dolby Atmos" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.introduction.IntroductionActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.sst.SSTActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui/com.motorola.dolby.dolbyui.ui.LauncherActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
@@ -5006,6 +5018,7 @@
   <item component="ComponentInfo{com.filemanager.managefile.fileexplorer.fileextractor/com.dani.example.presentation.ui.activities.main.MainActivity}" drawable="nmm_file_manager" name="File Manager" />
   <item component="ComponentInfo{com.alphainventor.filemanager/com.alphainventor.filemanager.activity.MainActivity}" drawable="file_manager_plus" name="File Manager Plus" />
   <item component="ComponentInfo{com.w2sv.filenavigator/com.w2sv.filenavigator.MainActivity}" drawable="file_navigator" name="File Navigator" />
+  <item component="ComponentInfo{com.w2sv.filenavigator/com.w2sv.filenavigator.ui.MainActivity}" drawable="file_navigator" name="File Navigator" />
   <item component="ComponentInfo{com.alif.vault.file/com.alif.vault.file.ui.main.MainActivity}" drawable="generic_lock" name="File Vault" />
   <item component="ComponentInfo{com.sharpened.androidfileviewer/com.sharpened.androidfileviewer.afv4.StartActivity}" drawable="file_viewer_for_android" name="File Viewer for Android" />
   <item component="ComponentInfo{io.filen.app/io.filen.app.MainActivity}" drawable="filen" name="Filen" />
@@ -5042,6 +5055,7 @@
   <item component="ComponentInfo{com.dpsteam.filmplus/com.dpsteam.filmplus.activities.SplashActivity}" drawable="film_plus" name="Film Plus" />
   <item component="ComponentInfo{com.guideplus.co/com.guideplus.co.SplashActivity}" drawable="film_plus" name="Film Plus" />
   <item component="ComponentInfo{de.filmfriend/crc641cb7adcffce4421b.MainActivity}" drawable="filmfriend" name="filmfriend" />
+  <item component="ComponentInfo{de.filmfriend/FilmwerteVod.App.Android.Common.Application.MainActivity}" drawable="filmfriend" name="filmfriend" />
   <item component="ComponentInfo{com.filmic.filmicpro/com.filmic.activity.FilmicActivity}" drawable="filmic_pro" name="Filmic Pro" />
   <item component="ComponentInfo{com.wondershare.filmora/com.filmorago.phone.ui.SplashActivity}" drawable="filmora" name="Filmora" />
   <item component="ComponentInfo{com.wondershare.filmorago/com.filmorago.phone.ui.homepage.HomePageActivityNewSinceV570}" drawable="filmora" name="Filmora" />
@@ -5284,6 +5298,7 @@
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.NewYearIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.GoldIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.VIPIconAlias}" drawable="flipkart" name="Flipkart" />
+  <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.SilverIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipperdevices.app/com.flipperdevices.singleactivity.impl.SingleActivity}" drawable="flipper" name="Flipper" />
   <item component="ComponentInfo{nl.flitsmeister/nl.flitsmeister.FM_SIMPLE_BLUE}" drawable="flitsmeister" name="Flitsmeister" />
   <item component="ComponentInfo{nl.flitsmeister/nl.flitsmeister.SPEED_CAM_3D}" drawable="flitsmeister" name="Flitsmeister" />
@@ -6141,6 +6156,7 @@
   <item component="ComponentInfo{com.riffsy.FBMGIFApp/com.riffsy.ui.activity.SplashActivity}" drawable="gif_maker_editor" name="GIF Keyboard" />
   <item component="ComponentInfo{com.bk.videotogif/com.bk.videotogif.ui.splash.ActivitySplash}" drawable="gif_maker_editor" name="GIF Maker" />
   <item component="ComponentInfo{com.bk.videotogif/com.bk.videotogif.ui.home.ActivityHome}" drawable="gif_maker_editor" name="GIF Maker" />
+  <item component="ComponentInfo{com.bk.videotogif/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="gif_maker_editor" name="GIF Maker" />
   <item component="ComponentInfo{com.gif.gifmaker/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="gif_maker_gif_editor" name="GIF Maker - GIF editor" />
   <item component="ComponentInfo{com.gif.gifmaker/com.gif.gifmaker.ui.splash.SplashScreen}" drawable="gif_maker_gif_editor" name="GIF Maker - GIF editor" />
   <item component="ComponentInfo{pro.gif.videotogif.gifeditor.gifmaker/com.media.zatashima.studio.LoadingScreen}" drawable="gif_maker_gif_editor_pro" name="GIF Maker, GIF Editor Pro" />
@@ -7242,6 +7258,7 @@
   <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app/jp.ne.ibis.ibispaintx.app.market.MarketAuthenticationActivity}" drawable="ibis_paint" name="ibis Paint X" />
   <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app/jp.ne.ibis.ibispaintx.app.title.TitleActivity}" drawable="ibis_paint" name="ibis Paint X" />
   <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app/jp.ne.ibis.ibispaintx.app.InitializeCheckActivity}" drawable="ibis_paint" name="ibis Paint X" />
+  <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app/com.google.android.archive.ReactivateActivity}" drawable="ibis_paint" name="ibis Paint X" />
   <item component="ComponentInfo{atws.app/tws.activity.launcher.LauncherActivity}" drawable="ibkr" name="IBKR" />
   <item component="ComponentInfo{atws.app/atws.activity.launcher.LauncherActivity}" drawable="ibkr" name="IBKR" />
   <item component="ComponentInfo{com.ibm.security.verifyapp/com.ibm.security.verifyapp.activities.LaunchActivity}" drawable="ibm_verify" name="IBM Verify" />
@@ -7892,6 +7909,7 @@
   <item component="ComponentInfo{com.eat.ch/com.jet.singleactivity.ui.MainActivity}" drawable="just_eat" name="Just Eat" />
   <item component="ComponentInfo{com.justeat.app.dk/com.takeaway.android.activity.Splash}" drawable="just_eat" name="Just Eat" />
   <item component="ComponentInfo{com.justeat.app.es/com.jet.singleactivity.ui.MainActivity}" drawable="just_eat" name="Just Eat" />
+  <item component="ComponentInfo{com.justeat.app.it/com.jet.singleactivity.ui.MainActivity}" drawable="just_eat" name="Just Eat" />
   <item component="ComponentInfo{com.brouken.player/com.brouken.player.PlayerActivity}" drawable="just_player" name="Just Player" />
   <item component="ComponentInfo{com.streamline.justtherecipe/com.streamline.justtherecipe.MainActivity}" drawable="just_the_recipe" name="Just the Recipe" />
   <item component="ComponentInfo{com.juphoon.justalk/com.juphoon.justalk.ui.splash.SplashActivityDefault}" drawable="justalk" name="JusTalk" />
@@ -8408,6 +8426,7 @@
   <item component="ComponentInfo{com.applemoncash/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="lemon_cash" name="Lemon Cash" />
   <item component="ComponentInfo{com.swordfish.lemuroid/com.swordfish.lemuroid.app.mobile.feature.main.MainActivity}" drawable="lemuroid" name="Lemuroid" />
   <item component="ComponentInfo{one4studio.iconpack.lenaadaptive/com.candybar.dev.activities.SplashActivity}" drawable="lena_adaptive_icons" name="Lena Adaptive Icons" />
+  <item component="ComponentInfo{one4studio.iconpack.lenaadaptive/com.one4studio.iconpack.MainActivity}" drawable="lena_adaptive_icons" name="Lena Adaptive Icons" />
   <item component="ComponentInfo{one4studio.iconpack.lenadark/com.candybar.dev.activities.SplashActivity}" drawable="lena_dark_icons" name="Lena Dark Icons" />
   <item component="ComponentInfo{com.lenovo.serviceit/com.lenovo.serviceit.start.SplashActivity}" drawable="lenovo" name="Lenovo" />
   <item component="ComponentInfo{com.lenovo.hec.lenovoextend/com.lenovo.hec.companionapp.auth.presentation.SplashActivity2}" drawable="lenovo_freestyle" name="Lenovo Freestyle" />
@@ -8863,6 +8882,7 @@
   <item component="ComponentInfo{be.cad.made.in.belgium/be.cad.made.in.belgium.MainActivity}" drawable="made_in" name="Made in" />
   <item component="ComponentInfo{com.maybank2u.life/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="mae" name="MAE" />
   <item component="ComponentInfo{com.aswat.carrefouruae/com.aswat.carrefouruae.feature.splash.view.activity.SplashActivity}" drawable="maf_carrefour" name="MAF Carrefour" />
+  <item component="ComponentInfo{com.aswat.carrefouruae/com.aswat.carrefouruae.mafretail_app.MainActivity}" drawable="maf_carrefour" name="MAF Carrefour" />
   <item component="ComponentInfo{software.indi.android.mpd/software.indi.android.mpd.client.splash.SplashActivity}" drawable="mafa" name="MAFA" />
   <item component="ComponentInfo{com.luizalabs.mlapp/com.luizalabs.mlapp.home.ui.HomeActivity}" drawable="magalu" name="Magalu" />
   <item component="ComponentInfo{com.luizalabs.mlapp/com.luizalabs.mlapp.home.ui.MainActivity}" drawable="magalu" name="Magalu" />
@@ -9777,6 +9797,7 @@
   <item component="ComponentInfo{org.telegram.messenger/org.telegram.messenger.ThemedClassicIcon}" drawable="nekogram" name="Momogram" />
   <item component="ComponentInfo{org.telegram.messenger/org.telegram.messenger.ThemedXEyeIcon}" drawable="nekogram" name="Momogram" />
   <item component="ComponentInfo{de.momox/de.momox.ui.component.splash.SplashActivity}" drawable="momox" name="momox" />
+  <item component="ComponentInfo{de.momox/de.momox.inbound.ui.MainActivity}" drawable="momox" name="momox" />
   <item component="ComponentInfo{fr.assurancemaladie.monespacesante/fr.cnamts.ens.MainActivity}" drawable="mon_espace_sante" name="Mon espace santé" />
   <item component="ComponentInfo{com.example.monjeu/com.godot.game.GodotAppLauncher}" drawable="godot" name="mon jeu" />
   <item component="ComponentInfo{com.monclubsportif.monclubsportif/com.rnmonclubsportif.MainActivity}" drawable="monclubsportif" name="MonClubSportif" />
@@ -9792,12 +9813,14 @@
   <item component="ComponentInfo{com.ktwapps.walletmanager/com.ktwapps.walletmanager.BaseActivity}" drawable="wallet" name="Money Manager" />
   <item component="ComponentInfo{com.ktwapps.walletmanager/com.ktwapps.walletmanager.MainActivity}" drawable="wallet" name="Money Manager" />
   <item component="ComponentInfo{com.realbyteapps.moneya/com.realbyte.money.ui.license.GPLicenseCheckActivity}" drawable="money_manager" name="Money Manager" />
+  <item component="ComponentInfo{com.realbyteapps.moneymanagerfree/com.realbyte.money.ui.intro.Intro}" drawable="money_manager" name="Money Manager" />
   <item component="ComponentInfo{com.moneyboxapp/com.moneyboxapp.app.REGULAR}" drawable="moneybox" name="Moneybox" />
   <item component="ComponentInfo{com.divum.MoneyControl/com.moneycontrol.handheld.SplashActivity.PRO}" drawable="moneycontrol" name="Moneycontrol" />
   <item component="ComponentInfo{com.divum.MoneyControl/com.moneycontrol.handheld.SplashActivity.NONPRO}" drawable="moneycontrol" name="Moneycontrol" />
   <item component="ComponentInfo{com.divum.MoneyControl/com.moneycontrol.handheld.SplashActivity}" drawable="moneycontrol" name="Moneycontrol" />
   <item component="ComponentInfo{com.whizdm.moneyview.loans/com.whizdm.moneyview.loans.launcher.LauncherActivity}" drawable="moneyview" name="Moneyview" />
   <item component="ComponentInfo{com.whizdm.moneyview.loans/com.whizdm.moneyview.loans.launcher.LauncherActivityDefault}" drawable="moneyview" name="Moneyview" />
+  <item component="ComponentInfo{com.whizdm.moneyview.loans/com.whizdm.moneyview.loans.launcher.LauncherActivitySeasonal}" drawable="moneyview" name="Moneyview" />
   <item component="ComponentInfo{com.oriondev.moneywallet/com.oriondev.moneywallet.ui.activity.LauncherActivity}" drawable="moneywallet" name="MoneyWallet" />
   <item component="ComponentInfo{im.monica.app.monica/im.monica.app.monica.MainActivity}" drawable="monica_ai" name="Monica AI" />
   <item component="ComponentInfo{app.com.example.szymi.myapplication/app.com.example.szymi.MainActivity}" drawable="monitor_burz" name="Monitor Burz" />
@@ -10325,6 +10348,7 @@
   <item component="ComponentInfo{com.myntra.android/com.myntra.android.activities.react.ReactActivity}" drawable="myntra" name="Myntra" />
   <item component="ComponentInfo{com.myntra.android/com.myntra.android.SplashActivity}" drawable="myntra" name="Myntra" />
   <item component="ComponentInfo{com.myntra.android/com.myntra.android.activities.react.ReactActivity.EORS_DEC_WINTER}" drawable="myntra" name="Myntra" />
+  <item component="ComponentInfo{com.myntra.android/com.myntra.android.activities.react.ReactActivity.MBB_PRIMARY}" drawable="myntra" name="Myntra" />
   <item component="ComponentInfo{nz.co.vista.android.movie.odeoncinemas/nz.co.vista.android.movie.abc.feature.splash.SplashActivity}" drawable="myodeon" name="myODEON" />
   <item component="ComponentInfo{com.ncloudtech.cloudoffice/com.ncloudtech.cloudoffice.android.myfm.launch.LaunchActivity}" drawable="myoffice_documents" name="MyOffice Documents" />
   <item component="ComponentInfo{com.ncloudtech.cloudoffice/com.ncloudtech.cloudoffice.NewIcons}" drawable="myoffice_documents" name="MyOffice Documents" />
@@ -10434,6 +10458,7 @@
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.DefaultIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.HollowIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{com.msob7y.namida.snapshot/com.msob7y.namida.snapshot.DefaultIcon}" drawable="namida" name="Namida" />
+  <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.ShadeIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{in.juspay.nammayatri/in.juspay.mobility.MainActivity}" drawable="namma_yatri" name="Namma Yatri" />
   <item component="ComponentInfo{in.juspay.nammayatri/com.mobility.movingtech.MainActivity}" drawable="namma_yatri" name="Namma Yatri" />
   <item component="ComponentInfo{com.kazufukurou.nanji/com.kazufukurou.nanji.ui.MainActivity}" drawable="nanji_clock_widget" name="Nanji Clock Widget" />
@@ -10712,6 +10737,7 @@
   <item component="ComponentInfo{com.ninefolders.hd3/com.ninefolders.hd3.activity.NineActivity}" drawable="nine" name="Nine" />
   <item component="ComponentInfo{adriandp.ninedash/adriandp.view.main.view.MainActivity}" drawable="nine_dash" name="Nine Dash" />
   <item component="ComponentInfo{de.csicar.ning/de.csicar.ning.MainActivity}" drawable="ning" name="Ning" />
+  <item component="ComponentInfo{com.ananinja.lava/com.ananinja.lava.splash.SplashActivity}" drawable="ninja" name="Ninja" />
   <item component="ComponentInfo{com.nintendo.znba/com.nintendo.znba.MainActivity}" drawable="nintendo_music" name="Nintendo Music" />
   <item component="ComponentInfo{com.nintendo.znca/com.nintendo.coral.ui.boot.BootActivity}" drawable="nintendo_switch" name="Nintendo Switch" />
   <item component="ComponentInfo{com.nintendo.znca/crc64e1ce91bfba58d316.MainActivity}" drawable="nintendo_switch" name="Nintendo Switch" />
@@ -11242,6 +11268,7 @@
   <item component="ComponentInfo{tn.com.tunisiana.android.maTunisiana/com.comviva.webaxn.ui.WebAxnActivity}" drawable="ooredoo" name="Ooredoo" />
   <item component="ComponentInfo{com.algeria.selfcare.app.android/com.example.ooredoo_selfcare_algeria.MainActivity}" drawable="ooredoo" name="Ooredoo" />
   <item component="ComponentInfo{om.ooredoo/crc64d99185bf69e73e40.SplashActivity}" drawable="ooredoo" name="Ooredoo" />
+  <item component="ComponentInfo{tn.com.tunisiana.android.maTunisiana/com.comviva.nextgen.ooredoodev.MainActivity}" drawable="ooredoo" name="Ooredoo" />
   <item component="ComponentInfo{qa.ooredoo.omm/qa.ooredoo.omm.ui.splashscreen.SplashScreenActivity}" drawable="ooredoo_money" name="Ooredoo Money" />
   <item component="ComponentInfo{com.opautoclicker.autoclicker/com.opautoclicker.autoclicker.activities.MainActivity}" drawable="op_auto_clicker" name="OP Auto Clicker" />
   <item component="ComponentInfo{fi.op.android.opmobiili/fi.op.android.opmobiili.common.mainui.MainActivity}" drawable="op_mobiili" name="OP-mobiili" />
@@ -11544,6 +11571,7 @@
   <item component="ComponentInfo{io.voodoo.paper2/com.google.firebase.MessagingUnityPlayerActivity}" drawable="paper_io_2" name="Paper.io 2" />
   <item component="ComponentInfo{io.voodoo.paper2/com.byfen.archiver.MainActivity}" drawable="paper_io_2" name="Paper.io 2" />
   <item component="ComponentInfo{com.mmicunovic.papercopy/com.mmicunovic.papercopy.ui.SplashActivity}" drawable="papercopy" name="Papercopy" />
+  <item component="ComponentInfo{com.mmicunovic.papercopy/com.mmicunovic.papercopy.MainActivity}" drawable="papercopy" name="Papercopy" />
   <item component="ComponentInfo{eu.bauerj.paperless_app/eu.bauerj.paperless_app.MainActivity}" drawable="paperless" name="Paperless" />
   <item component="ComponentInfo{de.astubenbord.paperless_mobile/de.astubenbord.paperless_mobile.MainActivity}" drawable="paperless" name="Paperless" />
   <item component="ComponentInfo{de.astubenbord.paperless_mobile/com.example.paperless_mobile.MainActivity}" drawable="paperless" name="Paperless" />
@@ -11980,6 +12008,7 @@
   <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.SplashActivityAliasNormal}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
   <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.activity.SplashActivity}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
   <item component="ComponentInfo{xyz.penpencil.physicswala/xyz.penpencil.physicswala.MainActivity}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
+  <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.SplashActivityAliasVishwasDiwas}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
   <item component="ComponentInfo{ai.inflection.pi/ai.inflection.pi.MainActivity}" drawable="inflection_pi" name="Pi" />
   <item component="ComponentInfo{dev.sanmer.pi/dev.sanmer.pi.ui.MainActivity}" drawable="generic_pi" name="PI" />
   <item component="ComponentInfo{dev.sanmer.pi/dev.sanmer.pi.ui.activity.MainActivity}" drawable="generic_pi" name="PI" />
@@ -12976,6 +13005,7 @@
   <item component="ComponentInfo{com.rec.screen/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="kimcy_screen_recorder" name="REC" />
   <item component="ComponentInfo{com.AgainstGravity.RecRoom/com.recroom.googleplaynative.SignInActivity}" drawable="rec_room" name="Rec Room" />
   <item component="ComponentInfo{com.AgainstGravity.RecRoom/com.google.android.archive.ReactivateActivity}" drawable="rec_room" name="Rec Room" />
+  <item component="ComponentInfo{com.AgainstGravity.RecRoom/com.againstgravity.recroom.GooglePlayNativeActivity}" drawable="rec_room" name="Rec Room" />
   <item component="ComponentInfo{co.megared.app/co.megared.app.MainActivity}" drawable="recarga_megared" name="Recarga Megared" />
   <item component="ComponentInfo{dje073.android.modernrecforge/dje073.android.modernrecforge.ActivityMain}" drawable="generic_microphone" name="RecForge II" />
   <item component="ComponentInfo{com.HonduneGames.ReCharge/com.unity3d.player.UnityPlayerActivity}" drawable="recharge_rc" name="Recharge RC" />
@@ -13995,6 +14025,7 @@
   <item component="ComponentInfo{com.beeasy.airpay/com.airpay.login.splash.SplashActivity}" drawable="shopeepay" name="ShopeePay" />
   <item component="ComponentInfo{com.beeasy.toppay/com.airpay.login.splash.SplashActivity}" drawable="shopeepay" name="ShopeePay" />
   <item component="ComponentInfo{com.shopeepay.my/com.shopee.app.ui.home.HomeActivity_}" drawable="shopeepay" name="ShopeePay" />
+  <item component="ComponentInfo{com.beeasy.toppay/com.airpay.login.integration.splash.SplashActivity}" drawable="shopeepay" name="ShopeePay" />
   <item component="ComponentInfo{gr.shopflix.mobileApp/gr.desquared.MVI_Base_Android.activities.SplashScreenImplActivity}" drawable="shopflix" name="SHOPFLIX" />
   <item component="ComponentInfo{com.shopify.mobile/com.shopify.mobile.MainActivity}" drawable="shopify" name="Shopify" />
   <item component="ComponentInfo{com.woefe.shoppinglist/com.woefe.shoppinglist.activity.MainActivity}" drawable="shopping_list" name="Shopping List" />
@@ -14200,6 +14231,7 @@
   <item component="ComponentInfo{com.simplemobiletools.contacts/com.simplemobiletools.contacts.activities.SplashActivity.Red}" drawable="generic_contacts" name="Simple Contacts" />
   <item component="ComponentInfo{com.simplemobiletools.contacts/com.simplemobiletools.contacts.activities.SplashActivity.Teal}" drawable="generic_contacts" name="Simple Contacts" />
   <item component="ComponentInfo{com.simplemobiletools.contacts/com.simplemobiletools.contacts.activities.SplashActivity.Yellow}" drawable="generic_contacts" name="Simple Contacts" />
+  <item component="ComponentInfo{com.simplemobiletools.contacts/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="generic_contacts" name="Simple Contacts" />
   <item component="ComponentInfo{com.simplemobiletools.contacts.pro/com.simplemobiletools.contacts.pro.activities.SplashActivity.Amber}" drawable="generic_contacts_pro" name="Simple Contacts Pro" />
   <item component="ComponentInfo{com.simplemobiletools.contacts.pro/com.simplemobiletools.contacts.pro.activities.SplashActivity.Blue}" drawable="generic_contacts_pro" name="Simple Contacts Pro" />
   <item component="ComponentInfo{com.simplemobiletools.contacts.pro/com.simplemobiletools.contacts.pro.activities.SplashActivity.Blue_grey}" drawable="generic_contacts_pro" name="Simple Contacts Pro" />
@@ -14742,6 +14774,7 @@
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.LavaAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivity}" drawable="snapdeal" name="Snapdeal" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivityDefault}" drawable="snapdeal" name="Snapdeal" />
+  <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivityDefaultClone}" drawable="snapdeal" name="Snapdeal" />
   <item component="ComponentInfo{com.fmsys.snapdrop/com.google.android.archive.ReactivateActivity}" drawable="snapdrop" name="Snapdrop" />
   <item component="ComponentInfo{net.snapdrop/net.snapdrop.MainActivity}" drawable="snapdrop" name="Snapdrop" />
   <item component="ComponentInfo{com.fmsys.snapdrop/com.fmsys.snapdrop.MainActivity}" drawable="snapdrop" name="Snapdrop" />
@@ -15301,6 +15334,7 @@
   <item component="ComponentInfo{ee.dustland.android.dustlandsudoku/ee.dustland.android.dustlandsudoku.SudokuHostActivity}" drawable="generic_sudoku" name="Sudoku — The Clean One" />
   <item component="ComponentInfo{com.easybrain.sudoku.android/com.easybrain.template.SplashActivity}" drawable="generic_sudoku" name="Sudoku.com" />
   <item component="ComponentInfo{com.easybrain.sudoku.android/com.easybrain.sudoku.gui.splash.SplashActivity}" drawable="generic_sudoku" name="Sudoku.com" />
+  <item component="ComponentInfo{com.easybrain.sudoku.android/com.easybrain.sudoku.android.SplashActivity}" drawable="generic_sudoku" name="Sudoku.com" />
   <item component="ComponentInfo{com.brainium.sudoku.free/com.unity3d.player.UnityPlayerActivity}" drawable="sudoku_number_match_game" name="Sudoku: Number Match Game" />
   <item component="ComponentInfo{com.brainium.sudoku.free/com.brainium.brainlib.core_android.BrainlibActivityFree}" drawable="sudoku_number_match_game" name="Sudoku: Number Match Game" />
   <item component="ComponentInfo{com.brainium.sudoku.free/com.braze.unity.BrazeUnityPlayerActivity}" drawable="sudoku_number_match_game" name="Sudoku: Number Match Game" />
@@ -15516,6 +15550,7 @@
   <item component="ComponentInfo{com.talabat/com.talabat.FlutterLandingScreen}" drawable="talabat" name="talabat" />
   <item component="ComponentInfo{com.talabat/com.talabat.LandingScreen}" drawable="talabat" name="talabat" />
   <item component="ComponentInfo{com.talabat/com.talabat.MainActivityDefault}" drawable="talabat" name="talabat" />
+  <item component="ComponentInfo{com.talabat/com.talabat.MainActivityRamadan}" drawable="talabat" name="talabat" />
   <item component="ComponentInfo{co.talenta/co.talenta.modul.splash.SplashActivity}" drawable="talenta" name="Talenta" />
   <item component="ComponentInfo{com.talkatone.android/com.talkatone.vedroid.Loading}" drawable="generic_dialer" name="Talkatone" />
   <item component="ComponentInfo{com.weaver.app.prod/com.weaver.app.ui.LaunchActivity}" drawable="talkie" name="Talkie" />
@@ -15781,6 +15816,7 @@
   <item component="ComponentInfo{com.testbook.tbapp/com.testbook.tbapp.android.SplashActivity}" drawable="testbook" name="Testbook" />
   <item component="ComponentInfo{com.robertlevonyan.testy/com.robertlevonyan.testy._base.MainActivity}" drawable="testy" name="Testy" />
   <item component="ComponentInfo{com.robertlevonyan.testy/com.robertlevonyan.testy.base.MainActivity}" drawable="testy" name="Testy" />
+  <item component="ComponentInfo{com.robertlevonyan.testy/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="testy" name="Testy" />
   <item component="ComponentInfo{com.pyamsoft.tetherfi/com.pyamsoft.tetherfi.main.MainActivity}" drawable="tetherfi" name="TetherFi" />
   <item component="ComponentInfo{com.n3twork.tetris/com.n3twork.NWUnityPlayerActivity}" drawable="tetris" name="Tetris" />
   <item component="ComponentInfo{com.raumfeld.android.controller/com.raumfeld.android.controller.clean.external.ui.root.RootActivity}" drawable="teufel" name="Teufel Raumfeld" />
@@ -15794,6 +15830,7 @@
   <item component="ComponentInfo{softmaker.applications.office.textmaker/softmaker.applications.textmaker.TextMaker}" drawable="textmaker" name="TextMaker" />
   <item component="ComponentInfo{com.enflick.android.TextNow/com.enflick.android.TextNow.activities.WelcomeActivity}" drawable="textnow" name="TextNow" />
   <item component="ComponentInfo{com.enflick.android.TextNow/authorization.ui.AuthorizationActivity}" drawable="textnow" name="TextNow" />
+  <item component="ComponentInfo{com.enflick.android.TextNow/com.enflick.android.TextNow.appicon.winter}" drawable="textnow" name="TextNow" />
   <item component="ComponentInfo{com.gogii.textplus/com.nextplus.android.activity.SplashScreenActivity}" drawable="textplus" name="textPlus" />
   <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1de9b6_bare}" drawable="textra_sms" name="Textra SMS" />
   <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff448aff}" drawable="textra_sms" name="Textra SMS" />
@@ -16191,6 +16228,7 @@
   <item component="ComponentInfo{ru.aleshin.timeplanner/ru.aleshin.timeplanner.presentation.ui.main.MainActivity}" drawable="timeplanner" name="TimePlanner" />
   <item component="ComponentInfo{com.toi.reader.activities/com.toi.reader.activities.ToiIconAlias}" drawable="times_of_india" name="Times Of India" />
   <item component="ComponentInfo{com.toi.reader.activities/com.toi.reader.activities.SplashScreenActivity}" drawable="times_of_india" name="Times Of India" />
+  <item component="ComponentInfo{com.toi.reader.activities/com.toi.reader.HomeNavigationActivity}" drawable="times_of_india" name="Times Of India" />
   <item component="ComponentInfo{com.jeyluta.timestampcamerafree/com.example.PermissionActivity}" drawable="timestamp_camera" name="Timestamp Camera" />
   <item component="ComponentInfo{com.jeyluta.timestampcameraent/com.example.PermissionActivity}" drawable="timestamp_camera_pro" name="Timestamp Camera EnterprisePro" />
   <item component="ComponentInfo{com.jeyluta.timestampcamera/com.example.PermissionActivity}" drawable="timestamp_camera_pro" name="Timestamp Camera Pro" />
@@ -17221,6 +17259,7 @@
   <item component="ComponentInfo{com.android.bbk.lockscreen3/com.android.bbk.lockscreen3.LockScreenActivity}" drawable="vivo_lock" name="vivo Lock" />
   <item component="ComponentInfo{com.vivo.notes/com.vivo.notes.Notes}" drawable="generic_notes" name="vivo Notes" />
   <item component="ComponentInfo{br.com.m4u.recarga.vivo/br.com.m4u.recarga.vivo.MainActivity}" drawable="vivo" name="vivo Pay" />
+  <item component="ComponentInfo{com.vivo.soundrecorder/com.android.activity.ReclistActivity}" drawable="generic_voice_recorder_waves" name="vivo Recorder" />
   <item component="ComponentInfo{com.vivo.setting.android/com.iapp.app.logoActivity}" drawable="settings" name="vivo Settings" />
   <item component="ComponentInfo{com.vivo.smartremote/com.vivo.smartremote.ui.MainActivity}" drawable="mi_remote" name="vivo Smart Remote" />
   <item component="ComponentInfo{com.vivo.Tips/com.vivo.Tips.MainActivity}" drawable="vivo_tips" name="vivo Tips" />
@@ -18192,10 +18231,12 @@
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_1}" drawable="morphe" name="YouTube Music" />
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/app.revanced.android.apps.youtube.music.revanced_original_4}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/app.revanced.android.apps.youtube.music.revanced_original_2}" drawable="generic_player" name="YouTube Music" />
+  <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_original_2}" drawable="generic_player" name="YouTube Music Morphe" />
   <item component="ComponentInfo{anddea.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.rvx.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{com.rvx.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
+  <item component="ComponentInfo{app.revanced.android.apps.youtube.music/app.revanced.android.apps.youtube.music.revanced_original_3}" drawable="generic_player" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{com.android.youtube.premium/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube_premium" name="YouTube Premium" />
   <item component="ComponentInfo{com.google.android.youtube.pro/com.google.android.youtube.pro.MainActivity}" drawable="youtube" name="Youtube Pro" />
   <item component="ComponentInfo{com.gold.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube" name="YouTube Pro" />
@@ -18370,6 +18411,7 @@
   <item component="ComponentInfo{com.htetznaing.fonttools/com.htetznaing.fonttools.MainActivity}" drawable="zfont_tool" name="zFont Tool" />
   <item component="ComponentInfo{com.ketchapp.zigzaggame/com.unity3d.player.UnityPlayerActivity}" drawable="zigzag" name="ZigZag" />
   <item component="ComponentInfo{com.loyalty.android/com.loyalty.android.splash.activities.SplashActivity}" drawable="zillion" name="Zillion" />
+  <item component="ComponentInfo{com.loyalty.android/com.loyalty.android.splash.activities.SplashActivityMain}" drawable="zillion" name="Zillion" />
   <item component="ComponentInfo{com.zillow.android.rentals/com.zillow.android.splashscreen.SplashScreenActivity}" drawable="zillow" name="Zillow" />
   <item component="ComponentInfo{com.zillow.android.zillowmap/com.zillow.android.splashscreen.SplashScreenActivity}" drawable="zillow" name="Zillow" />
   <item component="ComponentInfo{com.zing.mp3/com.zing.mp3.ui.activity.SplashActivity}" drawable="zing_mp3" name="Zing MP3" />
@@ -18792,6 +18834,7 @@
   <item component="ComponentInfo{co.tamara.user/co.tamara.user.LaunchActivity}" drawable="tamara" name="تمارا ~~ Tamara" />
   <item component="ComponentInfo{co.tamara.user/co.tamara.user.MainActivity}" drawable="tamara" name="تمارا ~~ Tamara" />
   <item component="ComponentInfo{sa.gov.nic.twkhayat/com.tawakkalna.twkapp.ui.SplashActivity}" drawable="tawakkalna_services" name="توكلنا خدمات ~~ Tawakkalna Services" />
+  <item component="ComponentInfo{sa.gov.nic.twkhayat/com.tawakkalna.twkapp.ui.MainActivity}" drawable="tawakkalna_services" name="توكلنا خدمات ~~ Tawakkalna Services" />
   <item component="ComponentInfo{sa.gov.nic.tawakkalna/com.store.android.ui.SplashActivity}" drawable="tawakkalna_emergency" name="توكلنا طوارئ ~~ Tawakkalna Emergency" />
   <item component="ComponentInfo{com.jarirbookstore.JBMarketingApp/com.yaqut.jarirapp.activities.onboarding.SplashScreen}" drawable="jarir" name="جرير ~~ Jarir" />
   <item component="ComponentInfo{com.haraj.app/com.haraj.app.main.MainActivity}" drawable="haraj" name="حراج ~~ Haraj" />
@@ -18851,6 +18894,7 @@
   <item component="ComponentInfo{numberplace.ohte/com.withprize.numpl.MainActivity}" drawable="generic_sudoku" name="ナンプレde懸賞 ~~ Sudoku de Sweepstakes" />
   <item component="ComponentInfo{jp.co.dwango.nicocas/jp.co.dwango.nicocas.ui.RootActivity}" drawable="niconico" name="ニコニコ ~~ Niconico" />
   <item component="ComponentInfo{jp.nicovideo.android/jp.nicovideo.android.StartupActivity}" drawable="niconico_video" name="ニコニコ動画 ~~ Niconico Video" />
+  <item component="ComponentInfo{jp.co.nitori/jp.co.nitori.MainActivity}" drawable="nitori" name="ニトリ ~~ NITORI" />
   <item component="ComponentInfo{mu.note/mu.note.activity.StartActivity}" drawable="note" name="ノート ~~ note" />
   <item component="ComponentInfo{mu.note/mu.note.presentation.start.StartActivity}" drawable="note" name="ノート ~~ note" />
   <item component="ComponentInfo{aculix.bulk.image.compressor/aculix.bulk.image.compressor.ui.MainActivity}" drawable="image_compressor" name="バッチ画像圧縮 ~~ Image Compressor" />


### PR DESCRIPTION
## Linked
Affirm (`com.affirm.central` → `affirm.svg`)
AIO Streamer (`com.streamdev.aiostreamer` → `jiotv.svg`)
Bstation (`com.bstar.intl` → `bilibili.svg`)
ByeByeDPI (`io.github.romanvht.byedpi` → `byebyedpi.svg`)
Caelus Adaptive Material Icons (`one4studio.iconpack.caelusadaptive` → `caelus_adaptive_material_icons.svg`)
Caelus Black Icons (`studio14.application.caelusblack` → `caelus_icons.svg`)
Caelus Duotone (`one4studio.iconpack.caelusduotone` → `caelus_icons.svg`)
Caelus Icons (`studio14.application.caelus` → `caelus_icons.svg`)
Caelus White (`studio14.application.caeluswhite` → `caelus_icons.svg`)
CRICFy TV (`com.cricfytv.sports` → `cricfy_tv.svg`)
Discover (`com.discoverfinancial.mobile` → `discover.svg`)
Dolby Atmos (`co.aospa.dolby.xiaomi` → `dolby.svg`)
File Navigator (`com.w2sv.filenavigator` → `file_navigator.svg`)
filmfriend (`de.filmfriend` → `filmfriend.svg`)
Flipkart (`com.flipkart.android` → `flipkart.svg`)
GIF Maker (`com.bk.videotogif` → `gif_maker_editor.svg`)
ibis Paint X (`jp.ne.ibis.ibispaintx.app` → `ibis_paint.svg`)
Just Eat (`com.justeat.app.it` → `just_eat.svg`)
Lena Adaptive Icons (`one4studio.iconpack.lenaadaptive` → `lena_adaptive_icons.svg`)
MAF Carrefour (`com.aswat.carrefouruae` → `maf_carrefour.svg`)
momox (`de.momox` → `momox.svg`)
Money Manager (`com.realbyteapps.moneymanagerfree` → `money_manager.svg`)
Moneyview (`com.whizdm.moneyview.loans` → `moneyview.svg`)
Myntra (`com.myntra.android` → `myntra.svg`)
Namida (`com.msob7y.namida` → `namida.svg`)
Ninja (`com.ananinja.lava` → `ninja.svg`)
Ooredoo (`tn.com.tunisiana.android.maTunisiana` → `ooredoo.svg`)
Papercopy (`com.mmicunovic.papercopy` → `papercopy.svg`)
Physics Wallah (PW) (`xyz.penpencil.physicswala` → `physics_wallah_pw.svg`)
Rec Room (`com.AgainstGravity.RecRoom` → `rec_room.svg`)
ShopeePay (`com.beeasy.toppay` → `shopeepay.svg`)
Simple Contacts (`com.simplemobiletools.contacts` → `generic_contacts.svg`)
Snapdeal (`com.snapdeal.main` → `snapdeal.svg`)
Sudoku.com (`com.easybrain.sudoku.android` → `generic_sudoku.svg`)
talabat (`com.talabat` → `talabat.svg`)
Testy (`com.robertlevonyan.testy` → `testy.svg`)
TextNow (`com.enflick.android.TextNow` → `textnow.svg`)
Times Of India (`com.toi.reader.activities` → `times_of_india.svg`)
vivo Recorder (`com.vivo.soundrecorder` → `generic_voice_recorder_waves.svg`)
YouTube Music Morphe (`app.morphe.android.apps.youtube.music` → `generic_player.svg`)
YouTube Music ReVanced (`app.revanced.android.apps.youtube.music` → `generic_player.svg`)
Zillion (`com.loyalty.android` → `zillion.svg`)
توكلنا خدمات ~~ Tawakkalna Services (`sa.gov.nic.twkhayat` → `tawakkalna_services.svg`)
ニトリ ~~ NITORI (`jp.co.nitori` → `nitori.svg`)