### PR TITLE
+48 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -244,6 +244,7 @@
   <item component="ComponentInfo{com.nll.cb/com.nll.cb.DefaultAlias}" drawable="generic_dialer" name="ACR Phone" />
   <item component="ComponentInfo{com.acronis.acronistrueimage/com.acronis.mobile.ui2.TheMainActivity}" drawable="acronis_true_image" name="Acronis True Image" />
   <item component="ComponentInfo{com.act.mobile.apps/com.act.mobile.apps.MainActivity}" drawable="act_fibernet" name="ACT Fibernet" />
+  <item component="ComponentInfo{com.act.mobile.apps/com.act.mobile.apps.MainActivitySmartWifi}" drawable="act_fibernet" name="ACT Fibernet" />
   <item component="ComponentInfo{org.android.actc/com.tedmob.actc.features.launch.RootActivity}" drawable="actc_pt" name="ACTC PT" />
   <item component="ComponentInfo{com.action.consumerapp/com.action.consumerapp.MainActivity}" drawable="action" name="Action" />
   <item component="ComponentInfo{com.google.android.apps.accessibility.maui.actionblocks/com.google.android.apps.accessibility.maui.actionblocks.home.HomeActivity}" drawable="action_blocks" name="Action Blocks" />
@@ -992,6 +993,7 @@
   <item component="ComponentInfo{com.tomclaw.appsend_rb/com.tomclaw.appsend_rb.screen.apps.AppsActivity}" drawable="appsend" name="AppSend" />
   <item component="ComponentInfo{com.appsfree.android/com.appsfree.android.ui.main.MainActivity}" drawable="appsfree" name="AppsFree" />
   <item component="ComponentInfo{info.muge.appshare/info.muge.appshare.launcher0}" drawable="appshare" name="AppShare" />
+  <item component="ComponentInfo{info.muge.appshare/info.muge.appshare.launcher1}" drawable="appshare" name="AppShare" />
   <item component="ComponentInfo{x1Trackmaster.x1Trackmaster/x1Trackmaster.x1Trackmaster.activities.MainActivity}" drawable="appsheet" name="AppSheet" />
   <item component="ComponentInfo{com.invalidco.appuly.appuly/com.invalidco.appuly.appuly.MainActivity}" drawable="appuly" name="Appuly" />
   <item component="ComponentInfo{es.valencia.lanzadera/es.valencia.lanzadera.activities.SplashActivity}" drawable="appvalencia" name="AppValència" />
@@ -1199,6 +1201,7 @@
   <item component="ComponentInfo{com.alexmercerind.audire/com.alexmercerind.audire.ui.MainActivity}" drawable="audire" name="Audire" />
   <item component="ComponentInfo{com.audubon.mobile.android/com.audubon.mobile.android.MainActivity}" drawable="audubon_bird_guide" name="Audubon Bird Guide" />
   <item component="ComponentInfo{studio14.application.auraicons/com.candybar.dev.activities.SplashActivity}" drawable="aura_icons" name="Aura Icons" />
+  <item component="ComponentInfo{studio14.application.auraicons/com.one4studio.iconpack.MainActivity}" drawable="aura_icons" name="Aura Icons" />
   <item component="ComponentInfo{com.aurora.adroid/com.aurora.adroid.activity.AuroraActivity}" drawable="aurora_droid" name="Aurora Droid" />
   <item component="ComponentInfo{com.aurora.adroid/com.aurora.adroid.ui.activity.AuroraActivity}" drawable="aurora_droid" name="Aurora Droid" />
   <item component="ComponentInfo{com.aurora.adroid/com.aurora.adroid.ui.activity.SplashActivity}" drawable="aurora_droid" name="Aurora Droid" />
@@ -1511,6 +1514,7 @@
   <item component="ComponentInfo{io.github.domi04151309.batterytool/io.github.domi04151309.batterytool.activities.SplashActivity}" drawable="battery_tool" name="Battery Tool" />
   <item component="ComponentInfo{com.lstapps.batterywidget/com.lstapps.batterywidget.MainActivity}" drawable="battery_widget" name="Battery Widget" />
   <item component="ComponentInfo{com.oneapps.batteryone/com.oneapps.batteryone.SplashScreen}" drawable="batteryone" name="BatteryOne" />
+  <item component="ComponentInfo{com.oneapps.batteryone/com.oneapps.batteryone.black}" drawable="batteryone" name="BatteryOne" />
   <item component="ComponentInfo{com.blizzard.messenger/com.blizzard.messenger.ui.SplashActivity}" drawable="battle_net" name="Battle.net" />
   <item component="ComponentInfo{com.blizzard.messenger/com.blizzard.messenger.ui.splash.SplashActivity}" drawable="battle_net" name="Battle.net" />
   <item component="ComponentInfo{com.blizzard.bma/com.blizzard.bma.SplashActivity}" drawable="battle_net_authenticator" name="Battle.net Authenticator" />
@@ -2257,6 +2261,7 @@
   <item component="ComponentInfo{com.netease.buff163/com.netease.buff.entry.launcher.icon1330}" drawable="buff" name="BUFF" />
   <item component="ComponentInfo{com.netease.buff163/com.netease.buff.entry.launcher.icon1380}" drawable="buff" name="BUFF" />
   <item component="ComponentInfo{com.netease.buff/com.netease.buff.entry.launcher.icon1500}" drawable="buff" name="BUFF" />
+  <item component="ComponentInfo{com.netease.buff/com.netease.buff.entry.launcher.icon2900}" drawable="buff" name="BUFF" />
   <item component="ComponentInfo{org.buffer.android/org.buffer.android.ui.splash.SplashScreenActivity}" drawable="buffer" name="Buffer" />
   <item component="ComponentInfo{com.shadowteam.buffywallsfree/com.shadowteam.buffywallsfree.MainActivity}" drawable="buffywalls" name="BuffyWalls" />
   <item component="ComponentInfo{com.shadowteam.buffywallspaid/com.shadowteam.buffywallsfree.MainActivity}" drawable="buffywalls_pro" name="BuffyWalls Pro" />
@@ -2393,6 +2398,7 @@
   <item component="ComponentInfo{com.maleo.bussimulatorid/com.hendrachannel.MainActivity}" drawable="bus_simulator_indonesia" name="Bus Simulator Indonesia" />
   <item component="ComponentInfo{com.maleo.bussimulatorid/com.unity3d.player.UnityPlayerActivity}" drawable="bus_simulator_indonesia" name="Bus Simulator Indonesia" />
   <item component="ComponentInfo{com.maleo.bussimulatorid/com.membo.MainActivity}" drawable="bus_simulator_indonesia" name="Bus Simulator Indonesia" />
+  <item component="ComponentInfo{com.maleo.hendra.channel/com.hendrachannel.MainActivity}" drawable="bus_simulator_indonesia" name="Bus Simulator Indonesia" />
   <item component="ComponentInfo{hearsilent.busplus/hearsilent.busplus.activity.SplashActivity}" drawable="bus_plus" name="Bus+" />
   <item component="ComponentInfo{com.appgenix.bizcal/com.appgenix.bizcal.LaunchActivity}" drawable="business_calendar" name="Business Calendar" />
   <item component="ComponentInfo{de.hafas.android.db.business/de.bahn.dbtickets.ui.DBNavLauncherActivity}" drawable="business_db_navigator" name="Business DB Navigator" />
