### PR TITLE
Implement initial icon linter scripts and automation

### DIFF
--- a/.github/icon_checklist.md
+++ b/.github/icon_checklist.md
@@ -18,3 +18,4 @@ a_and_w.svg | A&amp;W
 ### Common issuess
 ![](https://raw.githubusercontent.com/LawnchairLauncher/lawnicons/refs/heads/develop/docs/images/common-issues-to-fix.png)
 
+<!-- icon-checklist-posted -->

--- a/.github/scripts/bot_orchestrator.py
+++ b/.github/scripts/bot_orchestrator.py
@@ -1,13 +1,16 @@
 import os
+import argparse
+import re
 import subprocess
 import sys
 from pathlib import Path
-from github import Github
 
 # --- Configuration ---
 REPO_NAME = os.getenv("GITHUB_REPOSITORY")
-PR_NUMBER = int(os.getenv("PR_NUMBER"))  # type: ignore
+PR_NUMBER_RAW = os.getenv("PR_NUMBER")
+PR_NUMBER = int(PR_NUMBER_RAW) if PR_NUMBER_RAW else None
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+GITHUB_BASE_REF = os.getenv("GITHUB_BASE_REF")
 
 # Assuming a standard project structure
 REPO_ROOT = Path(__file__).parent.parent.parent
@@ -22,34 +25,83 @@ NEEDS_REVIEW_LABEL = "needs review"
 # --- Main Logic ---
 
 
-def get_changed_svgs() -> list[str]:
+def configure_repo_paths(repo_dir: str | None) -> None:
+    """Override repository-relative paths for local testing runs."""
+    global REPO_ROOT, APPFILTER_PATH, DRAWABLES_DIR
+
+    if not repo_dir:
+        return
+
+    resolved_repo_root = Path(repo_dir).expanduser().resolve()
+    REPO_ROOT = resolved_repo_root
+    APPFILTER_PATH = REPO_ROOT / "app/assets/appfilter.xml"
+    DRAWABLES_DIR = REPO_ROOT / "svgs/"
+
+
+def get_changed_svgs(base_ref: str) -> list[str]:
     """Finds SVG files changed in this PR compared to the target branch."""
-    target_branch = os.getenv("GITHUB_BASE_REF")
     drawables_pathspec = DRAWABLES_DIR.relative_to(REPO_ROOT).as_posix()
     cmd = ["git", "diff", "--name-only",
-           f"origin/{target_branch}", "HEAD", "--", drawables_pathspec]
+           f"origin/{base_ref}", "HEAD", "--", drawables_pathspec]
     result = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        return []
+    changed_files = result.stdout.strip().splitlines()
+    return [str(DRAWABLES_DIR / Path(f).name) for f in changed_files if f.endswith(".svg")]
+
+def get_changed_drawables(base_ref: str) -> list[str]:
+    """Extracts drawable names from added/modified lines in appfilter.xml diff."""
+    cmd = ["git", "diff", f"origin/{base_ref}", "HEAD", "--",
+           str(APPFILTER_PATH.as_posix())]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
         cwd=REPO_ROOT,
     )
     if result.returncode != 0:
         return []
 
+    drawables = []
+    for line in result.stdout.splitlines():
+        # Only look at added lines (+ prefix, not the +++ header)
+        if line.startswith('+') and not line.startswith('+++'):
+            match = re.search(r'drawable="([^"]+)"', line)
+            if match:
+                drawables.append(match.group(1))
+    return drawables
 
 def run_linter(script_path: Path, args: list[str]) -> str:
     """Runs a linter script and returns its stdout."""
     try:
+        child_env = os.environ.copy()
+        child_env["PYTHONUTF8"] = "1"
+        child_env["PYTHONIOENCODING"] = "utf-8"
+
         result = subprocess.run(
             [sys.executable, str(script_path)] + args,
             # check=False to capture output even on failure
-            capture_output=True, text=True, check=False
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            env=child_env,
         )
 
         if result.returncode != 0:
