### PR TITLE
+20 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -663,6 +663,7 @@
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.in/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.ca/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.au/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
+  <item component="ComponentInfo{com.americanexpress.android.acctsvcs.mx/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.b2w.americanas/com.b2w.main.activity.MainActivity}" drawable="americanas" name="Americanas" />
   <item component="ComponentInfo{com.vitorpamplona.amethyst/com.vitorpamplona.amethyst.ui.MainActivity}" drawable="amethyst" name="Amethyst" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.nl/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="Amex" />
@@ -969,6 +970,7 @@
   <item component="ComponentInfo{com.fankes.apperrorsdemo/com.fankes.apperrorsdemo.ui.activity.MainActivity}" drawable="apperrorstracking" name="AppErrorsDemo" />
   <item component="ComponentInfo{com.fankes.apperrorstracking/com.fankes.apperrorstracking.Home}" drawable="apperrorstracking" name="AppErrorsTracking" />
   <item component="ComponentInfo{com.appkb.android.twint/ch.twint.payment.ui.activities.start.StartActivity}" drawable="appkb_twint" name="APPKB TWINT" />
+  <item component="ComponentInfo{com.example.libusbAndroidTest/com.example.libusbAndroidTest.MainActivity}" drawable="drivedroid" name="Apple Dongle Volume Fixer" />
   <item component="ComponentInfo{com.gitlab.ardash.appleflinger.android/com.gitlab.ardash.appleflinger.android.AndroidLauncher}" drawable="apple_flinger" name="Apple Flinger" />
   <item component="ComponentInfo{com.apple.android.music/com.apple.android.music.onboarding.activities.SplashActivity}" drawable="apple_music" name="Apple Music" />
   <item component="ComponentInfo{com.apple.android.music/.onboarding.activities.SplashActivity}" drawable="apple_music" name="Apple Music" />
@@ -4623,6 +4625,7 @@
   <item component="ComponentInfo{me.blog.korn123.easydiary/me.blog.korn123.easydiary.activities.DiaryMainActivity.EasyDiary}" drawable="easy_diary" name="Easy Diary" />
   <item component="ComponentInfo{com.chornerman.easydpichanger/com.chornerman.easydpichanger.MainActivity}" drawable="easy_dpi_changer" name="Easy DPI Changer" />
   <item component="ComponentInfo{com.easyfastapp.app/com.easyfastapp.app.MainActivity}" drawable="easy_fast" name="Easy Fast" />
+  <item component="ComponentInfo{easy.launcher/easy.launcher.ime.promo.ImePromoActivity}" drawable="generic_keyboard" name="Easy Keyboard" />
   <item component="ComponentInfo{app.easy.launcher/com.github.droidworksstudio.launcher.ui.activities.MainActivity}" drawable="easy_launcher" name="Easy Launcher" />
   <item component="ComponentInfo{notes.notepad.checklist.calendar.todolist.notebook/notes.notepad.checklist.calendar.todolist.notebook.page.WelcomeActivity}" drawable="easy_notebook" name="Easy Notebook" />
   <item component="ComponentInfo{notes.notepad.checklist.calendar.todolist.notebook/notes.notepad.checklist.calendar.todolist.notebook.page.welcome.WelcomeActivity}" drawable="easy_notebook" name="Easy Notebook" />
@@ -4806,6 +4809,7 @@
   <item component="ComponentInfo{com.dustyroom.Empty/com.unity3d.player.UnityPlayerActivity}" drawable="empty" name="Empty." />
   <item component="ComponentInfo{com.endel.endel/com.endel.endel.use_cases.root.RootActivity}" drawable="endel" name="Endel" />
   <item component="ComponentInfo{es.awg.movilidadEOL/com.enel.enel_global_app.MainActivity}" drawable="endesa" name="Endesa" />
+  <item component="ComponentInfo{com.enel.mobile.endesaPT/com.enel.mobile.endesaPT.MainActivity}" drawable="endesa" name="Endesa" />
   <item component="ComponentInfo{com.timleg.quizPro/com.timleg.quiz.Game}" drawable="endless_quiz" name="Endless Quiz" />
   <item component="ComponentInfo{it.enel/com.example.it_full_digital.MainActivity}" drawable="enel" name="Enel" />
   <item component="ComponentInfo{it.enel/crc64d0549c3f31f5415a.SplashActivity}" drawable="enel" name="Enel" />