@@ -2471,6 +2477,7 @@
   <item component="ComponentInfo{br.gov.caixa.tem/br.SRJT.zWNl.V5Yn.ui.Ovr3.jTic}" drawable="caixa_tem" name="CAIXA Tem" />
   <item component="ComponentInfo{br.gov.caixa.tem/br.zE79A6.h8Gqa1.dENfR2.ui.lOFid8.nfxS75}" drawable="caixa_tem" name="CAIXA Tem" />
   <item component="ComponentInfo{br.gov.caixa.tem/br.eboWR1.v4m4V8.yKqJp3.ui.ehaiV7.ptHzT9}" drawable="caixa_tem" name="CAIXA Tem" />
+  <item component="ComponentInfo{br.gov.caixa.tem/br.qu97H1.n9nWX1.hQdoc9.ui.zSA2n0.eUYZj2}" drawable="caixa_tem" name="CAIXA Tem" />
   <item component="ComponentInfo{cgd.pt.caixadirectaparticulares/cgd.pt.caixadirectaparticulares.MainActivity}" drawable="caixadirecta" name="Caixadirecta" />
   <item component="ComponentInfo{me.mycake/me.mycake.MainActivity}" drawable="cake" name="Cake" />
   <item component="ComponentInfo{com.cakeresume.app/com.cakeresume.app.MainActivity}" drawable="cake_job" name="Cake Job" />
@@ -2566,6 +2573,7 @@
   <item component="ComponentInfo{org.solovyev.android.calculator/org.solovyev.android.calculator.onscreen.CalculatorOnscreenStartActivity}" drawable="calculator_plus_plus" name="Calculator ++" />
   <item component="ComponentInfo{calculatorlock.calculatorvault.photovault.hider/calculatorlock.calculatorvault.photovault.hider.SplashActivity.calculator3}" drawable="generic_calculator_plus_minus_multi_equal" name="Calculator Lock" />
   <item component="ComponentInfo{calc.gallery.lock/overlays.com.calculatorlib.UpdatedCalculatorActivity}" drawable="generic_calculator_plus_minus_multi_equal" name="Calculator Lock" />
+  <item component="ComponentInfo{calculatorlock.calculatorvault.photovault.hider/calculatorlock.calculatorvault.photovault.hider.SplashActivity}" drawable="generic_calculator_plus_minus_multi_equal" name="Calculator Lock" />
   <item component="ComponentInfo{com.duy.calculator.free/com.duy.ncalc.calculator.ScientificCalculatorActivity}" drawable="calculator_n_plus" name="Calculator N+" />
   <item component="ComponentInfo{com.duy.calculator.free/com.duy.ncalc.calculator.BasicCalculatorActivity}" drawable="calculator_n_plus" name="Calculator N+" />
   <item component="ComponentInfo{com.duy.calculator.free/com.duy.calculator.activities.ActivitySplashScreen}" drawable="calculator_n_plus" name="Calculator N+" />
@@ -3395,6 +3403,7 @@
   <item component="ComponentInfo{com.kokoschka.michael.qrtools/com.kokoschka.michael.qrtools.activities.SplashActivity}" drawable="generic_qr_reader" name="Codora" />
   <item component="ComponentInfo{com.kokoschka.michael.qrtools/com.kokoschka.michael.qrtools.MainActivity}" drawable="generic_qr_reader" name="Codora" />
   <item component="ComponentInfo{com.fanatee.cody/com.google.firebase.MessagingUnityPlayerActivity}" drawable="codycross" name="CodyCross" />
+  <item component="ComponentInfo{com.fanatee.cody/com.fanatee.cody.CodyUnityPlayerActivity}" drawable="codycross" name="CodyCross" />
   <item component="ComponentInfo{com.github.muellerma.coffee/com.github.muellerma.coffee.activities.MainActivity}" drawable="coffee" name="Coffee" />
   <item component="ComponentInfo{com.github.muellerma.coffee/com.github.muellerma.coffee.MainActivity}" drawable="coffee" name="Coffee" />
   <item component="ComponentInfo{com.openappslabs.coffee/com.openappslabs.coffee.MainActivity}" drawable="coffee_by_openappslabs" name="Coffee by OpenAppsLabs" />
@@ -3574,6 +3583,7 @@
   <item component="ComponentInfo{com.coppel.coppelapp/com.coppel.coppelapp.splash.presentation.SplashActivity}" drawable="bancoppel" name="Coppel" />
   <item component="ComponentInfo{com.coppel.coppelapp/oGCSj5.mKCAZ2.bF7je1.afFQS0.utBYV9.or0VD5}" drawable="bancoppel" name="Coppel" />
   <item component="ComponentInfo{com.coppel.coppelapp/gQFvU6.gesY72.gdKsn1.yDigQ7.r3FH22.eEjfj2}" drawable="bancoppel" name="Coppel" />
+  <item component="ComponentInfo{com.coppel.coppelapp/djxOS4.pgL2k6.kC5fa7.seSVe7.bLPYw9.zf0bh8}" drawable="bancoppel" name="Coppel" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.coptic/com.anysoftkeyboard.languagepack.coptic.MainActivity}" drawable="anysoftkeyboard" name="Coptic for AnySoftKeyboard" />
   <item component="ComponentInfo{com.weberdo.apps.copy/com.weberdo.apps.copy.MainActivity}" drawable="copy" name="Copy" />
   <item component="ComponentInfo{com.mediamushroom.copymydata/com.mediamushroom.copymydata.app.SplashActivity}" drawable="copy_my_data" name="Copy My Data" />
@@ -3942,6 +3952,7 @@
   <item component="ComponentInfo{com.flx_apps.digitaldetox/com.flx_apps.digitaldetox.MainActivity}" drawable="detoxdroid" name="DetoxDroid" />
   <item component="ComponentInfo{br.gov.sp.detran.consultas/br.gov.sp.detran.consultas.activity.MainActivity}" drawable="detran_sp" name="Detran.SP" />
   <item component="ComponentInfo{com.db.pwcc.dbmobile/com.db.pwcc.dbmobile.activities.SplashScreenActivity}" drawable="deutsche_bank" name="Deutsche Bank" />
+  <item component="ComponentInfo{com.db.pwcc.dbmobile/com.db.dbmobile.unity.feature.splash.SplashActivity}" drawable="deutsche_bank" name="Deutsche Bank" />
   <item component="ComponentInfo{de.deutschlandcard.app/de.deutschlandcard.app.ui.LaunchActivity}" drawable="deutschlandcard" name="DeutschlandCard" />
   <item component="ComponentInfo{de.deutschlandticket.app/de.deutschlandticket.app.MainActivity}" drawable="deutschlandticket_de" name="Deutschlandticket.de" />
   <item component="ComponentInfo{cn.trinea.android.developertools/c.b.a}" drawable="dev_tools" name="Dev Tools" />
@@ -4111,6 +4122,7 @@
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenLoading}" drawable="discord" name="Discord" />
   <item component="ComponentInfo{com.discord/com.discord.screens.ScreenMain}" drawable="discord" name="Discord" />
   <item component="ComponentInfo{com.discord/com.discord.main.MainMidnightPrism}" drawable="discord" name="Discord" />
+  <item component="ComponentInfo{com.discore/com.discord.main.MainDefault}" drawable="discord" name="Discord" />
   <item component="ComponentInfo{com.aliucord.themer/com.aliucord.themer.activities.MainActivity}" drawable="themed_icons" name="Discord Themer" />
   <item component="ComponentInfo{mmapps.mobile.discount.calculator/mmapps.mobile.discount.calculator.activities.MainActivity}" drawable="discount" name="Discount" />
   <item component="ComponentInfo{com.discoverfinancial.mobile/discover.activity}" drawable="discover" name="Discover" />