-            error_output = stderr or stdout or "No output captured."
+            error_output = result.stderr or result.stdout or "No output captured."
             return (
                 f"CRITICAL_ERROR: {script_path.name} exited with code "
                 f"{result.returncode}: {error_output}"
@@ -68,54 +120,178 @@ def find_bot_comment(pr):
     return None
 
 
-# --- Orchestration ---
-if __name__ == "__main__":
-    changed_svg_files = get_changed_svgs()
+def normalize_issue_message(message: str) -> str:
+    """Convert internal check IDs (e.g. C01, Q04) to plain numbers."""
+    token = message.strip()
+    match = re.fullmatch(r"[A-Za-z]+(\d+)", token)
+    if match:
+        return str(int(match.group(1)))
+    return token
+
+
+def chunk_for_command(values: list[str], fixed_args: list[str], max_chars: int = 7000) -> list[list[str]]:
+    """Split dynamic CLI values into safe chunks to avoid command-line length errors."""
+    if not values:
+        return []
+
+    chunks: list[list[str]] = []
+    base_len = sum(len(arg) + 1 for arg in fixed_args)
+    current_chunk: list[str] = []
+    current_len = base_len
+
+    for value in values:
+        value_len = len(value) + 1
+        if current_chunk and current_len + value_len > max_chars:
+            chunks.append(current_chunk)
+            current_chunk = [value]
+            current_len = base_len + value_len
+            continue
+
+        current_chunk.append(value)
+        current_len += value_len
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    return chunks
+
+
+def resolve_base_ref(explicit_base_ref: str | None) -> str:
+    def normalize_ref(ref: str) -> str:
+        ref = ref.strip()
+        if ref.startswith("refs/heads/"):
+            return ref[len("refs/heads/"):]
+        if ref.startswith("origin/"):
+            return ref[len("origin/"):]
+        return ref
+
+    if explicit_base_ref:
+        return normalize_ref(explicit_base_ref)
+
+    if GITHUB_BASE_REF:
+        return normalize_ref(GITHUB_BASE_REF)
+
+    # Fallback for local CLI runs where GITHUB_BASE_REF is not set.
+    result = subprocess.run(
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode == 0:
+        ref = result.stdout.strip()
+        if "/" in ref:
+            return ref.rsplit("/", 1)[-1]
+
+    return "main"
+
+
+def collect_final_report(base_ref: str) -> str:
+    changed_svg_files = get_changed_svgs(base_ref)
     all_errors = []
 
     # 1. Run SVG Linter on changed files only
     if changed_svg_files:
         print(f"Checking {len(changed_svg_files)} changed SVG files...")
-        svg_linter_args = ["--format", "compact"] + changed_svg_files
-        svg_errors = run_linter(SVG_LINTER_PATH, svg_linter_args)
-        if svg_errors:
-            all_errors.append(svg_errors)
+        svg_base_args = ["--format", "compact"]
+        for svg_chunk in chunk_for_command(changed_svg_files, svg_base_args):
+            svg_errors = run_linter(SVG_LINTER_PATH, svg_base_args + svg_chunk)
+            if svg_errors:
+                all_errors.append(svg_errors)
 
-    # 2. Run Name Checker
+    # 2. Run Name Checker (only on changed drawables)
     print("Checking appfilter.xml consistency...")
-    name_errors = run_linter(
-        NAME_CHECKER_PATH, [str(APPFILTER_PATH), str(DRAWABLES_DIR)])
-    if name_errors:
-        all_errors.append(name_errors)
+    changed_drawables = get_changed_drawables(base_ref)
+    name_checker_args = [str(APPFILTER_PATH), str(DRAWABLES_DIR)]
+    if changed_drawables:
+        drawable_flag_args = name_checker_args + ["--changed-drawables"]
+        for drawable_chunk in chunk_for_command(changed_drawables, drawable_flag_args):
+            name_errors = run_linter(
+                NAME_CHECKER_PATH,
+                drawable_flag_args + drawable_chunk,
+            )
+            if name_errors:
+                all_errors.append(name_errors)
+    else:
+        print("No changed drawables detected; skipping name checker.")
 
-    # 3. Connect to GitHub
-    g = Github(GITHUB_TOKEN)
-    repo = g.get_repo(REPO_NAME)  # type: ignore
+    return "\n".join(all_errors).strip()
+
+
+def parse_report_by_file(final_report: str) -> dict[str, list[str]]:
+    error_map: dict[str, list[str]] = {}
+    current_file: str | None = None
+
+    for raw_line in final_report.splitlines():
+        print(raw_line)
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        # Only first two ':' are structural: meta : info[:rest...]
+        parts = [p.strip() for p in line.split(":", 2)]
+
+        # No separator -> continuation
+        if len(parts) == 1:
+            if current_file is not None:
+                error_map[current_file].append(normalize_issue_message(parts[0]))
+            continue
+
+        meta = parts[0]
+        info = parts[1]
+        if len(parts) == 3:
+            # Keep all remaining ':' inside message body
+            info = f"{info}: {parts[2]}".strip()
+
+        # Start a new file block when meta is an svg path
+        if meta.lower().endswith(".svg"):
+            current_file = meta
+            error_map.setdefault(current_file, [])
+            if info:
+                error_map[current_file].append(normalize_issue_message(info))
+        elif current_file is not None:
+            # Non-file meta lines are continuation details for current file
+            combined = f"{meta}: {info}" if info else meta
+            error_map[current_file].append(normalize_issue_message(combined))
+
+    return error_map
+
+
+def build_comment_body(final_report: str) -> str:
+    error_map = parse_report_by_file(final_report)
+    comment_body = "**Common issues**\n\n"
+    if not error_map:
+        comment_body += f"{final_report}\n\n{BOT_SIGNATURE}"
+        return comment_body
+
+    for filename, issues in sorted(error_map.items()):
+        comment_body += f"{filename}\n"
+        for issue in issues:
+            comment_body += f"{issue}\n"
+        comment_body += "\n"
+    comment_body += f"{BOT_SIGNATURE}"
+    return comment_body
+
+
+def publish_to_github(final_report: str) -> int:
+    if not (REPO_NAME and GITHUB_TOKEN and PR_NUMBER is not None):
+        print("Missing GitHub environment variables for GitHub mode.")
+        return 2
+
+    from github import Github, Auth
+
+    auth = Auth.Token(GITHUB_TOKEN)
+    g = Github(auth=auth)
+    repo = g.get_repo(REPO_NAME)
     pr = repo.get_pull(PR_NUMBER)
-
-    final_report = "\n".join(all_errors).strip()
 
     bot_comment = find_bot_comment(pr)
 
-    # 4. Post or Update Comment
     if final_report:
-        # Group errors by file for cleaner output
-        error_map = {}
-        for line in final_report.splitlines():
-            if ':' not in line:
-                continue
-            filename, error_msg = line.split(':', 1)
-            if filename not in error_map:
-                error_map[filename] = []
-            error_map[filename].append(error_msg.strip())
-
-        # Build Markdown comment
-        comment_body = "### :warning: Linter found issues\n\n"
-        for filename, issues in sorted(error_map.items()):
-            comment_body += f"- **`{filename}`**\n"
-            for issue in issues:
-                comment_body += f"  - `{issue}`\n"
-        comment_body += f"\n{BOT_SIGNATURE}"
+        comment_body = build_comment_body(final_report)
 
         if bot_comment:
             print("Updating existing comment.")
@@ -124,17 +300,64 @@ if __name__ == "__main__":
             print("Posting new comment.")
             pr.create_issue_comment(comment_body)
 
-        # Ensure "needs review" label is removed if errors are found
+        # Ensure "needs review" label is removed if errors are found.
         if NEEDS_REVIEW_LABEL in [label.name for label in pr.get_labels()]:
             pr.remove_from_labels(NEEDS_REVIEW_LABEL)
-
     else:
-        # No errors found
         print("All checks passed.")
         if bot_comment:
             print("Deleting old comment.")
             bot_comment.edit("All checks passed.")
 
-        # Add "needs review" label if it's not there
+        # Add "needs review" label if it's not there.
         if NEEDS_REVIEW_LABEL not in [label.name for label in pr.get_labels()]:
             pr.add_to_labels(NEEDS_REVIEW_LABEL)
+
+    return 0
+
+
+def run_cli_output(final_report: str) -> int:
+    if final_report:
+        print(build_comment_body(final_report))
+        return 1
+
+    print("All checks passed.")
+    return 0
+
+
+# --- Orchestration ---
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run icon lint checks and publish to GitHub or print as CLI output."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["auto", "github", "cli"],
+        default="auto",
+        help="Output mode. 'auto' uses GitHub mode if required env vars are present.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help="Base branch to diff against (default: GITHUB_BASE_REF, origin/HEAD, or main).",
+    )
+    parser.add_argument(
+        "--repo-dir",
+        default=None,
+        help="Repository root directory to run against (default: script-based auto-detection).",
+    )
+    args = parser.parse_args()
+
+    configure_repo_paths(args.repo_dir)
+    base_ref = resolve_base_ref(args.base_ref)
+    final_report = collect_final_report(base_ref)
+
+    mode = args.mode
+    if mode == "auto":
+        mode = "github" if (REPO_NAME and GITHUB_TOKEN and PR_NUMBER is not None) else "cli"
+
+    if mode == "github":
+        sys.exit(publish_to_github(final_report))
+
+    sys.exit(run_cli_output(final_report))
+

--- a/.github/scripts/bot_orchestrator.py
+++ b/.github/scripts/bot_orchestrator.py
@@ -211,7 +211,7 @@ def collect_final_report(base_ref: str) -> str:
     name_checker_args = [
         "--appfilter", str(APPFILTER_PATH),
         "--drawables-dir", str(DRAWABLES_DIR),
-        "--format", "compact",
+        "--format", "text",
     ]
     if changed_drawables:
         drawable_flag_args = name_checker_args + ["--changed-drawables"]
@@ -229,41 +229,73 @@ def collect_final_report(base_ref: str) -> str:
     return "\n".join(all_errors).strip()
 
 
-def parse_report_by_file(final_report: str) -> dict[str, list[str]]:
-    error_map: dict[str, list[str]] = {}
+def parse_report_by_file(final_report: str) -> dict[str, dict[str, object]]:
+    error_map: dict[str, dict[str, object]] = {}
     current_file: str | None = None
+    code_pattern = re.compile(r"^[A-Za-z]+\d+$")
+
+    def ensure_bucket(filename: str) -> dict[str, object]:
+        if filename not in error_map:
+            error_map[filename] = {
+                "lint_icons_codes": set(),
+                "name_checker_messages": [],
+                "other_messages": [],
+            }
+        return error_map[filename]
+
+    def add_unique_message(bucket: dict[str, object], key: str, message: str) -> None:
+        if not message:
+            return
+        values = bucket.get(key)
+        if isinstance(values, list) and message not in values:
+            values.append(message)
 
     for raw_line in final_report.splitlines():
-        print(raw_line)
         line = raw_line.strip()
         if not line:
             continue
 
-        # Only first two ':' are structural: meta : info[:rest...]
-        parts = [p.strip() for p in line.split(":", 2)]
+        file_parts = [p.strip() for p in line.split(":", 1)]
+        if len(file_parts) == 2 and file_parts[0].lower().endswith(".svg"):
+            current_file = file_parts[0]
+            bucket = ensure_bucket(current_file)
+            payload = file_parts[1].strip()
+            if not payload:
+                continue
 
-        # No separator -> continuation
-        if len(parts) == 1:
-            if current_file is not None:
-                error_map[current_file].append(normalize_issue_message(parts[0]))
+            # lint-icons compact format: "icon.svg: C01, C05"
+            payload_tokens = [token.strip() for token in payload.split(",") if token.strip()]
+            if payload_tokens and all(code_pattern.fullmatch(token) for token in payload_tokens):
+                cast_codes = bucket["lint_icons_codes"]
+                if isinstance(cast_codes, set):
+                    for token in payload_tokens:
+                        normalized = normalize_issue_message(token)
+                        if normalized.isdigit():
+                            cast_codes.add(normalized)
+                continue
+
+            # name-checker text format: "icon.svg: NR03: Rename: ..."
+            finding_parts = [p.strip() for p in payload.split(":", 1)]
+            if len(finding_parts) == 2 and code_pattern.fullmatch(finding_parts[0]):
+                add_unique_message(bucket, "name_checker_messages", finding_parts[1])
+                continue
+
+            normalized = normalize_issue_message(payload)
+            if normalized.isdigit():
+                cast_codes = bucket["lint_icons_codes"]
+                if isinstance(cast_codes, set):
+                    cast_codes.add(normalized)
+            else:
+                add_unique_message(bucket, "other_messages", payload)
             continue
 
-        meta = parts[0]
-        info = parts[1]
-        if len(parts) == 3:
-            # Keep all remaining ':' inside message body
-            info = f"{info}: {parts[2]}".strip()
-
-        # Start a new file block when meta is an svg path
-        if meta.lower().endswith(".svg"):
-            current_file = meta
-            error_map.setdefault(current_file, [])
-            if info:
-                error_map[current_file].append(normalize_issue_message(info))
-        elif current_file is not None:
-            # Non-file meta lines are continuation details for current file
-            combined = f"{meta}: {info}" if info else meta
-            error_map[current_file].append(normalize_issue_message(combined))
+        if current_file is not None:
+            bucket = ensure_bucket(current_file)
+            continuation_parts = [p.strip() for p in line.split(":", 1)]
+            if len(continuation_parts) == 2 and code_pattern.fullmatch(continuation_parts[0]):
+                add_unique_message(bucket, "name_checker_messages", continuation_parts[1])
+            else:
+                add_unique_message(bucket, "other_messages", line)
 
     return error_map
 
@@ -271,15 +303,33 @@ def parse_report_by_file(final_report: str) -> dict[str, list[str]]:
 def build_comment_body(final_report: str) -> str:
     error_map = parse_report_by_file(final_report)
     comment_body = "**Common issues**\n\n"
+
     if not error_map:
         comment_body += f"{final_report}\n\n{BOT_SIGNATURE}"
         return comment_body
 
-    for filename, issues in sorted(error_map.items()):
+    for filename in sorted(error_map.keys()):
+        bucket = error_map[filename]
+        codes = bucket.get("lint_icons_codes", set())
+        name_messages = bucket.get("name_checker_messages", [])
+        other_messages = bucket.get("other_messages", [])
+
         comment_body += f"{filename}\n"
-        for issue in issues:
-            comment_body += f"{issue}\n"
+
+        if isinstance(codes, set) and codes:
+            sorted_codes = sorted(codes, key=lambda x: int(x))
+            comment_body += f"{', '.join(sorted_codes)}\n"
+
+        if isinstance(name_messages, list):
+            for message in name_messages:
+                comment_body += f"{message}\n"
+
+        if isinstance(other_messages, list):
+            for message in other_messages:
+                comment_body += f"{message}\n"
+
         comment_body += "\n"
+
     comment_body += f"{BOT_SIGNATURE}"
     return comment_body
 

--- a/.github/scripts/bot_orchestrator.py
+++ b/.github/scripts/bot_orchestrator.py
@@ -365,8 +365,7 @@ def publish_to_github(final_report: str) -> int:
         print("All checks passed.")
         if bot_comment:
             print("Deleting old comment.")
-            bot_comment.edit("All checks passed.")
-
+            bot_comment.edit(f"All checks passed.\n\n{BOT_SIGNATURE}")
         # Add "needs review" label if it's not there.
         if NEEDS_REVIEW_LABEL not in [label.name for label in pr.get_labels()]:
             pr.add_to_labels(NEEDS_REVIEW_LABEL)

--- a/.github/scripts/bot_orchestrator.py
+++ b/.github/scripts/bot_orchestrator.py
@@ -13,8 +13,8 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 REPO_ROOT = Path(__file__).parent.parent.parent
 APPFILTER_PATH = REPO_ROOT / "app/assets/appfilter.xml"
 DRAWABLES_DIR = REPO_ROOT / "svgs/"
-SVG_LINTER_PATH = REPO_ROOT / "lint_icons.py"  # UPDATE THIS
-NAME_CHECKER_PATH = REPO_ROOT / ".github/scripts/name_checker.py"  # UPDATE THIS
+SVG_LINTER_PATH = REPO_ROOT / "lint-icons.py"
+NAME_CHECKER_PATH = REPO_ROOT / ".github/scripts/name_checker.py"
 
 BOT_SIGNATURE = "--- \n*Linter Bot Report*"
 NEEDS_REVIEW_LABEL = "needs review"
@@ -25,10 +25,18 @@ NEEDS_REVIEW_LABEL = "needs review"
 def get_changed_svgs() -> list[str]:
     """Finds SVG files changed in this PR compared to the target branch."""
     target_branch = os.getenv("GITHUB_BASE_REF")
+    drawables_pathspec = DRAWABLES_DIR.relative_to(REPO_ROOT).as_posix()
     cmd = ["git", "diff", "--name-only",
-           f"origin/{target_branch}", "HEAD", "--", str(DRAWABLES_DIR)]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    return [line for line in result.stdout.splitlines() if line.endswith('.svg')]
+           f"origin/{target_branch}", "HEAD", "--", drawables_pathspec]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        return []
 
 
 def run_linter(script_path: Path, args: list[str]) -> str:
@@ -39,6 +47,14 @@ def run_linter(script_path: Path, args: list[str]) -> str:
             # check=False to capture output even on failure
             capture_output=True, text=True, check=False
         )
+
+        if result.returncode != 0:
+            error_output = stderr or stdout or "No output captured."
+            return (
+                f"CRITICAL_ERROR: {script_path.name} exited with code "
+                f"{result.returncode}: {error_output}"
+            )
+
         return result.stdout.strip()
     except Exception as e:
         return f"CRITICAL_ERROR: Failed to run {script_path.name}: {e}"