@@ -5061,6 +5065,7 @@
   <item component="ComponentInfo{com.blogspot.newapphorizons.fakegps/com.blogspot.newapphorizons.fakegps.MainActivity}" drawable="fake_gps_byterev" name="Fake GPS ByteRev" />
   <item component="ComponentInfo{com.lexa.fakegps/com.lexa.fakegps.TickToint}" drawable="fake_gps_location" name="Fake GPS location" />
   <item component="ComponentInfo{com.lexa.fakegps/com.lexa.fakegps.ui.Main}" drawable="fake_gps_location" name="Fake GPS location" />
+  <item component="ComponentInfo{com.hopefactory2021.fakegpslocation/com.hopefactory2021.fakegpslocation.MainActivity}" drawable="mock_locations" name="Fake GPS Location" />
   <item component="ComponentInfo{com.lerist.fakelocation/com.lerist.fakelocation.ui.activity.MainActivity}" drawable="fake_location" name="Fake Location" />
   <item component="ComponentInfo{cl.coders.faketraveler/cl.coders.faketraveler.MainActivity}" drawable="faketraveler" name="FakeTraveler" />
   <item component="ComponentInfo{com.Mediatonic.FallGuys_client/com.unity3d.player.UnityPlayerActivity}" drawable="fall_guys" name="Fall Guys" />
@@ -6219,6 +6224,7 @@
   <item component="ComponentInfo{com.google.android.inputmethod.latin/com.google.android.apps.inputmethod.libs.framework.core.LauncherActivity}" drawable="gboard" name="Gboard" />
   <item component="ComponentInfo{com.google.android.inputmethod.latin/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="Gboard" />
   <item component="ComponentInfo{com.google.android.inputmethod.latin.adobo/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="Gboard" />
+  <item component="ComponentInfo{com.google.android.inputmethod.morphe/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="Gboard Morphe" />
   <item component="ComponentInfo{com.google.android.inputmethod.latis/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="GboardMd" />
   <item component="ComponentInfo{com.gbox.android/com.gbox.android.SplashActivity}" drawable="gbox" name="GBox" />
   <item component="ComponentInfo{com.gbwhatsapp/com.gbwhatsapp.Icon0}" drawable="whatsapp" name="GBWhatsApp" />
@@ -7542,6 +7548,7 @@
   <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app/jp.ne.ibis.ibispaintx.app.InitializeCheckActivity}" drawable="ibis_paint" name="ibis Paint X" />
   <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app/com.google.android.archive.ReactivateActivity}" drawable="ibis_paint" name="ibis Paint X" />
   <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app/com.min.n.MainActivity}" drawable="ibis_paint" name="ibis Paint X" />
+  <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app.hms/jp.ne.ibis.ibispaintx.app.InitializeCheckActivity}" drawable="ibis_paint" name="ibis Paint X" />
   <item component="ComponentInfo{atws.app/tws.activity.launcher.LauncherActivity}" drawable="ibkr" name="IBKR" />
   <item component="ComponentInfo{atws.app/atws.activity.launcher.LauncherActivity}" drawable="ibkr" name="IBKR" />
   <item component="ComponentInfo{com.ibm.security.verifyapp/com.ibm.security.verifyapp.activities.LaunchActivity}" drawable="ibm_verify" name="IBM Verify" />
@@ -8162,6 +8169,7 @@
   <item component="ComponentInfo{at.zappn/de.joyn.mobile.app.splash.SplashActivity}" drawable="joyn" name="Joyn" />
   <item component="ComponentInfo{music.ytstream.youtify/com.ryanheise.audioservice.AudioServiceActivity}" drawable="joytify" name="Joytify" />
   <item component="ComponentInfo{jp.jpmob.app/jp.jpmob.app.MainActivity}" drawable="jp_smart_sim" name="JP SMART SIM" />
