### PR TITLE
Fix icon description workflow for forked PRs

### DIFF
--- a/.github/workflows/icon_description.yml
+++ b/.github/workflows/icon_description.yml
@@ -21,11 +21,17 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+
+      - name: Fetch base ref
+        run: |
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream ${{ github.event.pull_request.base.ref }}          
       
       - name: Get changed files
         id: files
         uses: tj-actions/changed-files@v46
         with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
             svgs/*
             app/assets/appfilter.xml


### PR DESCRIPTION
Fetch the base ref from upstream so git commands have access to the target branch's commit history. This fixes the "bad object" error when running on pull requests from forked repositories.