### PR TITLE
feat: add Apply to Lawnchair button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -168,6 +168,11 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent>
+        <!-- Lawnchair Apply Icons -->
+        <intent>
+            <action android:name="app.lawnchair.APPLY_ICONS" />
+            <category android:name="android.intent.category.DEFAULT" />
+        </intent>
         <intent>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.HOME" />

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/components/home/HomeBottomBar.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/components/home/HomeBottomBar.kt
@@ -33,6 +33,7 @@ import app.lawnchair.lawnicons.ui.theme.icon.Github
 import app.lawnchair.lawnicons.ui.theme.icon.IconRequest
 import app.lawnchair.lawnicons.ui.theme.icon.LawnIcons
 import app.lawnchair.lawnicons.ui.theme.icon.OpenCollective
+import app.lawnchair.lawnicons.ui.theme.icon.Palette
 import app.lawnchair.lawnicons.ui.theme.icon.Search
 import app.lawnchair.lawnicons.ui.util.Constants
 import app.lawnchair.lawnicons.ui.util.PreviewLawnicons
@@ -46,6 +47,7 @@ fun BoxScope.HomeBottomToolbar(
     onNavigateToAbout: () -> Unit,
     onNavigateToIconRequest: () -> Unit,
     onIconRequestUnavailable: () -> Unit,
+    onApplyToLawnchair: () -> Unit,
     onExpandSearch: () -> Unit,
     scrollBehavior: FloatingToolbarScrollBehavior,
     modifier: Modifier = Modifier,
@@ -139,6 +141,18 @@ fun BoxScope.HomeBottomToolbar(
             }
 
             SimpleTooltipBox(
+                label = stringResource(R.string.apply_to_lawnchair),
+            ) {
+                IconButton(onClick = onApplyToLawnchair) {
+                    Icon(
+                        imageVector = LawnIcons.Palette,
+                        contentDescription = stringResource(R.string.apply_to_lawnchair),
+                        modifier = Modifier.requiredSize(24.dp),
+                    )
+                }
+            }
+
+            SimpleTooltipBox(
                 label = stringResource(id = R.string.about),
             ) {
                 IconButton(onClick = onNavigateToAbout) {
@@ -204,6 +218,7 @@ private fun HomeBottomToolbarPreview() {
                 onNavigateToAbout = {},
                 onNavigateToIconRequest = {},
                 onIconRequestUnavailable = {},
+                onApplyToLawnchair = {},
                 onExpandSearch = {},
                 scrollBehavior = FloatingToolbarDefaults.exitAlwaysScrollBehavior(
                     FloatingToolbarExitDirection.Bottom,

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/home/Home.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/destination/home/Home.kt
@@ -16,6 +16,7 @@
 
 package app.lawnchair.lawnicons.ui.destination.home
 
+import android.content.Intent
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
@@ -48,6 +49,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
@@ -66,6 +68,7 @@ import app.lawnchair.lawnicons.ui.components.home.iconpreview.AppBarListItem
 import app.lawnchair.lawnicons.ui.components.home.iconpreview.IconPreviewGrid
 import app.lawnchair.lawnicons.ui.components.home.iconpreview.IconPreviewGridPaddings
 import app.lawnchair.lawnicons.ui.components.home.search.rememberSearchState
+import app.lawnchair.lawnicons.ui.util.Constants
 import app.lawnchair.lawnicons.ui.util.PreviewLawnicons
 import app.lawnchair.lawnicons.ui.util.PreviewProviders
 import app.lawnchair.lawnicons.ui.util.SampleData
@@ -233,6 +236,8 @@ private fun HomeScreen(
                     }
 
                     val string = stringResource(R.string.icon_requests_fulfilled)
+                    val lawnchairNotInstalled = stringResource(R.string.lawnchair_not_installed)
+                    val context = LocalContext.current
 
                     HomeBottomToolbar(
                         scrollBehavior = scrollBehavior,
@@ -248,6 +253,20 @@ private fun HomeScreen(
                                     )
                                 if (result == SnackbarResult.Dismissed) {
                                     snackbarHostState.currentSnackbarData?.dismiss()
+                                }
+                            }
+                        },
+                        onApplyToLawnchair = {
+                            val intent = Intent(Constants.LAWNCHAIR_APPLY_ICONS_ACTION)
+                                .putExtra("packageName", context.packageName)
+                            if (intent.resolveActivity(context.packageManager) != null) {
+                                context.startActivity(intent)
+                            } else {
+                                coroutineScope.launch {
+                                    snackbarHostState.showSnackbar(
+                                        message = lawnchairNotInstalled,
+                                        duration = SnackbarDuration.Short,
+                                    )
                                 }
                             }
                         },

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/theme/icon/Palette.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/theme/icon/Palette.kt
@@ -1,0 +1,92 @@
+package app.lawnchair.lawnicons.ui.theme.icon
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val LawnIcons.Palette: ImageVector
+    get() {
+        if (_Palette != null) {
+            return _Palette!!
+        }
+        _Palette = ImageVector.Builder(
+            name = "Palette",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f,
+        ).apply {
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(480f, 880f)
+                quadTo(397f, 880f, 324f, 848.5f)
+                quadTo(251f, 817f, 197f, 763f)
+                quadTo(143f, 709f, 111.5f, 636f)
+                quadTo(80f, 563f, 80f, 480f)
+                quadTo(80f, 396f, 112f, 323.5f)
+                quadTo(144f, 251f, 198f, 197f)
+                quadTo(252f, 143f, 325.5f, 111.5f)
+                quadTo(399f, 80f, 484f, 80f)
+                quadTo(560f, 80f, 629f, 108f)
+                quadTo(698f, 136f, 750f, 183.5f)
+                quadTo(802f, 231f, 831f, 295f)
+                quadTo(860f, 359f, 860f, 434f)
+                quadTo(860f, 540f, 800.5f, 590f)
+                quadTo(741f, 640f, 660f, 640f)
+                lineTo(580f, 640f)
+                quadTo(563f, 640f, 551.5f, 652.5f)
+                quadTo(540f, 665f, 540f, 680f)
+                quadTo(540f, 700f, 554f, 718f)
+                quadTo(568f, 736f, 568f, 760f)
+                quadTo(568f, 808f, 539.5f, 844f)
+                quadTo(511f, 880f, 480f, 880f)
+                close()
+                moveTo(240f, 520f)
+                quadTo(257f, 520f, 268.5f, 508.5f)
+                quadTo(280f, 497f, 280f, 480f)
+                quadTo(280f, 463f, 268.5f, 451.5f)
+                quadTo(257f, 440f, 240f, 440f)
+                quadTo(223f, 440f, 211.5f, 451.5f)
+                quadTo(200f, 463f, 200f, 480f)
+                quadTo(200f, 497f, 211.5f, 508.5f)
+                quadTo(223f, 520f, 240f, 520f)
+                close()
+                moveTo(360f, 360f)
+                quadTo(377f, 360f, 388.5f, 348.5f)
+                quadTo(400f, 337f, 400f, 320f)
+                quadTo(400f, 303f, 388.5f, 291.5f)
+                quadTo(377f, 280f, 360f, 280f)
+                quadTo(343f, 280f, 331.5f, 291.5f)
+                quadTo(320f, 303f, 320f, 320f)
+                quadTo(320f, 337f, 331.5f, 348.5f)
+                quadTo(343f, 360f, 360f, 360f)
+                close()
+                moveTo(600f, 360f)
+                quadTo(617f, 360f, 628.5f, 348.5f)
+                quadTo(640f, 337f, 640f, 320f)
+                quadTo(640f, 303f, 628.5f, 291.5f)
+                quadTo(617f, 280f, 600f, 280f)
+                quadTo(583f, 280f, 571.5f, 291.5f)
+                quadTo(560f, 303f, 560f, 320f)
+                quadTo(560f, 337f, 571.5f, 348.5f)
+                quadTo(583f, 360f, 600f, 360f)
+                close()
+                moveTo(720f, 520f)
+                quadTo(737f, 520f, 748.5f, 508.5f)
+                quadTo(760f, 497f, 760f, 480f)
+                quadTo(760f, 463f, 748.5f, 451.5f)
+                quadTo(737f, 440f, 720f, 440f)
+                quadTo(703f, 440f, 691.5f, 451.5f)
+                quadTo(680f, 463f, 680f, 480f)
+                quadTo(680f, 497f, 691.5f, 508.5f)
+                quadTo(703f, 520f, 720f, 520f)
+                close()
+            }
+        }.build()
+
+        return _Palette!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _Palette: ImageVector? = null

--- a/app/src/main/kotlin/app/lawnchair/lawnicons/ui/util/Constants.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/ui/util/Constants.kt
@@ -8,4 +8,5 @@ object Constants {
     const val OPEN_COLLECTIVE = WEBSITE + "open-collective/"
 
     const val ICON_PICKER_INTENT_ACTION = "com.novalauncher.THEME"
+    const val LAWNCHAIR_APPLY_ICONS_ACTION = "app.lawnchair.APPLY_ICONS"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,10 @@
     <string name="open_collective" translatable="false">Open Collective</string>
     <!-- Label for the icon request action in the toolbar -->
     <string name="request_icons">Request icons</string>
+    <!-- Label for the apply to Lawnchair action in the toolbar -->
+    <string name="apply_to_lawnchair">Apply to Lawnchair</string>
+    <!-- Snackbar shown when Lawnchair is not installed -->
+    <string name="lawnchair_not_installed">Lawnchair is not installed</string>
 
     <!-- Snackbar content -->
 


### PR DESCRIPTION
## Description

Add an "Apply to Lawnchair" button to the home toolbar, allowing users to directly apply Lawnicons as their icon pack in
Lawnchair without navigating to Lawnchair settings.

This is the Lawnicons-side implementation for [LawnchairLauncher/lawnchair#6594](https://github.com/LawnchairLauncher/
lawnchair/issues/6594). The Lawnchair-side implementation is at [LawnchairLauncher/lawnchair#6643](https://github.com/
LawnchairLauncher/lawnchair/pull/6643).

- Add Palette icon for the toolbar button
- Add <queries> declaration for the intent (Android 11+)
- Show snackbar if Lawnchair is not installed