### PR TITLE
Target SDK 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,7 @@ val version = "2.17.1"
 val versionDisplayName = version + if (!isReleaseBuild) " $devReleaseName" else ""
 
 android {
-    compileSdk = 36
+    compileSdk = 37
     namespace = "app.lawnchair.lawnicons"
 
     defaultConfig {


### PR DESCRIPTION
This PR updates Lawnicons' `compile` and `targetSdk` to SDK 37 (to target Android 17).

Allows merging #3698.