@@ -4717,6 +4729,7 @@
   <item component="ComponentInfo{egov.app/com.dict.egov.ui.splash.SplashActivityAlias}" drawable="egovph" name="eGovPH" />
   <item component="ComponentInfo{egov.app/com.dict.egov.ui.splash.SplashActivity}" drawable="egovph" name="eGovPH" />
   <item component="ComponentInfo{egov.app/com.dict.superapp.ui.splash.SplashActivity}" drawable="egovph" name="eGovPH" />
+  <item component="ComponentInfo{egov.app/egov.app.ui.splash.SplashActivity}" drawable="egovph" name="eGovPH" />
   <item component="ComponentInfo{moc.ortemazege.www/com.example.gpttest.MainActivity}" drawable="egy_metro_guide" name="Egy Metro Guide" />
   <item component="ComponentInfo{moc.ortemazege.www/moc.ortemazege.www.MainActivity}" drawable="egy_metro_guide" name="Egy Metro Guide" />
   <item component="ComponentInfo{nl.rodekruis.android/nl.rodekruis.android.MainActivity}" drawable="generic_aid" name="EHBO - Rode Kruis" />
@@ -5798,6 +5811,7 @@
   <item component="ComponentInfo{org.fossify.keyboard/org.fossify.keyboard.activities.SplashActivity.Yellow}" drawable="generic_keyboard" name="Fossify Keyboard" />
   <item component="ComponentInfo{org.fossify.home/org.fossify.home.activities.SplashActivity.Green}" drawable="fossify_launcher" name="Fossify Launcher" />
   <item component="ComponentInfo{org.fossify.home/org.fossify.home.activities.SplashActivity.Cyan}" drawable="fossify_launcher" name="Fossify Launcher" />
+  <item component="ComponentInfo{org.fossify.home/org.fossify.home.activities.SplashActivity.Orange}" drawable="fossify_launcher" name="Fossify Launcher" />
   <item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity}" drawable="messages" name="Fossify Messages" />
   <item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Amber}" drawable="messages" name="Fossify Messages" />
   <item component="ComponentInfo{org.fossify.messages/org.fossify.messages.activities.SplashActivity.Blue}" drawable="messages" name="Fossify Messages" />
@@ -6130,11 +6144,13 @@
   <item component="ComponentInfo{com.dddev.gallery.album.photo.editor/com.gallery.activities.SplashActivity}" drawable="photo_gallery" name="Gallery" />
   <item component="ComponentInfo{galleryapp.picturelock.gallerylock.albums/com.fragmentphotos.gallery.pro.events.SwashEvent}" drawable="photo_gallery" name="Gallery" />
   <item component="ComponentInfo{com.isfresh27.gallery/com.isfresh27.gallery.activities.SplashActivity.Red}" drawable="auto_change_wallpaper" name="Gallery" />
+  <item component="ComponentInfo{com.miui.gallery/com.miui.gallery.MainActivity}" drawable="generic_gallery" name="Gallery" />
   <item component="ComponentInfo{gallery.photomanager.picturegalleryapp.imagegallery/gallery.photomanager.picturegalleryapp.imagegallery.activity.GalleryActivity}" drawable="gallery_by_photozen" name="Gallery by PhotoZen" />
   <item component="ComponentInfo{com.thinkyeah.galleryvault/com.thinkyeah.galleryvault.ads.GvAppOpenSplashActivity}" drawable="gallery_vault" name="Gallery Vault" />
   <item component="ComponentInfo{com.thinkyeah.galleryvault/com.thinkyeah.galleryvault.LockingActivity}" drawable="gallery_vault" name="Gallery Vault" />
   <item component="ComponentInfo{com.g19mobile.gameboosterplus/com.g19mobile.gameboosterplus.SplashActivity}" drawable="game_booster" name="Game Booster" />
   <item component="ComponentInfo{com.g19mobile.gamebooster/com.fenixphoneboosterltd.gamebooster.SplashActivity}" drawable="game_booster" name="Game Booster" />
+  <item component="ComponentInfo{com.g19mobile.gamebooster/com.g19mobile.gamebooster.SplashActivity}" drawable="game_booster" name="Game Booster" />
   <item component="ComponentInfo{com.samsung.android.game.honeyplayplus/com.samsung.android.game.honeyplayplus.main.ui.LaunchActivity}" drawable="game_booster_plus" name="Game Booster +" />
   <item component="ComponentInfo{com.samsung.android.game.honeyplayplus/com.samsung.android.game.honeyplayplus.ui.LaunchActivity}" drawable="game_booster_plus" name="Game Booster +" />
   <item component="ComponentInfo{com.nearme.gamecenter/com.nearme.gamecenter.DefaultAlias}" drawable="game_center" name="Game Center" />
@@ -6233,6 +6249,7 @@
   <item component="ComponentInfo{com.merkuryinnovations.geeni/com.smart.ThingSplashActivity}" drawable="geeni" name="geeni" />
   <item component="ComponentInfo{at.geizhals.pv/at.geizhals.android.MainActivity}" drawable="geizhals" name="Geizhals" />
   <item component="ComponentInfo{at.geizhals.pv/at.geizhals.pv.GeizhalsSplashScreen}" drawable="geizhals" name="Geizhals" />
+  <item component="ComponentInfo{at.geizhals.pv/at.geizhals.pv.MainActivity}" drawable="geizhals" name="Geizhals" />
   <item component="ComponentInfo{com.gemini.android.app/com.gemini.android.MainActivity}" drawable="gemini" name="Gemini" />
   <item component="ComponentInfo{com.bionic.gemini/com.bionic.gemini.SplashActivity}" drawable="gemini_wallpaper" name="Gemini Wallpaper" />
   <item component="ComponentInfo{com.geminiman.wearosmanager/com.geminiman.wearosmanager.MainActivity}" drawable="geminiman" name="GeminiMan" />
@@ -8142,6 +8159,7 @@
   <item component="ComponentInfo{jp.joyfit.joyfitappandroid/jp.joyfit.joyfitappandroid.MainActivity}" drawable="joyfit" name="JOYFIT" />
   <item component="ComponentInfo{de.prosiebensat1digital.seventv/de.prosiebensat1digital.playerpluggable.testapp.splash.SplashActivity}" drawable="joyn" name="Joyn" />
   <item component="ComponentInfo{de.prosiebensat1digital.seventv/de.joyn.mobile.app.splash.SplashActivity}" drawable="joyn" name="Joyn" />
+  <item component="ComponentInfo{at.zappn/de.joyn.mobile.app.splash.SplashActivity}" drawable="joyn" name="Joyn" />
   <item component="ComponentInfo{music.ytstream.youtify/com.ryanheise.audioservice.AudioServiceActivity}" drawable="joytify" name="Joytify" />
   <item component="ComponentInfo{jp.jpmob.app/jp.jpmob.app.MainActivity}" drawable="jp_smart_sim" name="JP SMART SIM" />
   <item component="ComponentInfo{jp.co.jreast/jp.co.jreast.jreastapp.commuter.launchscreen.LaunchScreenActivity}" drawable="jr_east" name="JR East" />
@@ -8269,6 +8287,7 @@
   <item component="ComponentInfo{com.perm.kate/com.perm.kate.MainActivity}" drawable="kate_mobile" name="Kate Mobile" />
   <item component="ComponentInfo{com.perm.kate.mod/com.perm.kate.MainActivity}" drawable="kate_mobile" name="Kate Mobile" />
   <item component="ComponentInfo{de.combirisk.katwarn/de.combirisk.katwarn.MainActivity}" drawable="katwarn" name="KATWARN" />