--- a/.github/scripts/bot_orchestrator.py
+++ b/.github/scripts/bot_orchestrator.py
@@ -1,0 +1,124 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from github import Github
+
+# --- Configuration ---
+REPO_NAME = os.getenv("GITHUB_REPOSITORY")
+PR_NUMBER = int(os.getenv("PR_NUMBER"))  # type: ignore
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+# Assuming a standard project structure
+REPO_ROOT = Path(__file__).parent.parent.parent
+APPFILTER_PATH = REPO_ROOT / "app/assets/appfilter.xml"
+DRAWABLES_DIR = REPO_ROOT / "svgs/"
+SVG_LINTER_PATH = REPO_ROOT / "lint_icons.py"  # UPDATE THIS
+NAME_CHECKER_PATH = REPO_ROOT / ".github/scripts/name_checker.py"  # UPDATE THIS
+
+BOT_SIGNATURE = "--- \n*Linter Bot Report*"
+NEEDS_REVIEW_LABEL = "needs review"
+
+# --- Main Logic ---
+
+
+def get_changed_svgs() -> list[str]:
+    """Finds SVG files changed in this PR compared to the target branch."""
+    target_branch = os.getenv("GITHUB_BASE_REF")
+    cmd = ["git", "diff", "--name-only",
+           f"origin/{target_branch}", "HEAD", "--", str(DRAWABLES_DIR)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return [line for line in result.stdout.splitlines() if line.endswith('.svg')]
+
+
+def run_linter(script_path: Path, args: list[str]) -> str:
+    """Runs a linter script and returns its stdout."""
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script_path)] + args,
+            # check=False to capture output even on failure
+            capture_output=True, text=True, check=False
+        )
+        return result.stdout.strip()
+    except Exception as e:
+        return f"CRITICAL_ERROR: Failed to run {script_path.name}: {e}"
+
+
+def find_bot_comment(pr):
+    """Finds a previous comment made by this bot."""
+    for comment in pr.get_issue_comments():
+        if BOT_SIGNATURE in comment.body:
+            return comment
+    return None
+
+
+# --- Orchestration ---
+if __name__ == "__main__":
+    changed_svg_files = get_changed_svgs()
+    all_errors = []
+
+    # 1. Run SVG Linter on changed files only
+    if changed_svg_files:
+        print(f"Checking {len(changed_svg_files)} changed SVG files...")
+        svg_linter_args = ["--format", "compact"] + changed_svg_files
+        svg_errors = run_linter(SVG_LINTER_PATH, svg_linter_args)
+        if svg_errors:
+            all_errors.append(svg_errors)
+
+    # 2. Run Name Checker
+    print("Checking appfilter.xml consistency...")
+    name_errors = run_linter(
+        NAME_CHECKER_PATH, [str(APPFILTER_PATH), str(DRAWABLES_DIR)])
+    if name_errors:
+        all_errors.append(name_errors)
+
+    # 3. Connect to GitHub
+    g = Github(GITHUB_TOKEN)
+    repo = g.get_repo(REPO_NAME)  # type: ignore
+    pr = repo.get_pull(PR_NUMBER)
+
+    final_report = "\n".join(all_errors).strip()
+
+    bot_comment = find_bot_comment(pr)
+
+    # 4. Post or Update Comment
+    if final_report:
+        # Group errors by file for cleaner output
+        error_map = {}
+        for line in final_report.splitlines():
+            if ':' not in line:
+                continue
+            filename, error_msg = line.split(':', 1)
+            if filename not in error_map:
+                error_map[filename] = []
+            error_map[filename].append(error_msg.strip())
+
+        # Build Markdown comment
+        comment_body = "### :warning: Linter found issues\n\n"
+        for filename, issues in sorted(error_map.items()):
+            comment_body += f"- **`{filename}`**\n"
+            for issue in issues:
+                comment_body += f"  - `{issue}`\n"
+        comment_body += f"\n{BOT_SIGNATURE}"
+
+        if bot_comment:
+            print("Updating existing comment.")
+            bot_comment.edit(comment_body)
+        else:
+            print("Posting new comment.")
+            pr.create_issue_comment(comment_body)
+
+        # Ensure "needs review" label is removed if errors are found
+        if NEEDS_REVIEW_LABEL in [label.name for label in pr.get_labels()]:
+            pr.remove_from_labels(NEEDS_REVIEW_LABEL)
+
+    else:
+        # No errors found
+        print("All checks passed.")
+        if bot_comment:
+            print("Deleting old comment.")
+            bot_comment.edit("All checks passed.")
+
+        # Add "needs review" label if it's not there
+        if NEEDS_REVIEW_LABEL not in [label.name for label in pr.get_labels()]:
+            pr.add_to_labels(NEEDS_REVIEW_LABEL)

--- a/.github/scripts/bot_orchestrator.py
+++ b/.github/scripts/bot_orchestrator.py
@@ -82,8 +82,11 @@ def get_changed_drawables(base_ref: str) -> list[str]:
                 drawables.append(match.group(1))
     return drawables
 
-def run_linter(script_path: Path, args: list[str]) -> str:
+def run_linter(script_path: Path, args: list[str], accepted_exit_codes: set[int] | None = None) -> str:
     """Runs a linter script and returns its stdout."""
+    if accepted_exit_codes is None:
+        accepted_exit_codes = {0}
+
     try:
         child_env = os.environ.copy()
         child_env["PYTHONUTF8"] = "1"
@@ -100,7 +103,7 @@ def run_linter(script_path: Path, args: list[str]) -> str:
             env=child_env,
         )
 