+  <item component="ComponentInfo{com.aconvert.jpg2pdf/com.aconvert.jpg2pdf.MainActivity}" drawable="generic_pdf_square" name="JPG to PDF Converter" />
   <item component="ComponentInfo{jp.co.jreast/jp.co.jreast.jreastapp.commuter.launchscreen.LaunchScreenActivity}" drawable="jr_east" name="JR East" />
   <item component="ComponentInfo{jp.co.jrkyushu.jrqapp/jp.co.jrkyushu.jrqapp.MainActivity}" drawable="jr_east" name="JR East" />
   <item component="ComponentInfo{jp.co.jreast.jrepoint/jp.co.jreast.jrepoint.controller.boot.StartActivity}" drawable="jre_point" name="JRE POINT" />
@@ -9392,6 +9400,7 @@
   <item component="ComponentInfo{com.akira.material/com.akira.material.MainActivityMaterialYou}" drawable="material" name="Material" />
   <item component="ComponentInfo{com.numero.material_gallery/com.numero.material_gallery.MainActivity}" drawable="compose_material_catalog" name="Material Components Gallery" />
   <item component="ComponentInfo{io.materialdesign.catalog/io.materialdesign.catalog.main.MainActivity}" drawable="compose_material_catalog" name="Material Design Components" />
+  <item component="ComponentInfo{material.expressive.kwgt/material.expressive.kwgt.MainActivity}" drawable="m3_expressive_widgets" name="Material Expressive Widget" />
   <item component="ComponentInfo{me.zhanghai.android.files/me.zhanghai.android.files.filelist.FileListActivity}" drawable="generic_files" name="Material Files" />
   <item component="ComponentInfo{com.hippotech.materialislands/com.hippotech.materialislands.MainActivity}" drawable="material_islands" name="Material Islands" />
   <item component="ComponentInfo{com.maelchiotti.localmaterialnotes/com.maelchiotti.localmaterialnotes.MainActivity}" drawable="material_notes" name="Material Notes" />
@@ -10126,6 +10135,7 @@
   <item component="ComponentInfo{com.mobvoi.companion.at/com.mobvoi.companion.aw.ui.main.HomeActivity}" drawable="mobvoi_health" name="Mobvoi Health" />
   <item component="ComponentInfo{pl.nask.mobywatel/pl.gov.mc.fringers.mobywatel.MainActivity}" drawable="mobywatel" name="mObywatel" />
   <item component="ComponentInfo{ru.gavrikov.mocklocations/ru.gavrikov.mocklocations.ui.PreloadActivity}" drawable="mock_locations" name="Mock Locations" />
+  <item component="ComponentInfo{com.lilstiffy.mockgps/com.lilstiffy.mockgps.MainActivity}" drawable="mock_locations" name="MockGps" />
   <item component="ComponentInfo{com.gamedevltd.modernstrike/com.google.firebase.MessagingUnityPlayerActivity}" drawable="modern_strike_online" name="Modern Strike Online" />
   <item component="ComponentInfo{com.Shooter.ModernWarships/com.unity3d.player.UnityPlayerActivity}" drawable="modern_warships" name="Modern Warships" />
   <item component="ComponentInfo{com.playdigital.modo/com.playdigital.modo.MainActivity}" drawable="modo" name="MODO" />
@@ -12191,6 +12201,7 @@
   <item component="ComponentInfo{com.pcloud.pcloud/com.pcloud.screens.Main}" drawable="pcloud" name="pCloud" />
   <item component="ComponentInfo{com.kohei.android.pcmrecorder/com.kohei.android.pcmrecorder.MainActivity}" drawable="pcm_recorder" name="PCM Recorder" />
   <item component="ComponentInfo{id.co.limasakti.pdaminfo/id.co.limasakti.pdaminfo.feature.activity.SplashScreenActivity}" drawable="pdam_info" name="PDAM INFO" />
+  <item component="ComponentInfo{com.vayunmathur.pdf/com.vayunmathur.pdf.MainActivity}" drawable="pdf_viewer_plus" name="PDF" />
   <item component="ComponentInfo{swati4star.createpdf/swati4star.createpdf.activity.MainActivity}" drawable="pdf_converter" name="PDF CONVERTER" />
   <item component="ComponentInfo{swati4star.createpdf/swati4star.createpdf.activity.SplashActivity}" drawable="pdf_converter" name="PDF CONVERTER" />
   <item component="ComponentInfo{com.pdfconvertonline.pdfconvert/com.pdfconvertonline.pdfconvert.MainActivityNew}" drawable="generic_pdf_square" name="PDF Converter" />
