### PR TITLE
+4 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -13265,6 +13265,7 @@
   <item component="ComponentInfo{gecko.droid.mathematicshelper/md5213cb10e7a80b92f6b1e7f1295490527.RootActivity}" drawable="pocket_mathematics" name="Pocket Mathematics" />
   <item component="ComponentInfo{com.teenageengineering.pocketoperatorforpixel/com.unity3d.player.UnityPlayerActivity}" drawable="pocket_operator_for_pixel" name="pocket operator for Pixel" />
   <item component="ComponentInfo{com.teenageengineering.pocketoperatorforpixel/com.unity3d.player.FoldablePlayerActivity}" drawable="pocket_operator_for_pixel" name="pocket operator for Pixel" />
+  <item component="ComponentInfo{com.pocketoption.broker/com.potradeweb.activities.MainActivity}" drawable="pocket_broker" name="Pocket Option" />
   <item component="ComponentInfo{org.catrobat.paintroid/org.catrobat.paintroid.MainActivity}" drawable="pocket_paint" name="Pocket Paint" />
   <item component="ComponentInfo{Gecko.Droid.PhysicsHelper/md52f1b5a23cdde2c59a85df854f911f94a.RootListActivity}" drawable="pocket_physics" name="Pocket Physics" />
   <item component="ComponentInfo{com.nimblebit.pocketplanes/com.unity3d.player.UnityPlayerActivity}" drawable="pocket_planes" name="Pocket Planes" />
@@ -14089,6 +14090,7 @@
   <item component="ComponentInfo{reddit.news/reddit.news.RedditNavigation}" drawable="relay" name="Relay" />
   <item component="ComponentInfo{cc.relive.reliveapp/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="relive" name="Relive" />
   <item component="ComponentInfo{no.rema.bella/no.shortcut.bella.feature.main.welcome.WelcomeActivity}" drawable="rema_1000" name="REMA 1000" />
+  <item component="ComponentInfo{no.rema.bella/no.shortcut.bella.feature.main.MainActivity}" drawable="rema_1000" name="REMA 1000" />
   <item component="ComponentInfo{br.com.remessaonline/br.com.remessaonline.MainActivity}" drawable="remessa_online" name="Remessa Online" />
   <item component="ComponentInfo{com.remind101/com.remind101.features.welcome.WelcomeActivity}" drawable="remind" name="Remind" />
   <item component="ComponentInfo{com.remind101/com.remind101.splash.SplashActivity}" drawable="remind" name="Remind" />
@@ -17855,6 +17857,7 @@
   <item component="ComponentInfo{com.tuya.smart/com.smart.TuyaSplashActivity}" drawable="tuya_smart" name="Tuya Smart" />
   <item component="ComponentInfo{com.tuya.smart/com.smart.ThingSplashActivity}" drawable="tuya_smart" name="Tuya Smart" />
   <item component="ComponentInfo{dk.tv2.tv2play/dk.tv2.tv2play.ui.main.MainActivity}" drawable="tv_2_play" name="TV 2 Play" />
+  <item component="ComponentInfo{de.twokit.video.tv.cast.browser.lg/de.twokit.video.tv.cast.browser.lg.MainActivity}" drawable="tv_cast_for_samsung_tv" name="TV Cast for LG" />
   <item component="ComponentInfo{de.twokit.video.tv.cast.browser.samsung/de.twokit.video.tv.cast.browser.samsung.MainActivity}" drawable="tv_cast_for_samsung_tv" name="TV Cast for Samsung TV" />
   <item component="ComponentInfo{com.tozelabs.tvshowtime/com.tozelabs.tvshowtime.MainActivity}" drawable="tv_time" name="TV Time" />
   <item component="ComponentInfo{com.tozelabs.tvshowtime/com.tozelabs.tvshowtime.activity.KMainActivity_}" drawable="tv_time" name="TV Time" />
@@ -19885,6 +19888,7 @@
   <item component="ComponentInfo{com.zentity.sbank.csobsk/com.csobsk.smartbankingv2.activity.SplashActivity}" drawable="kbc" name="ČSOB" />
   <item component="ComponentInfo{com.zentity.sbank.csobsk/com.csobsk.smartbankingv2.smartbankingv3.modules.SplashActivity}" drawable="kbc" name="ČSOB" />
   <item component="ComponentInfo{sk.csob.smarttoken/com.csobsk.smartbankingv2.common.activity.HomeFragmentActivity}" drawable="csob_smarttoken" name="ČSOB SmartToken" />
+  <item component="ComponentInfo{eu.inmite.prj.ct.ct24.android/eu.inmite.prj.ct.ct24.android.MainActivity}" drawable="ivysilani" name="ČT24" />
   <item component="ComponentInfo{sk.tb.emv.mobile/ui.MainActivity}" drawable="citacka" name="Čítačka" />
   <item component="ComponentInfo{com.lemo.simarttest/com.lemo.simart.activity.StartActivity}" drawable="simart" name="Şımart" />
   <item component="ComponentInfo{com.lemo.simarttest/com.lemo.simarttest.ui.StartActivity}" drawable="simart" name="Şımart" />


### PR DESCRIPTION
<!-- bot: icons -->
## Icons

### Linked
ČT24 (`eu.inmite.prj.ct.ct24.android` → `ivysilani.svg`)
Pocket Option (`com.pocketoption.broker` → `pocket_broker.svg`)
REMA 1000 (`no.rema.bella` → `rema_1000.svg`)
TV Cast for LG (`de.twokit.video.tv.cast.browser.lg` → `tv_cast_for_samsung_tv.svg`)