-        if result.returncode != 0:
+        if result.returncode not in accepted_exit_codes:
             error_output = result.stderr or result.stdout or "No output captured."
             return (
                 f"CRITICAL_ERROR: {script_path.name} exited with code "
@@ -205,13 +208,18 @@ def collect_final_report(base_ref: str) -> str:
     # 2. Run Name Checker (only on changed drawables)
     print("Checking appfilter.xml consistency...")
     changed_drawables = get_changed_drawables(base_ref)
-    name_checker_args = [str(APPFILTER_PATH), str(DRAWABLES_DIR)]
+    name_checker_args = [
+        "--appfilter", str(APPFILTER_PATH),
+        "--drawables-dir", str(DRAWABLES_DIR),
+        "--format", "compact",
+    ]
     if changed_drawables:
         drawable_flag_args = name_checker_args + ["--changed-drawables"]
         for drawable_chunk in chunk_for_command(changed_drawables, drawable_flag_args):
             name_errors = run_linter(
                 NAME_CHECKER_PATH,
                 drawable_flag_args + drawable_chunk,
+                accepted_exit_codes={0, 1},
             )
             if name_errors:
                 all_errors.append(name_errors)

--- a/.github/scripts/name_checker.py
+++ b/.github/scripts/name_checker.py
@@ -9,8 +9,13 @@ from unidecode import unidecode
 
 def slugify_app_name(app_name: str) -> str:
     """Converts an app name from appfilter.xml to a valid drawable filename."""
-    # 1. Handle dual names: "Beijing Card ~~ 北京一卡通" -> "beijing_card"
-    primary_name = app_name.split('~~')[0].strip()
+    primary_name = ""
+
+    try:
+        # 1. Handle dual names: "北京一卡通 ~~ Beijing Card" -> "beijing_card"
+        primary_name = app_name.split('~~')[1].strip()
+    except IndexError:
+        primary_name = app_name
 
     # 2. Handle HTML entities: "A&amp;W" -> "A&W"
     # A simple replacement is safe enough for this specific use case.
@@ -21,9 +26,12 @@ def slugify_app_name(app_name: str) -> str:
 
     # 4. Standard slugification
     slug = slug.lower()
+    slug = slug.replace("'", "")  # Remove apostrophes completely (e.g., Subway's -> subways)
+    slug = slug.replace("&", "and")  # Replace & with 'and' for better readability
+    slug = slug.replace("+", "_plus_")  # Handle plus signs explicitly
+
     slug = re.sub(r'[^a-z0-9]+', '_', slug)  # Replace non-alphanumeric with _
     slug = slug.strip('_')
-
     # 5. Handle leading digits
     if slug and slug[0].isdigit():
         slug = f"_{slug}"

--- a/.github/scripts/name_checker.py
+++ b/.github/scripts/name_checker.py
@@ -1,0 +1,96 @@
+import sys
+import re
+import argparse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, Set
+from unidecode import unidecode
+
+
+def slugify_app_name(app_name: str) -> str:
+    """Converts an app name from appfilter.xml to a valid drawable filename."""
+    # 1. Handle dual names: "Beijing Card ~~ 北京一卡通" -> "beijing_card"
+    primary_name = app_name.split('~~')[0].strip()
+
+    # 2. Handle HTML entities: "A&amp;W" -> "A&W"
+    # A simple replacement is safe enough for this specific use case.
+    primary_name = primary_name.replace('&amp;', '&')
+
+    # 3. Transliterate to ASCII: "Habitação Caixa" -> "Habitacao Caixa"
+    slug = unidecode(primary_name)
+
+    # 4. Standard slugification
+    slug = slug.lower()
+    slug = re.sub(r'[^a-z0-9]+', '_', slug)  # Replace non-alphanumeric with _
+    slug = slug.strip('_')
+
+    # 5. Handle leading digits
+    if slug and slug[0].isdigit():
+        slug = f"_{slug}"
+
+    return slug
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Appfilter naming consistency filter")
+    parser.add_argument("appfilter", help="Path to appfilter.xml")
+    parser.add_argument(
+        "drawables_dir", help="Path to the directory containing SVGs")
+    args = parser.parse_args()
+
+    appfilter_path = Path(args.appfilter)
+    drawables_path = Path(args.drawables_dir)
+
+    # 1. Parse XML and get all declared drawables
+    try:
+        tree = ET.parse(appfilter_path)
+        root = tree.getroot()
+        xml_items: Dict[str, str] = {
+            item.get('drawable'): item.get('name')
+            for item in root.findall('.//item') if item.get('drawable')
+        }  # type: ignore
+    except Exception as e:
+        print(f"appfilter.xml: XML_PARSE_ERROR ({e})")
+        sys.exit(1)
+
+    # 2. Get all SVG files from the directory
+    disk_svgs: Set[str] = {p.stem for p in drawables_path.glob("*.svg")}
+
+    xml_drawables = set(xml_items.keys())
+
+    errors_found = False
+
+    # 3. Check for mismatches
+    orphaned_svgs = disk_svgs - xml_drawables
+    missing_svgs = xml_drawables - disk_svgs
+
+    for orphan in sorted(orphaned_svgs):
+        print(f"{orphan}.svg: ORPHAN_FILE (Not declared in appfilter.xml)")
+        errors_found = True
+
+    for missing in sorted(missing_svgs):
+        print(
+            f"{missing}.svg: MISSING_FILE (Declared in appfilter.xml but file not found)")
+        errors_found = True
+
+    # 4. Check for naming convention violations
+    for drawable, name in xml_items.items():
+        if drawable not in disk_svgs:
+            continue  # Skip if file is missing
+
+        expected_drawable = slugify_app_name(name)
+        if drawable != expected_drawable:
+            print(
+                f"{drawable}.svg: NAME_MISMATCH (Expected '{expected_drawable}' based on app name '{name}')")
+            errors_found = True
+
+    if errors_found:
+        sys.exit(1)
+    else:
+        print("Name consistency check passed.", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/name_checker.py
+++ b/.github/scripts/name_checker.py
@@ -45,10 +45,14 @@ def main():
     parser.add_argument("appfilter", help="Path to appfilter.xml")
     parser.add_argument(
         "drawables_dir", help="Path to the directory containing SVGs")
+    parser.add_argument(
+        "--changed-drawables", nargs="*", dest="changed_drawables",
+        help="If provided, only check these specific drawable names")
     args = parser.parse_args()
 
     appfilter_path = Path(args.appfilter)
     drawables_path = Path(args.drawables_dir)
+    changed_set: set[str] | None = set(args.changed_drawables)
 
     # 1. Parse XML and get all declared drawables
     try:
@@ -69,28 +73,36 @@ def main():
 
     errors_found = False
 
-    # 3. Check for mismatches
-    orphaned_svgs = disk_svgs - xml_drawables
-    missing_svgs = xml_drawables - disk_svgs
+    # 3. Check for mismatches — scoped to changed drawables if provided
+    if changed_set is not None:
+        xml_drawables_to_check = xml_drawables & changed_set
+        disk_svgs_to_check = disk_svgs & changed_set
+    else:
+        xml_drawables_to_check = xml_drawables
+        disk_svgs_to_check = disk_svgs
+
+    orphaned_svgs = disk_svgs_to_check - xml_drawables
+    missing_svgs = xml_drawables_to_check - disk_svgs
 
     for orphan in sorted(orphaned_svgs):
         print(f"{orphan}.svg: ORPHAN_FILE (Not declared in appfilter.xml)")
         errors_found = True
 
     for missing in sorted(missing_svgs):
-        print(
-            f"{missing}.svg: MISSING_FILE (Declared in appfilter.xml but file not found)")
+        print(f"{missing}.svg: MISSING_FILE (Declared in appfilter.xml but file not found)")
         errors_found = True
 
-    # 4. Check for naming convention violations
-    for drawable, name in xml_items.items():
+    # 4. Check naming convention — only for changed items
+    items_to_check = (
+        {d: n for d, n in xml_items.items() if d in changed_set}
+        if changed_set is not None else xml_items
+    )
+    for drawable, name in items_to_check.items():
         if drawable not in disk_svgs:
-            continue  # Skip if file is missing
-
+            continue
         expected_drawable = slugify_app_name(name)
         if drawable != expected_drawable:
-            print(
-                f"{drawable}.svg: NAME_MISMATCH (Expected '{expected_drawable}' based on app name '{name}')")
+            print(f"{drawable}.svg: NAME_MISMATCH (Expected '{expected_drawable}' based on app name '{name}')")
             errors_found = True
 
     if errors_found:

--- a/.github/scripts/name_checker.py
+++ b/.github/scripts/name_checker.py
@@ -1,116 +1,316 @@
-import sys
-import re
 import argparse
+import json
+import re
+import sys
 import xml.etree.ElementTree as ET
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import Dict, Set
+from typing import Any, Callable, Dict, List, Optional, TextIO, Type
 from unidecode import unidecode
 
 
-def slugify_app_name(app_name: str) -> str:
-    """Converts an app name from appfilter.xml to a valid drawable filename."""
-    primary_name = ""
+class Status(Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
 
+
+@dataclass(frozen=True)
+class Finding:
+    rule_id: str
+    category: str
+    status: Status
+    target: str
+    message: str
+
+
+@dataclass(frozen=True)
+class RuleSummary:
+    rule_id: str
+    category: str
+    status: Status
+    message: str
+
+
+@dataclass
+class CheckContext:
+    xml_items: Dict[str, str]
+    disk_svgs: set[str]
+    changed_set: Optional[set[str]]
+
+    @property
+    def xml_drawables(self) -> set[str]:
+        return set(self.xml_items.keys())
+
+    @property
+    def xml_drawables_to_check(self) -> set[str]:
+        if self.changed_set is None:
+            return self.xml_drawables
+        return self.xml_drawables & self.changed_set
+
+    @property
+    def disk_svgs_to_check(self) -> set[str]:
+        if self.changed_set is None:
+            return self.disk_svgs
+        return self.disk_svgs & self.changed_set
+
+
+@dataclass
+class RunReport:
+    findings: List[Finding] = field(default_factory=list)
+    summaries: List[RuleSummary] = field(default_factory=list)
+    fatal_error: Optional[str] = None
+
+    @property
+    def has_failures(self) -> bool:
+        return any(f.status == Status.FAIL for f in self.findings)
+
+
+RuleFunc = Callable[[CheckContext, str, str], List[Finding]]
+RULES_REGISTRY: List[tuple[RuleFunc, str, str]] = []
+
+
+def register_rule(rule_id: str, category: str = "Naming") -> Callable[[RuleFunc], RuleFunc]:
+    def decorator(func: RuleFunc) -> RuleFunc:
+        RULES_REGISTRY.append((func, rule_id, category))
+        return func
+    return decorator
+
+
+def slugify_app_name(app_name: str) -> str:
+    """Convert an app name from appfilter.xml into a drawable filename slug."""
     try:
-        # 1. Handle dual names: "北京一卡通 ~~ Beijing Card" -> "beijing_card"
-        primary_name = app_name.split('~~')[1].strip()
+        primary_name = app_name.split("~~", 1)[1].strip()
     except IndexError:
         primary_name = app_name
 
-    # 2. Handle HTML entities: "A&amp;W" -> "A&W"
-    # A simple replacement is safe enough for this specific use case.
-    primary_name = primary_name.replace('&amp;', '&')
+    primary_name = primary_name.replace("&amp;", "&")
 
-    # 3. Transliterate to ASCII: "Habitação Caixa" -> "Habitacao Caixa"
     slug = unidecode(primary_name)
-
-    # 4. Standard slugification
     slug = slug.lower()
-    slug = slug.replace("'", "")  # Remove apostrophes completely (e.g., Subway's -> subways)
-    slug = slug.replace("&", "and")  # Replace & with 'and' for better readability
-    slug = slug.replace("+", "_plus_")  # Handle plus signs explicitly
+    slug = slug.replace("'", "")
+    slug = slug.replace("&", "and")
+    slug = slug.replace("+", "_plus_")
+    slug = re.sub(r"[^a-z0-9]+", "_", slug)
+    slug = slug.strip("_")
 
-    slug = re.sub(r'[^a-z0-9]+', '_', slug)  # Replace non-alphanumeric with _
-    slug = slug.strip('_')
-    # 5. Handle leading digits
     if slug and slug[0].isdigit():
         slug = f"_{slug}"
 
     return slug
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Appfilter naming consistency filter")
-    parser.add_argument("appfilter", help="Path to appfilter.xml")
-    parser.add_argument(
-        "drawables_dir", help="Path to the directory containing SVGs")
-    parser.add_argument(
-        "--changed-drawables", nargs="*", dest="changed_drawables",
-        help="If provided, only check these specific drawable names")
-    args = parser.parse_args()
+@register_rule("NR01", category="Naming")
+def rule_orphan_file(ctx: CheckContext, rule_id: str, category: str) -> List[Finding]:
+    orphaned_svgs = sorted(ctx.disk_svgs_to_check - ctx.xml_drawables)
+    return [
+        Finding(
+            rule_id=rule_id,
+            category=category,
+            status=Status.FAIL,
+            target=f"{drawable}.svg",
+            message="Not declared in `appfilter.xml`",
+        )
+        for drawable in orphaned_svgs
+    ]
 
-    appfilter_path = Path(args.appfilter)
-    drawables_path = Path(args.drawables_dir)
-    changed_set: set[str] | None = set(args.changed_drawables)
 
-    # 1. Parse XML and get all declared drawables
+@register_rule("NR02", category="Naming")
+def rule_missing_file(ctx: CheckContext, rule_id: str, category: str) -> List[Finding]:
+    missing_svgs = sorted(ctx.xml_drawables_to_check - ctx.disk_svgs)
+    return [
+        Finding(
+            rule_id=rule_id,
+            category=category,
+            status=Status.FAIL,
+            target=f"{drawable}.svg",
+            message="Declared in `appfilter.xml` but file not found",
+        )
+        for drawable in missing_svgs
+    ]
+
+
+@register_rule("NR03", category="Naming")
+def rule_naming_mismatch(ctx: CheckContext, rule_id: str, category: str) -> List[Finding]:
+    findings: List[Finding] = []
+    for drawable in sorted(ctx.xml_drawables_to_check):
+        if drawable not in ctx.disk_svgs:
+            continue
+        app_name = ctx.xml_items.get(drawable, "")
+        expected = slugify_app_name(app_name)
+        if drawable != expected:
+            findings.append(
+                Finding(
+                    rule_id=rule_id,
+                    category=category,
+                    status=Status.FAIL,
+                    target=f"{drawable}.svg",
+                    message=f"Rename: `{expected}` (based on app name `{app_name}`)",
+                )
+            )
+    return findings
+
+
+class OutputHandler(ABC):
+    def __init__(self, dest: TextIO, verbose: bool):
+        self.dest = dest
+        self.verbose = verbose
+
+    @abstractmethod
+    def emit(self, report: RunReport) -> None:
+        raise NotImplementedError
+
+
+class ConsoleOutput(OutputHandler):
+    def emit(self, report: RunReport) -> None:
+        if report.fatal_error:
+            self.dest.write(f"FATAL_ERROR: {report.fatal_error}\n")
+            return
+
+        if self.verbose:
+            for summary in sorted(report.summaries, key=lambda s: s.rule_id):
+                self.dest.write(f"[{summary.status.value}] [{summary.category}: {summary.rule_id}] {summary.message}\n")
+
+        actionable = sorted(report.findings, key=lambda f: (f.target, f.rule_id, f.message))
+        for finding in actionable:
+            self.dest.write(f"{finding.target}: {finding.rule_id}: {finding.message}\n")
+
+
+class JsonOutput(OutputHandler):
+    def emit(self, report: RunReport) -> None:
+        data: Dict[str, Any] = {
+            "fatal_error": report.fatal_error,
+            "findings": [asdict(f) for f in sorted(report.findings, key=lambda i: (i.target, i.rule_id, i.message))],
+            "summary": [asdict(s) for s in sorted(report.summaries, key=lambda i: i.rule_id)] if self.verbose else [],
+        }
+        for entry in data["findings"]:
+            entry["status"] = entry["status"].value
+        for entry in data["summary"]:
+            entry["status"] = entry["status"].value
+        self.dest.write(json.dumps(data, indent=2))
+        self.dest.write("\n")
+
+
+class CompactOutput(OutputHandler):
+    def emit(self, report: RunReport) -> None:
+        if report.fatal_error:
+            self.dest.write(f"FATAL_ERROR: {report.fatal_error}\n")
+            return
+
+        grouped: Dict[str, set[str]] = {}
+        for finding in report.findings:
+            grouped.setdefault(finding.target, set()).add(finding.rule_id)
+
+        for target in sorted(grouped.keys()):
+            ids = ", ".join(sorted(grouped[target]))
+            self.dest.write(f"{target}: {ids}\n")
+
+
+OUTPUT_FACTORIES: Dict[str, Type[OutputHandler]] = {
+    "text": ConsoleOutput,
+    "json": JsonOutput,
+    "compact": CompactOutput,
+}
+
+
+def load_context(appfilter_path: Path, drawables_path: Path, changed_set: Optional[set[str]]) -> CheckContext:
+    if not appfilter_path.exists() or not appfilter_path.is_file():
+        raise ValueError(f"Invalid appfilter path: {appfilter_path}")
+    if not drawables_path.exists() or not drawables_path.is_dir():
+        raise ValueError(f"Invalid drawables directory: {drawables_path}")
+
     try:
         tree = ET.parse(appfilter_path)
-        root = tree.getroot()
-        xml_items: Dict[str, str] = {
-            item.get('drawable'): item.get('name')
-            for item in root.findall('.//item') if item.get('drawable')
-        }  # type: ignore
-    except Exception as e:
-        print(f"appfilter.xml: XML_PARSE_ERROR ({e})")
-        sys.exit(1)
+    except ET.ParseError as exc:
+        raise ValueError(f"XML_PARSE_ERROR ({exc})") from exc
 
-    # 2. Get all SVG files from the directory
-    disk_svgs: Set[str] = {p.stem for p in drawables_path.glob("*.svg")}
+    root = tree.getroot()
+    xml_items: Dict[str, str] = {
+        drawable: (item.get("name") or "")
+        for item in root.findall(".//item")
+        if (drawable := item.get("drawable"))
+    }
+    disk_svgs = {p.stem for p in drawables_path.glob("*.svg")}
+    return CheckContext(xml_items=xml_items, disk_svgs=disk_svgs, changed_set=changed_set)
 
-    xml_drawables = set(xml_items.keys())
 
-    errors_found = False
+def run_checks(ctx: CheckContext) -> RunReport:
+    report = RunReport()
 
-    # 3. Check for mismatches — scoped to changed drawables if provided
-    if changed_set is not None:
-        xml_drawables_to_check = xml_drawables & changed_set
-        disk_svgs_to_check = disk_svgs & changed_set
-    else:
-        xml_drawables_to_check = xml_drawables
-        disk_svgs_to_check = disk_svgs
+    for rule_func, rule_id, category in RULES_REGISTRY:
+        findings = rule_func(ctx, rule_id, category)
+        report.findings.extend(findings)
 
-    orphaned_svgs = disk_svgs_to_check - xml_drawables
-    missing_svgs = xml_drawables_to_check - disk_svgs
+        if findings:
+            report.summaries.append(
+                RuleSummary(
+                    rule_id=rule_id,
+                    category=category,
+                    status=Status.FAIL,
+                    message=f"{len(findings)} finding(s)",
+                )
+            )
+        else:
+            report.summaries.append(
+                RuleSummary(
+                    rule_id=rule_id,
+                    category=category,
+                    status=Status.PASS,
+                    message="No findings.",
+                )
+            )
 
-    for orphan in sorted(orphaned_svgs):
-        print(f"{orphan}.svg: ORPHAN_FILE (Not declared in appfilter.xml)")
-        errors_found = True
+    return report
 
-    for missing in sorted(missing_svgs):
-        print(f"{missing}.svg: MISSING_FILE (Declared in appfilter.xml but file not found)")
-        errors_found = True
 
-    # 4. Check naming convention — only for changed items
-    items_to_check = (
-        {d: n for d, n in xml_items.items() if d in changed_set}
-        if changed_set is not None else xml_items
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Drawable naming consistency linter")
+    parser.add_argument("--appfilter", required=True, help="Path to appfilter.xml")
+    parser.add_argument("--drawables-dir", required=True, help="Path to the directory containing SVGs")
+    parser.add_argument(
+        "--changed-drawables",
+        nargs="*",
+        default=None,
+        help="Only check these drawable names",
     )
-    for drawable, name in items_to_check.items():
-        if drawable not in disk_svgs:
-            continue
-        expected_drawable = slugify_app_name(name)
-        if drawable != expected_drawable:
-            print(f"{drawable}.svg: NAME_MISMATCH (Expected '{expected_drawable}' based on app name '{name}')")
-            errors_found = True
+    parser.add_argument("--format", choices=OUTPUT_FACTORIES.keys(), default="text", help="Output format")
+    parser.add_argument("--verbose", action="store_true", help="Show rule summaries in text/json output")
+    parser.add_argument("--output-file", help="Write output to file instead of stdout")
+    return parser.parse_args(argv)
 
-    if errors_found:
-        sys.exit(1)
-    else:
-        print("Name consistency check passed.", file=sys.stderr)
-        sys.exit(0)
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    changed_set: Optional[set[str]] = None
+    if args.changed_drawables is not None:
+        changed_set = set(args.changed_drawables)
+
+    try:
+        ctx = load_context(Path(args.appfilter), Path(args.drawables_dir), changed_set)
+    except ValueError as exc:
+        report = RunReport(fatal_error=str(exc))
+        handler = OUTPUT_FACTORIES[args.format](sys.stderr, verbose=args.verbose)
+        handler.emit(report)
+        return 2
+
+    report = run_checks(ctx)
+
+    out_stream: TextIO = sys.stdout
+    should_close = False
+    if args.output_file:
+        out_stream = open(args.output_file, "w", encoding="utf-8")
+        should_close = True
+
+    try:
+        handler = OUTPUT_FACTORIES[args.format](out_stream, verbose=args.verbose)
+        handler.emit(report)
+    finally:
+        if should_close:
+            out_stream.close()
+
+    return 1 if report.has_failures else 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,3 @@
+PyGithub==2.9.0
+svgelements==1.9.6
+unidecode==1.4.0

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -13,17 +13,17 @@ jobs:
       github.event.workflow_run.event == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
-
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Needed to compare with base branch
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -1,0 +1,33 @@
+name: Icon Linter
+
+on:
+  pull_request:
+    paths:
+      - 'svgs/*.svg'
+      - 'app/assets/appfilter.xml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Needed to compare with base branch
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Dependencies
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Run Linter and Post Comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: python .github/scripts/bot_orchestrator.py

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -1,13 +1,16 @@
 name: Icon Linter
 
 on:
-  pull_request:
-    paths:
-      - 'svgs/*.svg'
-      - 'app/assets/appfilter.xml'
+  # Lint icons after commenting checklist
+  workflow_run:
+    workflows: [ "Comment icon checklist" ]
+    types: [ completed ]
 
 jobs:
   lint:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -30,5 +33,5 @@ jobs:
       - name: Run Linter and Post Comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: python .github/scripts/bot_orchestrator.py

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -1,22 +1,56 @@
 name: Icon Linter
 
 on:
-  # Lint icons after commenting checklist
-  workflow_run:
-    workflows: [ "Comment icon checklist" ]
-    types: [ completed ]
+  pull_request:
+    branches: [ develop ]
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - svgs/*
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   lint:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request_target'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
     steps:
+      - name: Wait for checklist comment
+        id: wait_checklist
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const marker = "<!-- icon-checklist-posted -->";
+            const maxAttempts = 24;  // 24 * 5s = 2 minutes
+            const sleepMs = 5000;
+
+            const excludedUsers = process.env.EXCLUDED_USERS ?
+            process.env.EXCLUDED_USERS.split(',').map(user => user.trim()) : [];
+
+            const prAuthor = context.payload.pull_request.user.login;
+
+            if (excludedUsers.includes(prAuthor)) {
+              console.log(`Skipping wait for excluded user: ${prAuthor}`);
+              return;
+            }
+
+            let found = false;
+            for (let i = 0; i < maxAttempts; i++) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner, repo, issue_number, per_page: 100
+              });
+              found = comments.some(c => (c.body || "").includes(marker));
+              if (found) break;
+              await new Promise(r => setTimeout(r, sleepMs));
+            }
+
+            core.setOutput("checklist_found", String(found));
+            if (!found) core.warning("Checklist comment not found before timeout; continuing anyway.");
+
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # Only run on user for testing
+    if: github.event.pull_request.user.name == 'x9136'
     steps:
       - name: Wait for checklist comment
         id: wait_checklist
@@ -67,5 +69,5 @@ jobs:
       - name: Run Linter and Post Comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: python .github/scripts/bot_orchestrator.py

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -399,7 +399,9 @@ class ConsoleOutput(OutputHandler):
         # 1. Handle Catastrophic Errors
         if report.error:
             print(
-                f"{self.COLORS[Status.FAIL]}ERR{self.RESET} {report.file_path}: {report.error}")
+                f"{self.COLORS[Status.FAIL]}ERR{self.RESET} {report.file_path}: {report.error}",
+                file=self.dest,
+            )
             self.failed_count += 1
             return
 
@@ -417,18 +419,17 @@ class ConsoleOutput(OutputHandler):
             return
 
         # 3. Printing Logic
-        print(f"\n{report.file_path}")
-        for r in report.results:
+        print(f"\n{report.file_path}", file=self.dest)
             if not self.verbose and r.status == Status.PASS:
                 continue
 
-            color = self.COLORS.get(r.status, "")
-            timing = f" ({r.duration_ms:.2f}ms)" if self.verbose else ""
             print(
-                f"  [{color}{r.status.name:6}{self.RESET}] [{r.category}: {r.id}] {r.message}{timing}")
+                f"  [{color}{r.status.name:6}{self.RESET}] [{r.category}: {r.id}] {r.message}{timing}",
+                file=self.dest,
+            )
 
     def finish(self):
-        print(f"\nAnalysis complete. Failed files: {self.failed_count}")
+        print(f"\nAnalysis complete. Failed files: {self.failed_count}", file=self.dest)
 
 
 class JsonOutput(OutputHandler):
@@ -618,9 +619,9 @@ def main():
         sys.exit(0)
 
     out_stream = sys.stdout
+    out_stream = sys.stdout
     if args.output_file:
-        out_stream = open(args.output_file, 'w')
-
+        out_stream = open(args.output_file, 'w', encoding='utf-8')
     handler = OUTPUT_FACTORIES[args.format](
         out_stream, verbose=args.verbose)
 
@@ -628,10 +629,11 @@ def main():
 
     # imap_unordered is crucial for large file counts: it yields results as they finish.
     # We use a chunksize to reduce IPC overhead.
-    chunk_size = max(1, len(files) // (args.workers * 4))
+    workers = max(1, args.workers)
 
-    with ProcessPoolExecutor(max_workers=args.workers) as executor:
-        # Pass max_speed to every worker
+    chunk_size = max(1, len(files) // (workers * 4))
+
+    with ProcessPoolExecutor(max_workers=workers) as executor:
         # We use a partial or a list comprehension approach
         futures = executor.map(
             analyze_file,

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import time
 import logging
@@ -88,6 +89,14 @@ def register_check(speed: Speed, check_id: str):
         PLUGIN_REGISTRY[speed].append((func, check_id))
         return func
     return decorator
+
+# --- Helper Functions ---
+STYLE_PAIR_RE = re.compile(r'([\w-]+)\s*:\s*([^;]+)')
+
+def parse_style_attribute(style_str: Optional[str]) -> Dict[str, str]:
+    if not style_str:
+        return {}
+    return {k: v.strip() for k, v in STYLE_PAIR_RE.findall(style_str.lower())}
 
 # --- Rules Implementation ---
 
@@ -185,27 +194,60 @@ def rule_stroke_weight(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str
 
     return Status.PASS, f"Weights valid: {unique_weights}"
 
-
 @register_rule(rule_id="C07", category="Core")
 def rule_fill_color(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
-    """Core: Checks fill state (expects 'none' or no stroke)."""
+    """Core: Checks fill state (expects 'none', no stroke, or black color)."""
     if max_speed < Speed.MEDIUM:
         return Status.PASS, "Skipped fill check."
     if ctx.xml_tree is None:
         return Status.FAIL, "XML missing."
 
-    for el in ctx.xml_tree.iter():
-        tag = el.tag.split('}')[-1]
-        if tag in ['g', 'defs', 'style', 'svg']:
-            continue
-        if not el.get('stroke'):
-            continue  # Skip elements without strokes
+    allowed_colors = {'none', '#000000', '#000', 'black'}
 
-        fill = el.get('fill')
-        if fill is None and 'fill:none' not in el.get('style', ''):
-            return Status.REVIEW, f"<{tag}> has implicit fill (renders black)."
-        if fill not in ['none', None]:
-            return Status.FAIL, f"<{tag}> has explicit fill '{fill}'. Expected 'none'."
+    # The default SVG initial value for fill is technically 'black'
+    root = ctx.xml_tree.getroot() if hasattr(ctx.xml_tree, 'getroot') else ctx.xml_tree
+
+    root_style = parse_style_attribute(root.get('style'))
+    root_fill = root_style.get('fill') or root.get('fill', 'black').lower()
+
+    stack = [(root, root_fill)]
+
+    while stack:
+        el, inherited_fill = stack.pop()
+        tag = el.tag.split('}')[-1]
+
+        local_style = parse_style_attribute(el.get('style'))
+
+        local_stroke = local_style.get('stroke') or el.get('stroke')
+        if local_stroke:
+            local_stroke = local_stroke.lower()
+
+        local_fill = local_style.get('fill') or el.get('fill')
+        current_fill = local_fill.lower() if local_fill else inherited_fill
+
+        if tag in ['defs', 'style', 'clipPath', 'linearGradient', 'radialGradient']:
+            for child in el:
+                stack.append((child, current_fill))
+            continue
+
+        if tag in ['g', 'svg']:
+            for child in el:
+                stack.append((child, current_fill))
+            continue
+
+        if local_stroke:
+            if local_stroke not in allowed_colors:
+                return Status.FAIL, f"<{tag}> has non-black stroke '{local_stroke}'."
+
+            if not local_fill and current_fill == 'black':
+                return Status.REVIEW, f"<{tag}> has implicit fill (renders black because no parent sets 'none')."
+
+            if current_fill not in allowed_colors:
+                return Status.FAIL, f"<{tag}> resolves to unauthorized fill '{current_fill}'. Expected 'none' or black."
+
+        for child in el:
+            stack.append((child, current_fill))
+
     return Status.PASS, "Fill states are compliant."
 
 

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -1,19 +1,14 @@
-# WIP. Not pushed yet
-
 import sys
-import re
 import time
 import logging
 import argparse
 import json
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET # lint: ignore
 from pathlib import Path
-from enum import Enum, auto
+from enum import Enum, IntEnum
 from dataclasses import dataclass, field, asdict
 from concurrent.futures import ProcessPoolExecutor
 from abc import ABC, abstractmethod
-from enum import Enum, IntEnum
-from dataclasses import dataclass
 from typing import Callable, List, Dict, Optional, Any, Type
 
 try:
@@ -21,6 +16,8 @@ try:
     HAS_SVGELEMENTS = True
 except ImportError:
     HAS_SVGELEMENTS = False
+    SVG = None
+    SVGPath = None
 
 # --- Configuration ---
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
@@ -228,8 +225,8 @@ def rule_rounding_caps(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str
         tag = el.tag.split('}')[-1]
         if not el.get('stroke'):
             continue
-        if tag in ['rect', 'polygon']:
-            continue  # Closed shapes
+        if tag not in ['path', 'line', 'polyline']:
+            continue  # stroke-linecap is only relevant for open-ended shapes
 
         is_open = True
         if tag == 'path':
@@ -277,8 +274,10 @@ def rule_rounded_corners(ctx: CheckContext, max_speed: Speed) -> tuple[Status, s
     if ctx.xml_tree is None:
         return Status.FAIL, "XML missing."
 
-    ns = "{http://www.w3.org/2000/svg}"
-    for rect in ctx.xml_tree.iter(f'{ns}rect'):
+    for rect in ctx.xml_tree.iter():
+        tag = rect.tag.split('}')[-1]
+        if tag != 'rect':
+            continue
         try:
             rx = rect.get('rx')
             if rx is None:

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -560,7 +560,7 @@ def analyze_file(filepath_str: str, max_speed: Speed, exceptions: Dict[str, List
 
 def main():
     parser = argparse.ArgumentParser(description="SVG Linter & Optimizer")
-    parser.add_argument("input", help="SVG file or directory")
+    parser.add_argument("inputs", nargs="+", help="One or more SVG files and/or directories")
     parser.add_argument("--verbose", action="store_true",
                         help="Show all checks, including PASS")
     parser.add_argument("--format", choices=OUTPUT_FACTORIES.keys(),
@@ -594,11 +594,24 @@ def main():
     }
     max_speed = speed_map[args.speed]
 
-    input_path = Path(args.input)
-    if input_path.is_file():
-        files = [str(input_path)]
-    else:
-        files = [str(p) for p in input_path.rglob("*.svg")]
+    files: List[str] = []
+    seen: set[str] = set()
+    for raw_input in args.inputs:
+        input_path = Path(raw_input)
+        if input_path.is_file():
+            candidates = [input_path]
+        elif input_path.is_dir():
+            candidates = list(input_path.rglob("*.svg"))
+        else:
+            print(f"Input not found: {input_path}")
+            sys.exit(2)
+
+        for candidate in candidates:
+            candidate_str = str(candidate)
+            if candidate_str in seen:
+                continue
+            seen.add(candidate_str)
+            files.append(candidate_str)
 
     if not files:
         print("No SVG files found.")

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -355,6 +355,14 @@ def rule_placeholder_visual_alignment(ctx: CheckContext, max_speed: Speed) -> tu
     """Quality: [Placeholder] Checks for visual alignment instead of bounding-box alignment."""
     return Status.PASS, "Placeholder: Q04 Not Implemented (Requires SLOW/Geometry)."
 
+# --- Optimization Rules ---
+@register_rule(rule_id="O01", category="Optimization")
+def rule_svg_size(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Optimization: Flags SVGs larger than 3KB."""
+    if len(ctx.raw_content.encode('utf-8')) > 3 * 1024:
+        return Status.WARN, "SVG file size exceeds 3KB."
+    return Status.PASS, "SVG file size is within limits."
+
 # --- Output System (Modular) ---
 
 class OutputHandler(ABC):
@@ -383,6 +391,9 @@ class ConsoleOutput(OutputHandler):
         Status.EXEMPT: "\033[90m",  # Grey
     }
     RESET = "\033[0m"
+
+    def start(self):
+        pass
 
     def process(self, report: FileReport):
         # 1. Handle Catastrophic Errors

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -142,18 +142,37 @@ def rule_transparency(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]
         return Status.PASS, "Skipped transparency check."
     if ctx.xml_tree is None:
         return Status.FAIL, "XML missing, cannot check transparency."
-    forbidden = ['opacity', 'fill-opacity',
-                 'stroke-opacity', 'stop-opacity', 'filter', 'style']
+
+    forbidden_attrs = ['opacity', 'fill-opacity', 'stroke-opacity', 'stop-opacity', 'filter']
+    forbidden_style_props = set(forbidden_attrs)
+
     for el in ctx.xml_tree.iter():
-        for attr in forbidden:
+        tag = el.tag.split('}')[-1]
+
+        for attr in forbidden_attrs:
             val = el.get(attr)
-            if val:
-                if 'opacity' in attr and val in ['1', '1.0']:
+            if not val:
+                continue
+
+            normalized = val.strip().lower()
+            if 'opacity' in attr and normalized in {'1', '1.0'}:
+                continue
+
+            return Status.FAIL, f"Forbidden effect/transparency '{attr}' in <{tag}>"
+
+        style_val = el.get('style')
+        if style_val:
+            style_map = parse_style_attribute(style_val)
+            for prop, value in style_map.items():
+                if prop not in forbidden_style_props:
                     continue
-                if attr == 'style' and 'opacity:1' in val.replace(' ', ''):
+
+                normalized = value.strip().lower()
+                if 'opacity' in prop and normalized in {'1', '1.0'}:
                     continue
-                tag = el.tag.split('}')[-1]
-                return Status.FAIL, f"Forbidden effect/transparency '{attr}' in <{tag}>"
+
+                return Status.FAIL, f"Forbidden effect/transparency '{prop}' in style on <{tag}>"
+
     return Status.PASS, "No transparency found."
 
 

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -1,0 +1,587 @@
+# WIP. Not pushed yet
+
+import sys
+import re
+import time
+import logging
+import argparse
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from enum import Enum, auto
+from dataclasses import dataclass, field, asdict
+from concurrent.futures import ProcessPoolExecutor
+from abc import ABC, abstractmethod
+from enum import Enum, IntEnum
+from dataclasses import dataclass
+from typing import Callable, List, Dict, Optional, Any, Type
+
+try:
+    from svgelements import SVG, Path as SVGPath
+    HAS_SVGELEMENTS = True
+except ImportError:
+    HAS_SVGELEMENTS = False
+
+# --- Configuration ---
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class Status(Enum):
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    REVIEW = "REVIEW"
+    EXEMPT = "EXEMPT"
+
+
+class Speed(IntEnum):
+    FAST = 1     # Regex / String only
+    MEDIUM = 2   # XML Tree
+    SLOW = 3     # svgelements / Geometry
+
+
+@dataclass
+class CheckContext:
+    filename: str
+    raw_content: str
+    xml_tree: Optional[ET.Element] = None
+    svg_doc: Optional[Any] = None
+
+
+RULES_REGISTRY: List[tuple[Callable, str, str]] = []
+
+
+def register_rule(rule_id: str, category: str = "Core"):
+    """Decorator to register a pure function rule."""
+    def decorator(func):
+        RULES_REGISTRY.append((func, rule_id, category))
+        return func
+    return decorator
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    id: str
+    category: str
+    check_name: str
+    status: Status
+    message: str
+    duration_ms: float
+
+
+@dataclass
+class FileReport:
+    file_path: str
+    results: List[CheckResult] = field(default_factory=list)
+    error: Optional[str] = None
+
+    @property
+    def has_failure(self):
+        return any(r.status == Status.FAIL for r in self.results)
+
+
+# --- Plugin System ---
+PLUGIN_REGISTRY: Dict[Speed, List[tuple[Callable, str]]] = {
+    s: [] for s in Speed}
+
+
+def register_check(speed: Speed, check_id: str):
+    def decorator(func):
+        PLUGIN_REGISTRY[speed].append((func, check_id))
+        return func
+    return decorator
+
+# --- Rules Implementation ---
+
+# --- Core Rules ---
+
+@register_rule(rule_id="C01", category="Core")
+def rule_canvas_size(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: Ensures canvas is exactly 192x192."""
+    if max_speed < Speed.MEDIUM:
+        return Status.PASS, "Skipped canvas check."
+    if ctx.xml_tree is None:
+        return Status.FAIL, "XML missing, cannot verify canvas."
+    vb = ctx.xml_tree.get('viewBox', '').split()
+    w = ctx.xml_tree.get('width', '').strip('px ')
+    h = ctx.xml_tree.get('height', '').strip('px ')
+    if vb == ['0', '0', '192', '192'] or (w == '192' and h == '192'):
+        return Status.PASS, "Confirmed 192x192."
+    return Status.FAIL, f"Invalid canvas: viewBox={vb}, w={w}, h={h}"
+
+
+@register_rule(rule_id="C02", category="Core")
+def rule_placeholder_too_small(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: [Placeholder] Checks if icons are too small."""
+    return Status.PASS, "Placeholder: C02 Not Implemented (Requires Geometry)."
+
+
+@register_rule(rule_id="C03", category="Core")
+def rule_placeholder_outside_content(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: [Placeholder] Checks for elements outside the content area."""
+    return Status.PASS, "Placeholder: C03 Not Implemented (Requires Geometry)."
+
+
+@register_rule(rule_id="C04", category="Core")
+def rule_placeholder_square_size(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: [Placeholder] Checks size of square icons."""
+    return Status.PASS, "Placeholder: C04 Not Implemented (Requires Geometry)."
+
+
+@register_rule(rule_id="C05", category="Core")
+def rule_transparency(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: Bans transparency and opacity effects."""
+    if max_speed < Speed.MEDIUM:
+        return Status.PASS, "Skipped transparency check."
+    if ctx.xml_tree is None:
+        return Status.FAIL, "XML missing, cannot check transparency."
+    forbidden = ['opacity', 'fill-opacity',
+                 'stroke-opacity', 'stop-opacity', 'filter', 'style']
+    for el in ctx.xml_tree.iter():
+        for attr in forbidden:
+            val = el.get(attr)
+            if val:
+                if 'opacity' in attr and val in ['1', '1.0']:
+                    continue
+                if attr == 'style' and 'opacity:1' in val.replace(' ', ''):
+                    continue
+                tag = el.tag.split('}')[-1]
+                return Status.FAIL, f"Forbidden effect/transparency '{attr}' in <{tag}>"
+    return Status.PASS, "No transparency found."
+
+
+@register_rule(rule_id="C06", category="Core")
+def rule_stroke_weight(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: Validates stroke weights (6,8,10,12,14px)."""
+    if max_speed < Speed.MEDIUM:
+        return Status.PASS, "Skipped stroke weight check."
+    if ctx.xml_tree is None:
+        return Status.FAIL, "XML missing."
+
+    valid = {6.0, 8.0, 10.0, 12.0, 14.0}
+    strokes = []
+    for el in ctx.xml_tree.iter():
+        sw = el.get('stroke-width')
+        if sw:
+            try:
+                strokes.append(float(sw.replace('px', '').strip()))
+            except ValueError:
+                return Status.FAIL, f"Non-numeric stroke-width: {sw}"
+    if not strokes:
+        return Status.PASS, "No stroked elements."
+
+    unique_weights = set(strokes)
+    if not unique_weights.issubset(valid):
+        return Status.FAIL, f"Forbidden weights: {unique_weights - valid}"
+
+    if len(strokes) == 1:
+        weight = strokes[0]
+        if weight == 14.0:
+            return Status.REVIEW, "Minimal icon (14px): Confirm optical weight matches set."
+        if weight == 12.0:
+            return Status.REVIEW, "Minimal icon (12px): Confirm it doesn't look too thin."
+        return Status.REVIEW, f"Minimal icon using fine-detail weight ({weight}px)."
+
+    if any(w < 12.0 for w in unique_weights):
+        return Status.REVIEW, f"Fine details/dense icon detected: {unique_weights}"
+
+    return Status.PASS, f"Weights valid: {unique_weights}"
+
+
+@register_rule(rule_id="C07", category="Core")
+def rule_fill_color(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: Checks fill state (expects 'none' or no stroke)."""
+    if max_speed < Speed.MEDIUM:
+        return Status.PASS, "Skipped fill check."
+    if ctx.xml_tree is None:
+        return Status.FAIL, "XML missing."
+
+    for el in ctx.xml_tree.iter():
+        tag = el.tag.split('}')[-1]
+        if tag in ['g', 'defs', 'style', 'svg']:
+            continue
+        if not el.get('stroke'):
+            continue  # Skip elements without strokes
+
+        fill = el.get('fill')
+        if fill is None and 'fill:none' not in el.get('style', ''):
+            return Status.REVIEW, f"<{tag}> has implicit fill (renders black)."
+        if fill not in ['none', None]:
+            return Status.FAIL, f"<{tag}> has explicit fill '{fill}'. Expected 'none'."
+    return Status.PASS, "Fill states are compliant."
+
+
+@register_rule(rule_id="C08", category="Core")
+def rule_rounding_caps(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: Validates 'round' stroke-linecap on open paths."""
+    if max_speed < Speed.MEDIUM:
+        return Status.PASS, "Skipped cap check."
+    if ctx.xml_tree is None:
+        return Status.FAIL, "XML missing."
+
+    root_cap = ctx.xml_tree.get('stroke-linecap')
+    if root_cap == 'round':
+        return Status.PASS, "Root defines 'round' cap."
+
+    for el in ctx.xml_tree.iter():
+        tag = el.tag.split('}')[-1]
+        if not el.get('stroke'):
+            continue
+        if tag in ['rect', 'polygon']:
+            continue  # Closed shapes
+
+        is_open = True
+        if tag == 'path':
+            d = el.get('d', '').strip()
+            if not d or d.endswith('z') or d.endswith('Z'):
+                is_open = False
+            elif max_speed >= Speed.SLOW and HAS_SVGELEMENTS:
+                try:
+                    is_open = not SVGPath(d).closed  # type: ignore
+                except Exception:
+                    return Status.FAIL, "Unparseable path data."
+
+        if is_open and el.get('stroke-linecap') != 'round':
+            return Status.FAIL, f"Open <{tag}> lacks 'round' stroke-linecap."
+
+    return Status.PASS, "All open paths have round caps."
+
+
+@register_rule(rule_id="C09", category="Core")
+def rule_rounding_joints(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: Validates 'round' stroke-linejoin."""
+    if max_speed < Speed.MEDIUM:
+        return Status.PASS, "Skipped join check."
+    if ctx.xml_tree is None:
+        return Status.FAIL, "XML missing."
+
+    root_join = ctx.xml_tree.get('stroke-linejoin')
+    if root_join == 'round':
+        return Status.PASS, "Root defines 'round' join."
+
+    for el in ctx.xml_tree.iter():
+        tag = el.tag.split('}')[-1]
+        if not el.get('stroke') or tag in ['svg', 'g', 'defs']:
+            continue
+        if el.get('stroke-linejoin') != 'round':
+            return Status.FAIL, f"<{tag}> lacks 'round' stroke-linejoin."
+    return Status.PASS, "All path joints are round."
+
+
+@register_rule(rule_id="C10", category="Core")
+def rule_rounded_corners(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Core: Validates <rect> corner rounding (rx)."""
+    if max_speed < Speed.MEDIUM:
+        return Status.PASS, "Skipped rect rounding check."
+    if ctx.xml_tree is None:
+        return Status.FAIL, "XML missing."
+
+    ns = "{http://www.w3.org/2000/svg}"
+    for rect in ctx.xml_tree.iter(f'{ns}rect'):
+        try:
+            rx = rect.get('rx')
+            if rx is None:
+                return Status.FAIL, "Rect lacks rx attribute."
+            if not (6 <= float(rx) <= 32):
+                return Status.FAIL, f"Rect rx='{rx}' out of 6-32 range."
+        except (ValueError, TypeError):
+            return Status.FAIL, f"Rect has invalid rx: {rect.get('rx')}"
+    return Status.PASS, "All rects properly rounded."
+
+# --- Quality Rules ---
+
+@register_rule(rule_id="Q01", category="Quality")
+def rule_placeholder_adjacent_stroke_weight(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Quality: [Placeholder] Checks for large differences in adjacent stroke weights."""
+    return Status.PASS, "Placeholder: Q01 Not Implemented (Requires SLOW/Geometry)."
+
+
+@register_rule(rule_id="Q02", category="Quality")
+def rule_placeholder_black_spots(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Quality: [Placeholder] Detects unintentional black spots from overlapping paths."""
+    return Status.PASS, "Placeholder: Q02 Not Implemented (Requires SLOW/Geometry)."
+
+
+@register_rule(rule_id="Q03", category="Quality")
+def rule_placeholder_strokes_too_close(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Quality: [Placeholder] Checks for strokes that are too close to each other."""
+    return Status.PASS, "Placeholder: Q03 Not Implemented (Requires SLOW/Geometry)."
+
+
+@register_rule(rule_id="Q04", category="Quality")
+def rule_placeholder_visual_alignment(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str]:
+    """Quality: [Placeholder] Checks for visual alignment instead of bounding-box alignment."""
+    return Status.PASS, "Placeholder: Q04 Not Implemented (Requires SLOW/Geometry)."
+
+# --- Output System (Modular) ---
+
+class OutputHandler(ABC):
+    """Base class for modular output formats."""
+
+    def __init__(self, dest: Any = sys.stdout, verbose: bool = False):
+        self.dest = dest
+        self.verbose = verbose
+        self.failed_count = 0
+
+    @abstractmethod
+    def start(self): pass
+
+    @abstractmethod
+    def process(self, report: FileReport): pass
+
+    @abstractmethod
+    def finish(self): pass
+
+class ConsoleOutput(OutputHandler):
+    COLORS = {
+        Status.PASS: "\033[92m",   # Green
+        Status.WARN: "\033[93m",   # Yellow
+        Status.FAIL: "\033[91m",   # Red
+        Status.REVIEW: "\033[95m",  # Magenta
+        Status.EXEMPT: "\033[90m",  # Grey
+    }
+    RESET = "\033[0m"
+
+    def process(self, report: FileReport):
+        # 1. Handle Catastrophic Errors
+        if report.error:
+            print(
+                f"{self.COLORS[Status.FAIL]}ERR{self.RESET} {report.file_path}: {report.error}")
+            self.failed_count += 1
+            return
+
+        # 2. Determine Visibility
+        # Actionable = anything that isn't a PASS
+        actionable_results = [
+            r for r in report.results if r.status not in (Status.PASS, Status.EXEMPT)]
+        has_failure = any(r.status == Status.FAIL for r in report.results)
+
+        if has_failure:
+            self.failed_count += 1
+
+        # Skip printing if not verbose and nothing is wrong
+        if not self.verbose and not actionable_results:
+            return
+
+        # 3. Printing Logic
+        print(f"\n{report.file_path}")
+        for r in report.results:
+            if not self.verbose and r.status == Status.PASS:
+                continue
+
+            color = self.COLORS.get(r.status, "")
+            timing = f" ({r.duration_ms:.2f}ms)" if self.verbose else ""
+            print(
+                f"  [{color}{r.status.name:6}{self.RESET}] [{r.category}: {r.id}] {r.message}{timing}")
+
+    def finish(self):
+        print(f"\nAnalysis complete. Failed files: {self.failed_count}")
+
+
+class JsonOutput(OutputHandler):
+    def start(self):
+        self.dest.write("[\n")
+        self.first = True
+
+    def process(self, report: FileReport):
+        # In non-verbose mode, skip files that passed everything perfectly
+        actionable = [r for r in report.results if r.status != Status.PASS]
+        if not self.verbose and not actionable and not report.error:
+            return
+
+        if not self.first:
+            self.dest.write(",\n")
+        self.first = False
+
+        if any(r.status == Status.FAIL for r in report.results):
+            self.failed_count += 1
+
+        data = asdict(report)
+        # Enums to strings for JSON
+        for r in data['results']:
+            r['status'] = r['status'].value
+
+        # Strip PASS results from JSON if not verbose to save disk/bandwidth on 8k files
+        if not self.verbose:
+            data['results'] = [r for r in data['results'] if r['status'] != "PASS"]
+
+        self.dest.write(json.dumps(data))
+
+    def finish(self):
+        self.dest.write("\n]\n")
+
+
+class CompactOutput(OutputHandler):
+    """
+    Minimalist output:
+    filename.svg: ID-01, ID-02
+    """
+
+    def start(self):
+        pass
+
+    def process(self, report: FileReport):
+        # Gather IDs of all results that are FAIL
+        failed_ids = [r.id for r in report.results if r.status == Status.FAIL]
+
+        if report.error:
+            # Handle catastrophic file errors (e.g. unreadable)
+            self.dest.write(
+                f"{report.file_path}: CRITICAL_ERROR ({report.error}) \n")
+            self.failed_count += 1
+        elif failed_ids:
+            # Sort IDs for consistent output
+            ids_str = ", ".join(sorted(set(failed_ids)))
+            self.dest.write(f"{report.file_path}: {ids_str} \n")
+            self.failed_count += 1
+
+    def finish(self):
+        # Summary sent to stderr to avoid polluting stdout if user pipes output
+        if self.failed_count > 0:
+            print(
+                f"\nFound {self.failed_count} files with failures.", file=sys.stderr)
+
+
+OUTPUT_FACTORIES: Dict[str, Type[OutputHandler]] = {
+    'text': ConsoleOutput,
+    'json': JsonOutput,
+    'compact': CompactOutput
+}
+
+# --- Worker Logic ---
+
+
+def analyze_file(filepath_str: str, max_speed: Speed, exceptions: Dict[str, List[str]]) -> FileReport:
+    path = Path(filepath_str)
+    report = FileReport(filepath_str)
+    filename = path.name
+
+    # 1. Load context
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except Exception as e:
+        report.error = f"Read Error: {e}"
+        return report
+
+    ctx = CheckContext(filename=filename, raw_content=raw)
+
+    # Lazy Load parsing based on max_speed
+    if max_speed >= Speed.MEDIUM:
+        try:
+            ctx.xml_tree = ET.fromstring(raw)
+        except ET.ParseError:
+            pass  # Handled inside rules that require XML
+
+    if max_speed >= Speed.SLOW and HAS_SVGELEMENTS and ctx.xml_tree is not None:
+        try:
+            from io import BytesIO
+            ctx.svg_doc = SVG.parse(  # type: ignore
+                BytesIO(raw.encode('utf-8')))  # type: ignore
+        except Exception:
+            pass
+
+    # 2. Execute Rules sequentially
+    for rule_func, rule_id, category in RULES_REGISTRY:
+        t0 = time.perf_counter()
+
+        try:
+            status, msg = rule_func(ctx, max_speed)
+        except Exception as e:
+            status, msg = Status.FAIL, f"Rule Exception: {e}"
+
+        dt = (time.perf_counter() - t0) * 1000
+
+        # 3. Handle Exceptions / Exemptions natively
+        if status not in (Status.PASS, Status.WARN):
+            if filename in exceptions.get(rule_id, []):
+                status = Status.EXEMPT
+                msg = f"[EXEMPTED] {msg}"
+
+        report.results.append(CheckResult(
+            rule_id, category, rule_func.__name__, status, msg, dt))
+
+    return report
+
+# --- Main ---
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SVG Linter & Optimizer")
+    parser.add_argument("input", help="SVG file or directory")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Show all checks, including PASS")
+    parser.add_argument("--format", choices=OUTPUT_FACTORIES.keys(),
+                        default="text", help="Output format")
+    parser.add_argument(
+        "--output-file", help="Write output to file instead of stdout")
+    parser.add_argument(
+        "--speed", choices=["fast", "medium", "slow"], default="slow", help="Max check complexity")
+    parser.add_argument("--workers", type=int, default=4,
+                        help="Parallel processes")
+    parser.add_argument("--exceptions", default="exceptions.json",
+                        help="JSON file for allowlists")
+
+    args = parser.parse_args()
+
+    # Load Exceptions
+    exceptions = {}
+    exc_path = Path(args.exceptions)
+    if exc_path.exists():
+        try:
+            exceptions = json.loads(exc_path.read_text())
+            # Format: { "WGT-01": ["icon.svg", "icon2.svg"] }
+        except Exception as e:
+            print(f"Error loading exceptions: {e}")
+            sys.exit(1)
+
+    speed_map = {
+        "fast": Speed.FAST,
+        "medium": Speed.MEDIUM,
+        "slow": Speed.SLOW
+    }
+    max_speed = speed_map[args.speed]
+
+    input_path = Path(args.input)
+    if input_path.is_file():
+        files = [str(input_path)]
+    else:
+        files = [str(p) for p in input_path.rglob("*.svg")]
+
+    if not files:
+        print("No SVG files found.")
+        sys.exit(0)
+
+    out_stream = sys.stdout
+    if args.output_file:
+        out_stream = open(args.output_file, 'w')
+
+    handler = OUTPUT_FACTORIES[args.format](
+        out_stream, verbose=args.verbose)
+
+    handler.start()
+
+    # imap_unordered is crucial for large file counts: it yields results as they finish.
+    # We use a chunksize to reduce IPC overhead.
+    chunk_size = max(1, len(files) // (args.workers * 4))
+
+    with ProcessPoolExecutor(max_workers=args.workers) as executor:
+        # Pass max_speed to every worker
+        # We use a partial or a list comprehension approach
+        futures = executor.map(
+            analyze_file,
+            files, [max_speed]*len(files), [exceptions]*len(files),
+            chunksize=chunk_size
+        )
+
+        for report in futures:
+            handler.process(report)
+
+    handler.finish()
+
+    if args.output_file:
+        out_stream.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -480,12 +480,12 @@ class CompactOutput(OutputHandler):
         if report.error:
             # Handle catastrophic file errors (e.g. unreadable)
             self.dest.write(
-                f"{report.file_path}: CRITICAL_ERROR ({report.error}) \n")
+                f"{Path(report.file_path).name}: CRITICAL_ERROR ({report.error}) \n")
             self.failed_count += 1
         elif failed_ids:
             # Sort IDs for consistent output
             ids_str = ", ".join(sorted(set(failed_ids)))
-            self.dest.write(f"{report.file_path}: {ids_str} \n")
+            self.dest.write(f"{Path(report.file_path).name}: {ids_str} \n")
             self.failed_count += 1
 
     def finish(self):

--- a/lint-icons.py
+++ b/lint-icons.py
@@ -185,8 +185,8 @@ def rule_stroke_weight(ctx: CheckContext, max_speed: Speed) -> tuple[Status, str
         weight = strokes[0]
         if weight == 14.0:
             return Status.REVIEW, "Minimal icon (14px): Confirm optical weight matches set."
-        if weight == 12.0:
-            return Status.REVIEW, "Minimal icon (12px): Confirm it doesn't look too thin."
+        if weight == 10.0:
+            return Status.REVIEW, "Dense     icon (10px): Confirm it doesn't look too thin."
         return Status.REVIEW, f"Minimal icon using fine-detail weight ({weight}px)."
 
     if any(w < 12.0 for w in unique_weights):


### PR DESCRIPTION
This pull request introduces a comprehensive automated linter workflow for drawable naming consistency in pull requests that modify SVG icon files. The main changes include adding a new Python linter script, its dependencies, and a GitHub Actions workflow to run the linter on PRs, as well as a minor update to the icon checklist documentation.

**Automated Linting Workflow and Linter Script:**

* Added a new GitHub Actions workflow (`.github/workflows/pr_linter.yml`) that triggers on pull requests affecting SVG files. This workflow waits for a checklist comment, sets up the environment, installs dependencies, and runs the new linter script.
* Introduced `.github/scripts/name_checker.py`, a Python script that checks for orphaned SVG files, missing files declared in `appfilter.xml`, and naming mismatches between SVG filenames and their corresponding app names. The script supports multiple output formats and is designed for CI use.
* Added a requirements file (`.github/scripts/requirements.txt`) specifying dependencies needed for the linter, including `unidecode`, `svgelements`, and `PyGithub`.

**Documentation:**

* Updated `.github/icon_checklist.md` to include a marker comment that signals when the icon checklist has been posted, enabling the workflow to detect readiness.

TODO:

- [ ] Implement remaining quality checks (to be done next time)
- [x] Create PR description
- [x] Test GH action in separate repo
- [ ] Ensure code quality
- [ ] Thoroughly test for edge cases