+  <item component="ComponentInfo{at.gv.bmi.KATWARN/at.gv.bmi.KATWARN.MainActivity}" drawable="katwarn" name="KATWARN" />
   <item component="ComponentInfo{com.kaufland.Kaufland/com.kaufland.kaufland.splash.SplashActivity}" drawable="kaufland" name="Kaufland" />
   <item component="ComponentInfo{com.predidit.kazumi/com.example.kazumi.MainActivity}" drawable="kazumi" name="Kazumi" />
   <item component="ComponentInfo{com.kbc.mobile.android.phone.kbc/com.kbc.mobile.android.mbk.activities.SplashScreenActivity}" drawable="kbc" name="KBC" />
@@ -8514,6 +8533,7 @@
   <item component="ComponentInfo{com.kobobooks.android/com.kobobooks.android.screens.MainNavActivity}" drawable="kobo_books" name="Kobo Books" />
   <item component="ComponentInfo{com.kobobooks.android/com.google.android.archive.ReactivateActivity}" drawable="kobo_books" name="Kobo Books" />
   <item component="ComponentInfo{kodaforkustom.droidbeauty.pack/kodaforkustom.droidbeauty.pack.MainActivity}" drawable="koda_for_kustom" name="Koda for Kustom" />
+  <item component="ComponentInfo{kodaforkustom.droidbeauty.pack/dev.jahir.kuper.app.MainActivity}" drawable="koda_for_kustom" name="Koda for Kustom" />
   <item component="ComponentInfo{org.xbmc.kodi/org.xbmc.kodi.Splash}" drawable="kodi" name="Kodi" />
   <item component="ComponentInfo{org.xbmc.kodi/org.xbmc.kodi.Main}" drawable="kodi" name="Kodi" />
   <item component="ComponentInfo{ca.koho/ca.koho.MainActivity}" drawable="koho" name="KOHO" />
@@ -8810,6 +8830,7 @@
   <item component="ComponentInfo{com.boost.lg.remote/com.boost.lg.remote.ui.activity.SplashActivity}" drawable="android_tv_remote_service" name="LG TV Remote" />
   <item component="ComponentInfo{in.gaffarmart.www.tataskyremote/in.gaffarmart.www.tataskyremote.dispatcher_activity}" drawable="android_tv_remote_service" name="LG TV Remote" />
   <item component="ComponentInfo{com.lge.vvm/com.lge.vvm.ProvisioningStateMachine}" drawable="generic_voicemail" name="LG Voicemail" />
+  <item component="ComponentInfo{com.lge.vvm/com.lge.vvm.launcher.VVMLauncherActivity}" drawable="generic_voicemail" name="LG Voicemail" />
   <item component="ComponentInfo{ee.lhv.lhv/ee.lhv.lhv.activity.login.LoginActivity}" drawable="lhv" name="LHV" />
   <item component="ComponentInfo{com.overdrive.mobile.android.libby/com.overdrive.mobile.android.nautilus.ui.Activity_Main}" drawable="libby" name="Libby" />
   <item component="ComponentInfo{com.absinthe.libchecker/com.absinthe.libchecker.features.home.ui.MainActivity}" drawable="libchecker" name="LibChecker" />
@@ -9197,6 +9218,7 @@
   <item component="ComponentInfo{com.arlosoft.macrodroid/com.arlosoft.macrodroid.intro.IntroActivity}" drawable="macrodroid" name="MacroDroid" />
   <item component="ComponentInfo{com.arlosoft.macrodroid.helper/com.arlosoft.macrodroid.helper.ui.HomeScreenActivity}" drawable="macrodroid_helper" name="MacroDroid Helper" />
   <item component="ComponentInfo{com.sbs.diet/com.sbs.diet.MainActivity}" drawable="macrofactor" name="MacroFactor" />
+  <item component="ComponentInfo{com.sbs.diet/com.sbs.diet.MainActivityAlias}" drawable="macrofactor" name="MacroFactor" />
   <item component="ComponentInfo{com.berdik.macsposed/com.berdik.macsposed.ui.activity.MainActivity}" drawable="macsposed" name="MACsposed" />
   <item component="ComponentInfo{com.berdik.macsposed/com.berdik.macsposed.InstructionsActivity}" drawable="macsposed" name="MACsposed" />
   <item component="ComponentInfo{com.mada.madapay/com.emcrey.app.activities.SupportActivity}" drawable="mada_pay" name="mada Pay" />
@@ -9493,6 +9515,7 @@
   <item component="ComponentInfo{org.telegram.mdgram/org.telegram.mdgram.MaterialYou}" drawable="mdgram" name="MDGram" />
   <item component="ComponentInfo{org.telegram.mdgram/org.telegram.ui.LaunchActivityBlueIcon}" drawable="mdgram" name="MDGram" />
   <item component="ComponentInfo{com.akira.mdm/com.akira.manager.MainActivity}" drawable="mdm" name="MDM" />
+  <item component="ComponentInfo{com.akira.mdm/com.akira.mdm.MainActivity}" drawable="mdm" name="MDM" />
   <item component="ComponentInfo{com.stoik.mdscan/com.stoik.mdscan.MDScanActivity}" drawable="mdscan_plus_ocr" name="MDScan + OCR" />
   <item component="ComponentInfo{com.stoik.mdscan/com.stoik.mdscan.MainActivity}" drawable="mdscan_plus_ocr" name="MDScan + OCR" />
   <item component="ComponentInfo{com.xd.metapass/com.xd.metapass.ui.MainActivity}" drawable="me_pass" name="ME Pass" />
@@ -9821,6 +9844,7 @@
   <item component="ComponentInfo{com.google.android.gms/org.microg.nlp.ui.SettingsLauncherActivity}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{app.revanced.android.gms/org.microg.gms.ui.SettingsActivity}" drawable="microg_settings" name="microG Settings" />
   <item component="ComponentInfo{de.favo.mircophone/de.favo.mircophone.Microphone}" drawable="microphone" name="Microphone" />
+  <item component="ComponentInfo{net.bitplane.android.microphone/net.bitplane.android.microphone.MicrophoneActivity}" drawable="generic_microphone" name="Microphone" />
   <item component="ComponentInfo{com.ms.office365admin/com.ms.office365admin.MainActivity}" drawable="microsoft_365_admin" name="Microsoft 365 Admin" />
   <item component="ComponentInfo{com.ms.office365admin/com.ms.office365admin.SplashScreen}" drawable="microsoft_365_admin" name="Microsoft 365 Admin" />
   <item component="ComponentInfo{com.microsoft.office.officehub/com.microsoft.office.officesuite.OfficeSuiteActivity}" drawable="microsoft_365_copilot" name="Microsoft 365 Copilot" />
@@ -9844,6 +9868,7 @@
   <item component="ComponentInfo{com.microsoft.emmx/com.microsoft.ruby.Main2}" drawable="microsoft_edge" name="Microsoft Edge" />
   <item component="ComponentInfo{com.microsoft.emmx/com.microsoft.ruby.Main4}" drawable="microsoft_edge" name="Microsoft Edge" />
   <item component="ComponentInfo{com.microsoft.emmx.beta/com.microsoft.ruby.Main}" drawable="microsoft_edge_beta" name="Microsoft Edge Beta" />
+  <item component="ComponentInfo{com.microsoft.emmx.beta/com.microsoft.ruby.Main3}" drawable="microsoft_edge_beta" name="Microsoft Edge Beta" />
   <item component="ComponentInfo{com.microsoft.emmx.canary/com.google.android.apps.chrome.Main}" drawable="microsoft_edge_canary" name="Microsoft Edge Canary" />
   <item component="ComponentInfo{com.microsoft.emmx.canary/com.microsoft.ruby.Main}" drawable="microsoft_edge_canary" name="Microsoft Edge Canary" />
   <item component="ComponentInfo{com.microsoft.emmx.canary/com.microsoft.ruby.Main3}" drawable="microsoft_edge_canary" name="Microsoft Edge Canary" />
