### PR TITLE
Migrate dev.zacsweers.metro.Provider usages

### DIFF
--- a/app/src/main/kotlin/app/lawnchair/lawnicons/di/MetroViewModelFactoryImpl.kt
+++ b/app/src/main/kotlin/app/lawnchair/lawnicons/di/MetroViewModelFactoryImpl.kt
@@ -19,7 +19,6 @@ package app.lawnchair.lawnicons.di
 import androidx.lifecycle.ViewModel
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
@@ -30,7 +29,7 @@ import kotlin.reflect.KClass
 @SingleIn(AppScope::class)
 class MetroViewModelFactoryImpl(
     // These maps are autopopulated by Metro based on @ContributesIntoMap
-    override val viewModelProviders: Map<KClass<out ViewModel>, Provider<ViewModel>>,
-    override val assistedFactoryProviders: Map<KClass<out ViewModel>, Provider<ViewModelAssistedFactory>>,
-    override val manualAssistedFactoryProviders: Map<KClass<out ManualViewModelAssistedFactory>, Provider<ManualViewModelAssistedFactory>>,
+    override val viewModelProviders: Map<KClass<out ViewModel>, () -> ViewModel>,
+    override val assistedFactoryProviders: Map<KClass<out ViewModel>, () -> ViewModelAssistedFactory>,
+    override val manualAssistedFactoryProviders: Map<KClass<out ManualViewModelAssistedFactory>, () -> ManualViewModelAssistedFactory>,
 ) : MetroViewModelFactory()


### PR DESCRIPTION
```
w: file:///home/runner/work/lawnicons/lawnicons/app/src/main/kotlin/app/lawnchair/lawnicons/di/MetroViewModelFactoryImpl.kt:33:38 Using the desugared `Provider<T>` type is discouraged. Prefer the function syntax form `() -> T` instead.
w: file:///home/runner/work/lawnicons/lawnicons/app/src/main/kotlin/app/lawnchair/lawnicons/di/MetroViewModelFactoryImpl.kt:34:44 Using the desugared `Provider<T>` type is discouraged. Prefer the function syntax form `() -> T` instead.
w: file:///home/runner/work/lawnicons/lawnicons/app/src/main/kotlin/app/lawnchair/lawnicons/di/MetroViewModelFactoryImpl.kt:35:50 Using the desugared `Provider<T>` type is discouraged. Prefer the function syntax form `() -> T` instead.
```