@@ -13298,6 +13309,7 @@
   <item component="ComponentInfo{com.rock.wash.reader/com.rock.wash.reader.activity.WakeUpActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
   <item component="ComponentInfo{com.qrscanner.qrcodescanner.barcodereader.barcodescanner/com.qrcode.scanner.qrcodescannerapp.views.activities.SplashActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
   <item component="ComponentInfo{qrcode.qrcodescanner.qrcodereader.barcode.barcodescanner/com.superfast.qrcode.activity.SplashActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
+  <item component="ComponentInfo{com.a1pha.qrcodescanner/com.a1pha.qrcodescanner.MainActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
   <item component="ComponentInfo{com.dshatz.qrtile/com.dshatz.qrtile.QrDialog}" drawable="qrky" name="QR Code Scanner Tile" />
   <item component="ComponentInfo{la.droid.qr/la.droid.qr.Tabs}" drawable="qr_droid" name="QR Droid" />
   <item component="ComponentInfo{la.droid.qr/la.droid.qr.DeCamara}" drawable="qr_droid" name="QR Droid" />
@@ -13312,6 +13324,7 @@
   <item component="ComponentInfo{qrcodereader.barcodescanner.scan.qrscanner/qrcodereader.barcodescanner.scan.qrscanner.page.SplashActivity}" drawable="generic_qr_reader" name="QR Scanner" />
   <item component="ComponentInfo{com.appswing.qr.barcodescanner.barcodereader/com.appswing.qr.barcodescanner.barcodereader.activities.main.MainActivity}" drawable="generic_qr_reader" name="QR Scanner" />
   <item component="ComponentInfo{com.imagetotext.qrcodescanner/com.imagetotext.qrcodescanner.MainActivity}" drawable="generic_qr_reader" name="QR Scanner" />
+  <item component="ComponentInfo{com.digitalchemy.barcodeplus/com.digitalchemy.barcodeplus.ui.screen.MainScreenActivity}" drawable="generic_qr_reader" name="QR Scanner Plus" />
   <item component="ComponentInfo{com.sweak.qralarm/com.sweak.qralarm.MainActivity}" drawable="qralarm" name="QRAlarm" />
   <item component="ComponentInfo{com.sweak.qralarm/com.sweak.qralarm.app.MainActivity}" drawable="qralarm" name="QRAlarm" />
   <item component="ComponentInfo{com.sweak.qralarm/com.sweak.qralarm.app.activity.MainActivity}" drawable="qralarm" name="QRAlarm" />
@@ -15450,6 +15463,7 @@
   <item component="ComponentInfo{com.smilerlee.klondike/com.smilerlee.klondike.KlondikeActivity}" drawable="generic_solitaire" name="Solitaire" />
   <item component="ComponentInfo{com.tripledot.solitaire/com.imagepicker.CustomUnityPlayerActivity}" drawable="generic_solitaire" name="Solitaire" />
   <item component="ComponentInfo{solitaire.patience.card.games.klondike.free/solitaire.patience.card.games.klondike.free.MainActivity}" drawable="generic_solitaire" name="Solitaire" />
+  <item component="ComponentInfo{com.moonfrog.solitaire.club/com.unity3d.player.UnityPlayerActivity}" drawable="generic_solitaire" name="Solitaire" />
   <item component="ComponentInfo{com.brainium.solitaire/com.brainium.solitaire.SolitaireLoader}" drawable="generic_solitaire" name="Solitaire+" />
   <item component="ComponentInfo{home.solo.launcher.free/home.solo.launcher.free.Launcher}" drawable="solo_launcher" name="Solo Launcher" />
   <item component="ComponentInfo{home.solo.launcher.free/home.solo.launcher.free.SplashActivity}" drawable="solo_launcher" name="Solo Launcher" />