@@ -9966,6 +9991,7 @@
   <item component="ComponentInfo{com.mojang.minecraftpe46ng/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftpe682/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftqf/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
+  <item component="ComponentInfo{com.mojang.minecraftperclone/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecrafttrialpe/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft Trial" />
   <item component="ComponentInfo{com.panu/com.panu.SplashScreenActivity}" drawable="generic_minesweeper" name="Minesweeper" />
   <item component="ComponentInfo{Draziw.Button.Mines/minesweeper.Button.Mines.BoardViewActivity}" drawable="generic_minesweeper" name="Minesweeper" />
@@ -10114,6 +10140,8 @@
   <item component="ComponentInfo{in.mohalla.video/in.mohalla.sharechat.splash.SplashActivity}" drawable="moj" name="Moj" />
   <item component="ComponentInfo{in.mohalla.video/in.mohalla.sharechat.mojvideoplayer.MojVideoPlayerActivity}" drawable="moj" name="Moj" />
   <item component="ComponentInfo{pl.mojdhl.app/pl.mojdhl.app.MainActivity}" drawable="dhl" name="Moj DHL" />
+  <item component="ComponentInfo{com.next.innovation.takatak/com.mx.buzzify.activity.SplashActivity}" drawable="generic_player" name="Moj Lite" />
+  <item component="ComponentInfo{com.next.innovation.takatak/in.mohalla.sharechat.mojvideoplayer.MojVideoPlayerActivity}" drawable="generic_player" name="Moj Lite" />
   <item component="ComponentInfo{com.transart_media.novotel_app/com.transart_media.novotel_app.MainActivity}" drawable="moj_novotel" name="Moj novotel" />
   <item component="ComponentInfo{rs.Raiffeisen.mobile/eu.newfrontier.iBanking.mobile.raiffeisen.activities.RzbSplashScreenActivity}" drawable="raiffeisen_bank" name="Moja mBanka" />
   <item component="ComponentInfo{co.infinum.rba.eva/co.infinum.rba.eva.ui.splash.SplashActivity}" drawable="raiffeisen_bank" name="mojaRBA" />
@@ -11030,6 +11058,7 @@
   <item component="ComponentInfo{com.offsec.nethunter.store/org.fdroid.fdroid.views.main.MainActivity}" drawable="nethunter_store" name="NetHunter Store" />
   <item component="ComponentInfo{com.NetmedsMarketplace.Netmeds/com.netmedsmarketplace.netmeds.AppUriSchemeHandler}" drawable="netmeds" name="Netmeds" />
   <item component="ComponentInfo{com.NetmedsMarketplace.Netmeds/com.netmedsmarketplace.netmeds.screens.splash.SplashActivity}" drawable="netmeds" name="Netmeds" />
+  <item component="ComponentInfo{com.NetmedsMarketplace.Netmeds/com.netmedsmarketplace.netmeds.screens.activity.MainActivity}" drawable="netmeds" name="Netmeds" />
   <item component="ComponentInfo{cz.mroczis.netmonster/cz.mroczis.kotlin.presentation.main.MainActivity}" drawable="netmonster" name="NetMonster" />
   <item component="ComponentInfo{app.netpractice.app/app.netpractice.app.MainActivity}" drawable="netpractice" name="NetPractice" />
   <item component="ComponentInfo{com.edumobile3/com.edumobile3.MainActivity}" drawable="netschool" name="NetSchool" />
@@ -11037,6 +11066,7 @@
   <item component="ComponentInfo{br.com.netshoes.app/netshoes.com.napps.splash.SplashScreenActivity}" drawable="netshoes" name="Netshoes" />
   <item component="ComponentInfo{com.nisargjhaveri.netspeed/com.nisargjhaveri.netspeed.settings.SettingsActivity}" drawable="netspeed_indicator" name="NetSpeed Indicator" />
   <item component="ComponentInfo{com.valuephone.vpnetto/de.netto.b2c.activity.FragmentActivity}" drawable="netto" name="Netto" />
+  <item component="ComponentInfo{com.valuephone.vpnetto/de.netto.b2c.FragmentActivity}" drawable="netto" name="Netto" />
   <item component="ComponentInfo{pl.lebihan.network/pl.lebihan.network.RadioNetwork}" drawable="generic_dialer" name="Network" />
   <item component="ComponentInfo{net.techet.netanalyzerlite.an/net.techet.netanalyzerlite.an.activity.MainActivity}" drawable="network_analyzer" name="Network Analyzer" />
   <item component="ComponentInfo{net.techet.netanalyzer.an/net.techet.netanalyzer.an.activity.MainActivity}" drawable="network_analyzer_pro" name="Network Analyzer Pro" />
@@ -11240,6 +11270,7 @@
   <item component="ComponentInfo{com.android.notepads/com.android.notepads.note.view.NotePadMainActivity}" drawable="generic_notes" name="Notepad" />
   <item component="ComponentInfo{com.atomczak.notepat/com.atomczak.notepat.MainActivity}" drawable="samsung_notes" name="Notepad" />
   <item component="ComponentInfo{com.ztnstudio.notepad/com.ztnstudio.notepad.presentation.splash.SplashActivity}" drawable="notepad" name="Notepad" />
+  <item component="ComponentInfo{com.ztnstudio.notepad/com.ztnstudio.notepad.presentation.main.view.NoteListActivity}" drawable="notepad" name="Notepad" />
   <item component="ComponentInfo{uk.co.tdsstudios.noterly/uk.co.tdsstudios.noterly.MainActivity}" drawable="noterly" name="Noterly" />
   <item component="ComponentInfo{com.android.notes/com.android.notes.Notes}" drawable="generic_notes" name="Notes" />
   <item component="ComponentInfo{foundation.e.notes/it.niedermann.owncloud.notes.main.MainActivity}" drawable="generic_notes" name="Notes" />
@@ -11438,6 +11469,7 @@
   <item component="ComponentInfo{pt.pingodoce/pt.pingodoce.app.presentation.landing.splash.SplashActivity}" drawable="o_meu_pingo_doce" name="O Meu Pingo Doce" />
   <item component="ComponentInfo{com.coloros.relax/com.coloros.relax.function.MainActivity}" drawable="o_relax" name="O Relax" />
   <item component="ComponentInfo{com.coloros.relax/com.coloros.relax.ui.MainActivity}" drawable="o_relax" name="O Relax" />
+  <item component="ComponentInfo{com.oneplus.relax/com.coloros.relax.ui.MainActivity}" drawable="o_relax" name="O Relax" />
   <item component="ComponentInfo{com.safariflow.queue/oreilly.queue.ContentNavigationActivity}" drawable="oreilly" name="O'Reilly" />
   <item component="ComponentInfo{com.safariflow.queue/oreilly.queue.SplashActivity}" drawable="oreilly" name="O'Reilly" />
   <item component="ComponentInfo{canvasm.myo2/com.tuenti.messenger.ui.activity.MainActivity}" drawable="o2" name="O2" />
@@ -11812,6 +11844,7 @@
   <item component="ComponentInfo{com.opera.browser.beta/com.opera.android.OperaStartActivity}" drawable="opera_beta" name="Opera Beta" />
   <item component="ComponentInfo{com.opera.browser.beta/com.opera.Opera}" drawable="opera_beta" name="Opera Beta" />
   <item component="ComponentInfo{com.opera.browser.beta/com.opera.Launcher5}" drawable="opera_beta" name="Opera Beta" />
