### PR TITLE
Add backer's pick

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit_backers_pick.yml
+++ b/.github/ISSUE_TEMPLATE/submit_backers_pick.yml
@@ -1,0 +1,24 @@
+name: Submit backer's pick
+description: For Open Collective backers.
+title: ""
+labels: ["backer"]
+
+body:
+
+  - type: input
+    id: oc_profile_link
+    validations:
+      required: true
+    attributes:
+      label: Open Collective profile link
+      description: |
+        To verify your backer status, please add your GitHub account to your Open Collective profile: your avatar in the top right → Settings (Info) → Social Links → Add GitHub link → Save.
+
+  - type: upload
+    id: icon_request_file
+    validations:
+      required: true
+    attributes:
+      label: Icon request file
+      description: |
+        Create an icon request file: Open Lawnicons → Tap "Request icons" → Select icons → Save file.

--- a/.github/ISSUE_TEMPLATE/submit_backers_pick.yml
+++ b/.github/ISSUE_TEMPLATE/submit_backers_pick.yml
@@ -5,6 +5,11 @@ labels: ["backer"]
 
 body:
 
+  - type: markdown
+    attributes:
+      value: |
+        An option for backers to highlight icons on our icon request dashboard. It doesn't guarantee fulfillment, but it raises the priority of the requested icons among thousands of others.
+        
   - type: input
     id: oc_profile_link
     validations:

--- a/.github/ISSUE_TEMPLATE/submit_backers_pick.yml
+++ b/.github/ISSUE_TEMPLATE/submit_backers_pick.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Open Collective profile link
       description: |
-        To verify your backer status, please add your GitHub account to your Open Collective profile: your avatar in the top right → Settings (Info) → Social Links → Add GitHub link → Save.
+        To verify your backer status, please add your GitHub account to your Open Collective profile: click avatar in the top right → Settings (Info) → Social Links → Add GitHub link → Save.
 
   - type: upload
     id: icon_request_file


### PR DESCRIPTION
An option for our backers to highlight the icons they need on the Lawnicons request dashboard.