@@ -16025,6 +16039,7 @@
   <item component="ComponentInfo{com.nintendo.zara/com.snslinkage.dena.snslinkageunityplugin.SnsLinkageSafeUnityPlayerNativeActivity}" drawable="super_mario_run" name="Super Mario Run" />
   <item component="ComponentInfo{com.nintendo.zara/com.unity3d.player.UnityPlayerActivity}" drawable="super_mario_run" name="Super Mario Run" />
   <item component="ComponentInfo{com.adilhanney.super_nonogram/com.adilhanney.super_nonogram.MainActivity}" drawable="i_love_hue_too" name="Super Nonogram" />
+  <item component="ComponentInfo{com.opalastudios.pads/org.cocos2dx.cpp.AppActivity}" drawable="generic_grid_3x3" name="Super Pads" />
   <item component="ComponentInfo{com.superproductivity.superproductivity/com.superproductivity.superproductivity.FullscreenActivity}" drawable="super_productivity" name="Super Productivity" />
   <item component="ComponentInfo{com.superandroid.quicksettingspro/com.superandroid.quicksettingspro.MainActivity}" drawable="super_quick_settings_pro" name="Super Quick Settings Pro" />
   <item component="ComponentInfo{com.tombayley.statusbar/com.tombayley.statusbar.app.ui.home.MainActivity}" drawable="super_status_bar" name="Super Status Bar" />
@@ -16056,6 +16071,8 @@
   <item component="ComponentInfo{com.jrzheng.supervpnpayment/com.jrzheng.supervpnpayment.activity.MainActivity}" drawable="supervpn_pro" name="SuperVPN Pro" />
   <item component="ComponentInfo{com.Neurononfire.SupremeDuelist/com.google.firebase.MessagingUnityPlayerActivity}" drawable="supreme_duelist" name="Supreme Duelist" />
   <item component="ComponentInfo{com.Neurononfire.SupremeDuelist/com.google.android.archive.ReactivateActivity}" drawable="supreme_duelist" name="Supreme Duelist" />
+  <item component="ComponentInfo{com.Neurononfire.SupremeDuelist2019/com.google.firebase.MessagingUnityPlayerActivity}" drawable="supreme_duelist" name="Supreme Duelist" />
+  <item component="ComponentInfo{com.Neurononfire.SupremeDuelist2019/com.unity3d.player.UnityPlayerActivity}" drawable="supreme_duelist" name="Supreme Duelist" />
   <item component="ComponentInfo{com.getsurfboard/com.getsurfboard.ui.activity.MainActivity}" drawable="surfboard" name="Surfboard" />
   <item component="ComponentInfo{com.blackview.surfline/com.horse.browser.MainActivity}" drawable="generic_compass" name="Surfline" />
   <item component="ComponentInfo{com.surfshark.vpnclient.android/com.surfshark.vpnclient.android.StartActivity}" drawable="surfshark" name="Surfshark" />
@@ -17422,6 +17439,7 @@
   <item component="ComponentInfo{com.ultimateguitar.tabs/com.ultimateguitar.ugpro.ui.activity.StartUpActivity}" drawable="ultimate_guitar" name="Ultimate Guitar" />
   <item component="ComponentInfo{com.ultimateguitar.tabs/com.ultimateguitar.ugpro.UGMainActivity}" drawable="ultimate_guitar" name="Ultimate Guitar" />
   <item component="ComponentInfo{com.ultimateguitar.ugpro/com.ultimateguitar.ugpro.ui.activity.StartUpActivity}" drawable="ultimate_guitar" name="Ultimate Guitar" />
+  <item component="ComponentInfo{com.mixapplications.ultimateusb/com.mixapplications.ultimateusb.MainActivity}" drawable="drivedroid" name="Ultimate USB" />
   <item component="ComponentInfo{com.uvnv.ultramobile/com.ultramobile.ultra.MainActivity}" drawable="ultra_mobile" name="Ultra Mobile" />
   <item component="ComponentInfo{org.moire.ultrasonic/org.moire.ultrasonic.activity.MainActivity}" drawable="ultrasonic" name="Ultrasonic" />
   <item component="ComponentInfo{org.moire.ultrasonic/org.moire.ultrasonic.activity.NavigationActivity}" drawable="ultrasonic" name="Ultrasonic" />