+  <item component="ComponentInfo{com.opera.browser.beta/com.opera.Launcher6}" drawable="opera_beta" name="Opera Beta" />
   <item component="ComponentInfo{com.opera.gx/com.opera.gx.MainActivity}" drawable="opera_gx" name="Opera GX" />
   <item component="ComponentInfo{com.opera.mini.native/com.opera.mini.android.Browser}" drawable="opera_mini" name="Opera Mini" />
   <item component="ComponentInfo{com.opera.mini.native/com.opera.android.Default}" drawable="opera_mini" name="Opera Mini" />
@@ -12039,6 +12072,7 @@
   <item component="ComponentInfo{com.digitalbore.papertag/com.digitalbore.papertag.MainActivity}" drawable="papertag" name="Papertag" />
   <item component="ComponentInfo{com.ojhdtapp.parabox/com.ojhdtapp.parabox.MainActivity}" drawable="parabox" name="Parabox" />
   <item component="ComponentInfo{com.tunergames.paradigm/com.unity3d.player.UnityPlayerActivity}" drawable="paradigm_reboot" name="Paradigm: Reboot" />
+  <item component="ComponentInfo{com.tunergames.paradigm/com.tunergames.paradigm.AprilFoolDefaultLauncherAlias}" drawable="paradigm_reboot" name="Paradigm: Reboot" />
   <item component="ComponentInfo{com.reactcorp.cocalero/com.reactcorp.cocalero.MainActivity}" drawable="parallel" name="Parallel" />
   <item component="ComponentInfo{com.lbe.parallel.intl/com.lbe.parallel.ui.tour.SplashActivity}" drawable="parallel_space" name="Parallel Space" />
   <item component="ComponentInfo{com.lbe.parallel.intl.arm64/com.lbe.doubleagent.MainActivity}" drawable="parallel_space" name="Parallel Space" />
@@ -12096,6 +12130,7 @@
   <item component="ComponentInfo{com.arrow.wallpapers.pastelwall/com.arrow.wallpapers.pastelwall.activity.SplashScreen}" drawable="pastel_wallpapers" name="Pastel Wallpapers" />
   <item component="ComponentInfo{com.arrow.wallpapers.pastelwall/com.arrow.wallpapers.pastelwall.activities.ActivitySplash}" drawable="pastel_wallpapers" name="Pastel Wallpapers" />
   <item component="ComponentInfo{com.gmg.pastel.lina.iconpack/com.gmg.pastel.lina.iconpack.activities.SplashActivity}" drawable="pastelina_icons" name="PasteLina Icons" />
+  <item component="ComponentInfo{com.gmg.pastel.lina.iconpack/com.gmg.pastel.lina.iconpack.activities.MainActivity}" drawable="pastelina_icons" name="Pastelina Icons" />
   <item component="ComponentInfo{com.digidiced.pxwrelease/com.unity3d.player.UnityPlayerActivity}" drawable="patchwork" name="Patchwork" />
   <item component="ComponentInfo{com.patelco.patelco/com.patelco.patelco.MainActivity}" drawable="patelco" name="Patelco" />
   <item component="ComponentInfo{com.pathao.user/com.pathao.user.ui.core.splash.SplashActivity}" drawable="pathao" name="Pathao" />
@@ -12810,6 +12845,7 @@
   <item component="ComponentInfo{com.sodexo.app.pt/es.alt10.project.android.MainAppActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{com.sodexo.consumers.colombia/com.sodexo.consumers.SplashActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{com.sodexo.flexogift/com.sodexo.flexogift.MainActivity}" drawable="pluxee" name="Pluxee" />
+  <item component="ComponentInfo{com.pluxeegroup.consumers.global/com.pluxeegroup.consumers.global.MainActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{com.Version1/com.Version1.Version1}" drawable="pnb_one" name="PNB ONE" />
   <item component="ComponentInfo{com.Version1/com.Version1.MainActivity}" drawable="pnb_one" name="PNB ONE" />
   <item component="ComponentInfo{in.pnb.pnbparivaar/in.pnb.pnbparivaar.MainActivity}" drawable="pnb_one" name="PNB Parivar" />
@@ -12911,6 +12947,7 @@
   <item component="ComponentInfo{com.ss.popupWidget/com.ss.popupWidget.PopupWidgetActivity}" drawable="popup_widget" name="Popup Widget" />
   <item component="ComponentInfo{com.aaronjwood.portauthority.free/com.aaronjwood.portauthority.activity.MainActivity}" drawable="port_authority" name="Port Authority" />
   <item component="ComponentInfo{pl.plksa.portalpasazera/crc64cc116f7452d542b7.SplashActivity}" drawable="portal_pasazera" name="Portal Pasażera" />
+  <item component="ComponentInfo{pl.plksa.portalpasazera/pl.plksa.portalpasazera.MainActivity}" drawable="portal_pasazera" name="Portal Pasażera" />
   <item component="ComponentInfo{com.stealthcopter.portdroid/com.stealthcopter.portdroid.activities.StartActivity}" drawable="portdroid" name="PortDroid" />
   <item component="ComponentInfo{br.com.portoseguro.experienciacliente.mundoporto/br.com.portoseguro.superapp.ui.splash.SplashActivity}" drawable="porto" name="Porto" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.portuguese/com.anysoftkeyboard.languagepack.portuguese.MainActivity}" drawable="anysoftkeyboard" name="Portugese for AnySoftKeyboard" />
@@ -13311,6 +13348,7 @@
   <item component="ComponentInfo{quick.nnkhire.quickpercentage/quick.nnkhire.quickpercentage.MainActivity}" drawable="quick_percentage_calculator" name="Quick Percentage Calculator" />
   <item component="ComponentInfo{com.tk.quicksearch/com.tk.quicksearch.app.MainActivity}" drawable="quick_search" name="Quick Search" />
   <item component="ComponentInfo{com.tk.quicksearch/com.tk.quicksearch.MainActivity}" drawable="quick_search" name="Quick Search" />
+  <item component="ComponentInfo{com.tk.quicksearch/com.tk.quicksearch.app.MainActivityAliasDefault}" drawable="quick_search" name="Quick Search" />
   <item component="ComponentInfo{it.simonesestito.ntiles/it.simonesestito.ntiles.MainSplash}" drawable="quick_settings" name="Quick Settings" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.QuickShareShortcut}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share (Google Shortcuts Launcher)" />
   <item component="ComponentInfo{com.rhmsoft.edit/com.rhmsoft.edit.activity.MainActivity}" drawable="quickedit" name="QuickEdit" />
@@ -14207,6 +14245,7 @@
   <item component="ComponentInfo{com.thisisaim.yourlanguage/au.com.sbs.mobilex.radio.modules.splash.SplashActivity}" drawable="sbs_audio" name="SBS Audio" />
   <item component="ComponentInfo{com.sbs.worldnewsaustralia/au.com.sbs.mobilex.news.modules.splash.SplashActivity}" drawable="sbs_news" name="SBS News" />
   <item component="ComponentInfo{com.sbs.ondemand.android/com.sbs.ondemand.ui.MainActivity}" drawable="sbs_on_demand" name="SBS On Demand" />
+  <item component="ComponentInfo{com.sbs.ondemand.android/com.sbs.ondemand.MainActivity}" drawable="sbs_on_demand" name="SBS On Demand" />
   <item component="ComponentInfo{capital.scalable.droid/capital.scalable.droid.overlay.cockpit.screen.CockpitActivity}" drawable="scalable_capital" name="Scalable Capital" />
   <item component="ComponentInfo{capital.scalable.droid/capital.scalable.droid.redesign.screens.cockpit.CockpitActivity}" drawable="scalable_capital" name="Scalable Capital" />
   <item component="ComponentInfo{com.scalapay.scalapay_customer_app/com.scalapay.scalapay_customer_app.MainActivity}" drawable="scalapay" name="Scalapay" />
