### PR TITLE
+2 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -11223,6 +11223,7 @@
   <item component="ComponentInfo{com.zentity.vodafone/com.zentity.vodafone.SplashScreenActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{al.myvodafone.android/com.oneapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{au.com.vodafone.mobile.gss/com.vfmobileapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
+  <item component="ComponentInfo{com.vodafone.selfservis/com.vodafone.selfservis.FiveGAlias}" drawable="_5g_only" name="My Vodafone 5G" />
   <item component="ComponentInfo{fr.meteo/fr.meteo.activity.SplashscreenActivity_}" drawable="my_weather" name="My Weather" />
   <item component="ComponentInfo{com.myworkoutplan.myworkoutplan/com.myworkoutplan.myworkoutplan.MainActivity}" drawable="my_workout_plan" name="My Workout Plan" />
   <item component="ComponentInfo{jp.co.yamahamotor.myyamahamotor/crc6414aa322ddbc6eef4.MainActivity}" drawable="my_yamaha_motor" name="My Yamaha Motor" />
@@ -18280,6 +18281,7 @@
   <item component="ComponentInfo{com.tmob.AveaOIM/com.avea.oim.SplashActivity}" drawable="turk_telekom" name="Türk Telekom" />
   <item component="ComponentInfo{com.tmob.AveaOIM/moim.android.MourningMoimApplicationAlias}" drawable="turk_telekom" name="Türk Telekom" />
   <item component="ComponentInfo{com.tmob.AveaOIM/moim.android.DefaultMoimApplicationAlias}" drawable="turk_telekom" name="Türk Telekom" />
+  <item component="ComponentInfo{com.tmob.AveaOIM/moim.android.FiveGMoimApplicationAlias}" drawable="_5g_only" name="Türk Telekom 5G" />
   <item component="ComponentInfo{com.mobilsozluk/com.mobilsozluk.MainActivity}" drawable="turkce_sozluk" name="Türkçe Sözlük" />
   <item component="ComponentInfo{com.ataexpress.tiklagelsin/com.ataexpress.tiklagelsin.MainActivity}" drawable="tikla_gelsin" name="Tıkla Gelsin" />
   <item component="ComponentInfo{com.ataexpress.tiklagelsin/com.ataexpress.tiklagelsin.MainActivityDefault}" drawable="tikla_gelsin" name="Tıkla Gelsin" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
My Vodafone 5G (`com.vodafone.selfservis` → `_5g_only.svg`)
Türk Telekom 5G (`com.tmob.AveaOIM` → `_5g_only.svg`)