@@ -17588,6 +17606,7 @@
   <item component="ComponentInfo{godau.fynn.usagedirect/godau.fynn.usagedirect.AppUsageStatisticsActivity}" drawable="usagedirect" name="usageDirect" />
   <item component="ComponentInfo{com.extreamsd.usbaudioplayerpro/com.extreamsd.usbaudioplayershared.ScreenSlidePagerActivity}" drawable="usb_audio_player" name="USB Audio Player" />
   <item component="ComponentInfo{com.extreamsd.usbaudioplayerpro/com.extreamsd.usbaudioplayershared}" drawable="usb_audio_player" name="USB Audio Player" />
+  <item component="ComponentInfo{com.extreamsd.usbaudiorecorderpro/com.extreamsd.usbaudiorecordershared.AllTabsActivity}" drawable="drivedroid" name="USB Audio Recorder PRO" />
   <item component="ComponentInfo{com.sec.android.autobackup/com.sec.android.autobackup.ui.LauncherActivity}" drawable="usb_backup" name="USB Backup" />
   <item component="ComponentInfo{me.arianb.usb_hid_client/me.arianb.usb_hid_client.MainActivity}" drawable="generic_keyboard" name="USB HID Client" />
   <item component="ComponentInfo{com.tcl.usercare/com.tcl.usercare.ui.activity.main.MainActivity}" drawable="user_center" name="User Center" />
@@ -18909,6 +18928,7 @@
   <item component="ComponentInfo{com.yazio.android/yazio.login.LoginActivity}" drawable="yazio" name="YAZIO" />
   <item component="ComponentInfo{com.a3.yearlyprogess/com.a3.yearlyprogess.MainActivity}" drawable="yearly_progress" name="Yearly Progress" />
   <item component="ComponentInfo{com.yeelight.cherry/com.yeelight.cherry.ui.activity.LauncherActivity}" drawable="yeelight" name="Yeelight" />
+  <item component="ComponentInfo{com.yeelight.yeelight_fluid/com.yeelight.yeelight_fluid.MainActivity}" drawable="yeelight" name="Yeelight" />
   <item component="ComponentInfo{com.yelp.android/com.yelp.android.ui.ActivityNearby}" drawable="yelp" name="Yelp" />
   <item component="ComponentInfo{com.yelp.android/com.yelp.android.ui.activities.RootActivity}" drawable="yelp" name="Yelp" />
   <item component="ComponentInfo{com.yelp.android/com.yelp.android.nearby.ui.ActivityNearby}" drawable="yelp" name="Yelp" />


### PR DESCRIPTION
## Linked
American Express (Amex) (`com.americanexpress.android.acctsvcs.mx` → `american_express_amex.svg`)
Apple Dongle Volume Fixer (`com.example.libusbAndroidTest` → `drivedroid.svg`)
Easy Keyboard (`easy.launcher` → `generic_keyboard.svg`)
Endesa (`com.enel.mobile.endesaPT` → `endesa.svg`)
Fake GPS Location (`com.hopefactory2021.fakegpslocation` → `mock_locations.svg`)
Gboard Morphe (`com.google.android.inputmethod.morphe` → `gboard.svg`)
ibis Paint X (`jp.ne.ibis.ibispaintx.app.hms` → `ibis_paint.svg`)
JPG to PDF Converter (`com.aconvert.jpg2pdf` → `generic_pdf_square.svg`)
Material Expressive Widget (`material.expressive.kwgt` → `m3_expressive_widgets.svg`)
MockGps (`com.lilstiffy.mockgps` → `mock_locations.svg`)
PDF (`com.vayunmathur.pdf` → `pdf_viewer_plus.svg`)
QR Code Scanner (`com.a1pha.qrcodescanner` → `generic_qr_reader.svg`)
QR Scanner Plus (`com.digitalchemy.barcodeplus` → `generic_qr_reader.svg`)
Solitaire (`com.moonfrog.solitaire.club` → `generic_solitaire.svg`)
Super Pads (`com.opalastudios.pads` → `generic_grid_3x3.svg`)
Supreme Duelist (`com.Neurononfire.SupremeDuelist2019` → `supreme_duelist.svg`)
Ultimate USB (`com.mixapplications.ultimateusb` → `drivedroid.svg`)
USB Audio Recorder PRO (`com.extreamsd.usbaudiorecorderpro` → `drivedroid.svg`)
Yeelight (`com.yeelight.yeelight_fluid` → `yeelight.svg`)