@@ -15770,6 +15809,7 @@
   <item component="ComponentInfo{com.statista.dailydata/com.statista.dailydata.MainActivity}" drawable="statista" name="Statista" />
   <item component="ComponentInfo{dev.netlob.spotistats/dev.netlob.spotistats.MainActivity}" drawable="stats_fm" name="stats.fm" />
   <item component="ComponentInfo{im.status.ethereum/im.status.ethereum.MainActivity}" drawable="status" name="Status" />
+  <item component="ComponentInfo{app.status.mobile/app.status.mobile.StatusQtActivity}" drawable="status" name="Status" />
   <item component="ComponentInfo{com.downlood.sav.whmedia/com.downlood.sav.whmedia.Activity.SplashScreenActivity}" drawable="status_download" name="Status Download" />
   <item component="ComponentInfo{statussaver.statusdownloader.downloadstatus.videoimagesaver/statussaver.statusdownloader.downloadstatus.videoimagesaver.app.ui.splash.SplashActivity}" drawable="download_twitter_videos" name="Status Saver" />
   <item component="ComponentInfo{savestatus.videodownloader.storysaver.statuskeeper/savestatus.videodownloader.storysaver.statuskeeper.app.ui.splash.SplashActivity}" drawable="download_twitter_videos" name="Status Saver" />
@@ -16155,7 +16195,6 @@
   <item component="ComponentInfo{com.tailscale.ipn/org.gioui.GioActivity}" drawable="tailscale" name="Tailscale" />
   <item component="ComponentInfo{com.tailscale.ipn/com.tailscale.ipn.IPNActivity}" drawable="tailscale" name="Tailscale" />
   <item component="ComponentInfo{gov.taipei.pass/gov.taipei.card.activity.MainActivity}" drawable="taipeipass" name="TaipeiPASS" />
-  <item component="ComponentInfo{com.next.innovation.takatak/com.mx.buzzify.activity.SplashActivity}" drawable="generic_player" name="Takatak" />
   <item component="ComponentInfo{be.pizza.android/com.takeaway.android.activity.Splash}" drawable="just_eat" name="Takeaway" />
   <item component="ComponentInfo{be.pizza.android/com.takeaway.android.Startup}" drawable="just_eat" name="Takeaway" />
   <item component="ComponentInfo{ch.lieferservice.android/com.takeaway.android.activity.Splash}" drawable="just_eat" name="Takeaway" />
@@ -16455,6 +16494,7 @@
   <item component="ComponentInfo{image.to.text.ocr/image.to.text.ocr.activity.MainActivity}" drawable="text_scanner" name="Text Scanner" />
   <item component="ComponentInfo{com.contactstopdfconverter.app.androidx/com.contactstopdfconverter.app.androidx.SplashScreen}" drawable="generic_pdf_file" name="Text to PDF" />
   <item component="ComponentInfo{com.stcodesapp.text2speech/com.stcodesapp.text2speech.ui.activities.SplashActivity}" drawable="text_to_speech" name="Text To Speech" />
+  <item component="ComponentInfo{com.stcodesapp.text2speech/com.stcodesapp.text2speech.ui.splash.SplashActivity}" drawable="text_to_speech" name="Text To Speech" />
   <item component="ComponentInfo{com.corphish.quicktools/com.corphish.quicktools.activities.MainActivity}" drawable="text_tools" name="Text Tools" />
   <item component="ComponentInfo{com.corphish.quicktools/com.corphish.quicktools.activities.RouterActivity}" drawable="text_tools" name="Text Tools" />
   <item component="ComponentInfo{softmaker.applications.office.textmaker/softmaker.applications.textmaker.TextMaker}" drawable="textmaker" name="TextMaker" />
@@ -16934,6 +16974,7 @@
   <item component="ComponentInfo{jp.tokyo.metro.kotsu.toei.naviapp/jp.tokyo.metro.kotsu.toei.naviapp.MainActivity}" drawable="toei_transportation" name="TOEI TRANSPORTATION" />
   <item component="ComponentInfo{com.banglalink.toffee/com.banglalink.toffee.ui.home.HomeActiv}" drawable="toffee" name="Toffee" />
   <item component="ComponentInfo{com.banglalink.toffee/com.banglalink.toffee.ui.splash.SplashScreenActivity}" drawable="toffee" name="Toffee" />
+  <item component="ComponentInfo{com.banglalink.toffee/com.mobiotics.vlive.android.ui.splash.SplashActivity}" drawable="toffee" name="Toffee" />
   <item component="ComponentInfo{com.togetherprice/com.togetherprice.MainActivity}" drawable="together_price" name="Together Price" />
   <item component="ComponentInfo{com.toggl.giskard/com.toggl.ui.MainActivity}" drawable="toggl_track" name="Toggl Track" />
   <item component="ComponentInfo{blue.tokimeki.tokimeki/blue.tokimeki.tokimeki.MainActivity}" drawable="tokimeki_for_bluesky" name="TOKIMEKI for Bluesky" />
@@ -17137,6 +17178,7 @@
   <item component="ComponentInfo{com.errorsevendev.games.trikky/com.unity3d.player.UnityPlayerActivity}" drawable="trikky" name="Trikky" />
   <item component="ComponentInfo{com.osfans.trime/com.osfans.trime.PrefLauncherAlias}" drawable="trime" name="Trime" />
   <item component="ComponentInfo{com.osfans.trime/com.osfans.trime.Pref}" drawable="trime" name="Trime" />
+  <item component="ComponentInfo{com.osfans.trime/com.osfans.trime.MainLauncherAlias}" drawable="trime" name="Trime" />
   <item component="ComponentInfo{ctrip.english/com.ctrip.ibu.myctrip.main.module.home.IBUHomeActivity}" drawable="trip_com" name="Trip.com" />
   <item component="ComponentInfo{ctrip.english/com.ctrip.ibu.myctrip.main.module.home.IBUHomeAct}" drawable="trip_com" name="Trip.com" />
   <item component="ComponentInfo{ctrip.english/com.ctrip.ibu.myctrip.main.module.home.IBUHomeActivity.alias}" drawable="trip_com" name="Trip.com" />
@@ -17204,6 +17246,7 @@
   <item component="ComponentInfo{app.fedilab.tubelab/app.fedilab.fedilabtube.MainActivity}" drawable="tubelab" name="TubeLab" />
   <item component="ComponentInfo{app.fedilab.tubelab/app.fedilab.fedilabtube.activities.MainActivity}" drawable="tubelab" name="TubeLab" />
   <item component="ComponentInfo{devian.tubemate.v3/devian.tubemate.v3.Main}" drawable="tubemate" name="TubeMate" />
+  <item component="ComponentInfo{devian.tubemate.home/devian.tubemate.home.Main}" drawable="tubemate" name="TubeMate" />
   <item component="ComponentInfo{com.tubitv/com.tubitv.activities.MainActivity}" drawable="tubi" name="Tubi" />
   <item component="ComponentInfo{org.polymorphicshade.tubular/org.schabi.newpipe.MainActivity}" drawable="tubular" name="Tubular" />
   <item component="ComponentInfo{com.tuentiargentina/com.tuentiargentina.MainActivity}" drawable="tuenti" name="Tuenti" />
@@ -17802,6 +17845,7 @@
   <item component="ComponentInfo{com.nemo.vidmate/com.nemo.vidmate.WelcomeActivity}" drawable="video_fun" name="Video Fun" />
   <item component="ComponentInfo{com.naing.vwallpaper/com.naing.vwallpaper.MainActivity}" drawable="video_live_wallpaper" name="Video Live Wallpaper" />
   <item component="ComponentInfo{me.craftsapp.video.wallpaper/me.craftsapp.video.wallpaper.SplashActivity}" drawable="video_live_wallpapers" name="Video Live Wallpapers" />
