### PR TITLE
+2 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -14782,6 +14782,7 @@
   <item component="ComponentInfo{com.netease.sky/com.tgc.sky.netease.GameActivity_Netease}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.netease.sky/com.tgc.sky.TGCBootActivity}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.netease.sky/com.netease.ntunisdk.external.protocol.ProtocolLauncher}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
+  <item component="ComponentInfo{com.netease.sky.vivo/com.netease.ntunisdk.external.protocol.ProtocolLauncher}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.flightradar24.skycards/com.flightradar24.skycards.MainActivity}" drawable="skycards" name="SkyCards" />
   <item component="ComponentInfo{com.skycash.beta/com.norbsoft.android.ease.activities.SplashScreenActivity}" drawable="skycash" name="SkyCash" />
   <item component="ComponentInfo{skyline.emu/emu.skyline.MainActivity}" drawable="skyline" name="Skyline" />
@@ -19232,6 +19233,7 @@
   <item component="ComponentInfo{com.lingnanpass/com.lingnanpass.GuideActivity}" drawable="lingnan_pass" name="岭南通 ~~ Lingnan Pass" />
   <item component="ComponentInfo{com.miHoYo.enterprise.NGHSoD/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="崩坏3 ~~ Honkai Impact 3rd" />
   <item component="ComponentInfo{com.miHoYo.bh3.bilibili/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="崩坏3 ~~ Honkai Impact 3rd" />
+  <item component="ComponentInfo{com.miHoYo.bh3.vivo/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="崩坏3 ~~ Honkai Impact 3rd" />
   <item component="ComponentInfo{com.tencent.tmgp.bh3/com.miHoYo.overridenativeactivity.OverrideNativeActivity}" drawable="honkai_impact_3" name="崩坏3 ~~ Honkai Impact 3rd" />
   <item component="ComponentInfo{com.miHoYo.hkrpg/com.mihoyo.combosdk.ComboSDKActivity}" drawable="honkai_star_rail" name="崩坏：星穹铁道 ~~ Honkai: Star Rail" />
   <item component="ComponentInfo{com.miHoYo.hkrpg.bilibili/com.mihoyo.combosdk.ComboSDKActivity}" drawable="honkai_star_rail" name="崩坏：星穹铁道 ~~ Honkai: Star Rail" />


### PR DESCRIPTION
~~ReVanced Manager now uses a different activity, which I link here.~~
The two other are links to variants of Honkai Impact and Sky: Children of the Light from the Chinese Vivo app store: https://h5.appstore.vivo.com.cn/

## Icons
<!-- Please specify in the sections below which apps and packages you have worked on.
     Unnecessary sections can be deleted. -->

### Linked
<!-- New app packages for existing icons. -->
~~ReVanced Manager (`app.revanced.manager.flutter` → `youtube_revanced.svg`)~~  
Sky: Children of the Light (`com.netease.sky.vivo` → `sky_children_of_the_light.svg`)  
崩坏3 ~~ Honkai Impact 3rd (`com.miHoYo.bh3.vivo` → `honkai_impact_3.svg`)  
