### PR TITLE
Replace unstale label with stale removal

### DIFF
--- a/.github/workflows/close_stale_prs.yml
+++ b/.github/workflows/close_stale_prs.yml
@@ -17,4 +17,4 @@ jobs:
           days-before-issue-stale: -1
           exempt-draft-pr: true
           operations-per-run: 500
-          labels-to-add-when-unstale: unstale
+          labels-to-remove-when-unstale: stale


### PR DESCRIPTION
Remove the stale label when a pull request becomes active again. The unstale label is redundant.