+  <item component="ComponentInfo{me.craftsapp.video.wallpaper/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="video_live_wallpapers" name="Video Live Wallpapers" />
   <item component="ComponentInfo{videoeditor.videomaker.videoeditorforyoutube/com.camerasideas.instashot.main.MainActivity}" drawable="video_maker" name="Video Maker" />
   <item component="ComponentInfo{com.fundevs.app.mediaconverter/com.fundevs.app.mediaconverter.SplashActivity}" drawable="video_mp3_converter" name="Video MP3 Converter" />
   <item component="ComponentInfo{com.videoplayer.arcplayer/com.teeter.videoplayer.SplashActivity}" drawable="video_player_all_format" name="Video Player All Format" />
@@ -18575,6 +18619,7 @@
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.vpn.splash.SplashActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.vpn.ui.activities.EntryPointActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.ui.AppStartActivity}" drawable="windscribe" name="Windscribe" />
+  <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.ui.preferences.icons.GlitchScribeActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windyty.android/com.windyty.android.MainActivity}" drawable="windy" name="Windy" />
   <item component="ComponentInfo{com.windyty.android/com.windyty.android.Standard}" drawable="windy" name="Windy" />
   <item component="ComponentInfo{com.wingos.wingcamera/com.wingos.wingcamera.Camera}" drawable="generic_camera" name="WingOS Camera" />
@@ -18961,6 +19006,7 @@
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/app.revanced.android.apps.youtube.music.revanced_original_2}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.android.youtube.music.premium/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="generic_player_pro" name="YouTube Music" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_original_2}" drawable="generic_player" name="YouTube Music Morphe" />
+  <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_2}" drawable="morphe" name="YouTube Music Morphe" />
   <item component="ComponentInfo{anddea.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.rvx.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
@@ -19182,8 +19228,10 @@
   <item component="ComponentInfo{com.zoho.lens.customer/com.zoho.lens.technician.compose.OnBoardActivity}" drawable="zoho_lens" name="Zoho Lens" />
   <item component="ComponentInfo{com.zoho.mail/com.zoho.mail.android.activities.Login}" drawable="zoho_mail" name="Zoho Mail" />
   <item component="ComponentInfo{com.zoho.notebook/com.zoho.notebook.activities.NoteBookActivity}" drawable="zoho_notebook" name="Zoho Notebook" />
+  <item component="ComponentInfo{com.zoho.notebook/com.zoho.notebook.activities.DefaultIconAlias}" drawable="zoho_notebook" name="Zoho Notebook" />
   <item component="ComponentInfo{com.zoho.zohoone/com.zoho.zohoone.applock.AppLockActivity}" drawable="zoho_one" name="Zoho One" />
   <item component="ComponentInfo{com.zoho.zohoone/com.zoho.zohoone.splash.SplashScreenActivity}" drawable="zoho_one" name="Zoho One" />
+  <item component="ComponentInfo{com.zoho.zohooneuser/com.zoho.zohooneuser.AppLockActivity}" drawable="zoho_one" name="Zoho One" />
   <item component="ComponentInfo{com.zoho.accounts.oneauth/com.zoho.accounts.oneauth.v2.ui.login.WalkthroughActivity}" drawable="zoho_oneauth" name="Zoho OneAuth" />
   <item component="ComponentInfo{com.zoho.accounts.oneauth/com.zoho.accounts.oneauth.v2.ui.applock.AppLockActivity}" drawable="zoho_oneauth" name="Zoho OneAuth" />
   <item component="ComponentInfo{com.zoho.projects/com.zoho.projects.android.activity.ZohoProjectsLogin}" drawable="zoho_projects" name="Zoho Projects" />


### PR DESCRIPTION
## Linked
ACT Fibernet (`com.act.mobile.apps` → `act_fibernet.svg`)
AppShare (`info.muge.appshare` → `appshare.svg`)
Aura Icons (`studio14.application.auraicons` → `aura_icons.svg`)
BatteryOne (`com.oneapps.batteryone` → `batteryone.svg`)
BUFF (`com.netease.buff` → `buff.svg`)
Bus Simulator Indonesia (`com.maleo.hendra.channel` → `bus_simulator_indonesia.svg`)
CAIXA Tem (`br.gov.caixa.tem` → `caixa_tem.svg`)
Calculator Lock (`calculatorlock.calculatorvault.photovault.hider` → `generic_calculator_plus_minus_multi_equal.svg`)
CodyCross (`com.fanatee.cody` → `codycross.svg`)
Coppel (`com.coppel.coppelapp` → `bancoppel.svg`)
Deutsche Bank (`com.db.pwcc.dbmobile` → `deutsche_bank.svg`)
Discord (`com.discore` → `discord.svg`)
eGovPH (`egov.app` → `egovph.svg`)
Fossify Launcher (`org.fossify.home` → `fossify_launcher.svg`)
Gallery (`com.miui.gallery` → `generic_gallery.svg`)
Game Booster (`com.g19mobile.gamebooster` → `game_booster.svg`)
Geizhals (`at.geizhals.pv` → `geizhals.svg`)
Joyn (`at.zappn` → `joyn.svg`)
KATWARN (`at.gv.bmi.KATWARN` → `katwarn.svg`)
Koda for Kustom (`kodaforkustom.droidbeauty.pack` → `koda_for_kustom.svg`)
LG Voicemail (`com.lge.vvm` → `generic_voicemail.svg`)
MacroFactor (`com.sbs.diet` → `macrofactor.svg`)
MDM (`com.akira.mdm` → `mdm.svg`)
Microphone (`net.bitplane.android.microphone` → `generic_microphone.svg`)
Microsoft Edge Beta (`com.microsoft.emmx.beta` → `microsoft_edge_beta.svg`)
Minecraft (`com.mojang.minecraftperclone` → `minecraft.svg`)
Moj Lite (`com.next.innovation.takatak` → `generic_player.svg`)
Netmeds (`com.NetmedsMarketplace.Netmeds` → `netmeds.svg`)
Netto (`com.valuephone.vpnetto` → `netto.svg`)
Notepad (`com.ztnstudio.notepad` → `notepad.svg`)
O Relax (`com.oneplus.relax` → `o_relax.svg`)
Opera Beta (`com.opera.browser.beta` → `opera_beta.svg`)
Paradigm: Reboot (`com.tunergames.paradigm` → `paradigm_reboot.svg`)
Pastelina Icons (`com.gmg.pastel.lina.iconpack` → `pastelina_icons.svg`)
Pluxee (`com.pluxeegroup.consumers.global` → `pluxee.svg`)
Portal Pasażera (`pl.plksa.portalpasazera` → `portal_pasazera.svg`)
Quick Search (`com.tk.quicksearch` → `quick_search.svg`)
SBS On Demand (`com.sbs.ondemand.android` → `sbs_on_demand.svg`)
Status (`app.status.mobile` → `status.svg`)
Text To Speech (`com.stcodesapp.text2speech` → `text_to_speech.svg`)
Toffee (`com.banglalink.toffee` → `toffee.svg`)
Trime (`com.osfans.trime` → `trime.svg`)
TubeMate (`devian.tubemate.home` → `tubemate.svg`)
Video Live Wallpapers (`me.craftsapp.video.wallpaper` → `video_live_wallpapers.svg`)
Windscribe (`com.windscribe.vpn` → `windscribe.svg`)
YouTube Music Morphe (`app.morphe.android.apps.youtube.music` → `morphe.svg`)
Zoho Notebook (`com.zoho.notebook` → `zoho_notebook.svg`)
Zoho One (`com.zoho.zohooneuser` → `zoho_one.svg`)