### PR TITLE
Change debug build skip logic for meta changes

### DIFF
--- a/.github/workflows/build_debug_apk.yml
+++ b/.github/workflows/build_debug_apk.yml
@@ -17,21 +17,22 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Check for ignored paths
+      - name: Check for changes in source files
         uses: dorny/paths-filter@v4
         id: filter
         with:
-          base: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           filters: |
             workflows:
-              - '!**.md'
-              - '!LICENSE'
-              - '!.idea/**'
-              - '!docs/**'
-              - '!.github/**'
-              - '!.gitignore'
-              - '!.gitattributes'
-
+              - 'app/**'
+              - 'gradle/**'
+              - 'gradle.properties'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'svg-processor/**'
+              - 'svgs/**'
+              
   build-debug-apk:
     runs-on: ubuntu-latest
     needs: check-paths

--- a/.github/workflows/build_debug_apk.yml
+++ b/.github/workflows/build_debug_apk.yml
@@ -84,8 +84,8 @@ jobs:
 
   send-notifications:
     runs-on: ubuntu-latest
-    needs: [ build-debug-apk, check-style, check-paths ]
-    if: needs.check-paths.outputs.skip_steps != 'true'
+    needs: check-paths
+    if: always() && needs.check-paths.result == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -100,6 +100,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install gitpython requests
       - name: Download artifact
+        if: needs.check-paths.outputs.skip_steps != 'true'
         uses: actions/download-artifact@v8
         with:
           name: Debug APK

--- a/send_notifications.py
+++ b/send_notifications.py
@@ -116,8 +116,13 @@ if len(commits) != 0:
     send_message_to_ci_channel(message=telegram_message)
     send_message_to_builds_channel(message=discord_message)
 
-    with open(f'{artifact_directory}/{os.listdir(artifact_directory)[0]}', 'rb') as apk:
-        send_document_to_ci_channel(document=apk)
-
-    with open(f'{artifact_directory}/{os.listdir(artifact_directory)[0]}', 'rb') as apk:
-         send_document_to_builds_channel(document=apk)
+    if artifact_directory and os.path.isdir(artifact_directory):
+        try:
+            files = os.listdir(artifact_directory)
+            if files:
+                with open(f'{artifact_directory}/{files[0]}', 'rb') as apk:
+                    send_document_to_ci_channel(document=apk)
+                with open(f'{artifact_directory}/{files[0]}', 'rb') as apk:
+                    send_document_to_builds_channel(document=apk)
+        except Exception as e:
+            print(f"Failed to send APK: {e}")


### PR DESCRIPTION
- Use include-based path filtering to skip debug builds on meta changes
- Restore notifications so they always send, regardless of build status

For meta-changes, the checks will be 4 times faster.

Closes #2264 