### PR TITLE
+2 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -11488,6 +11488,7 @@
   <item component="ComponentInfo{nu.gpu.nagram/org.telegram.messenger.BlueIcon}" drawable="nagram_niello_icon" name="Nagram X" />
   <item component="ComponentInfo{nu.gpu.nagram/org.telegram.messenger.NielloIcon}" drawable="nagram_niello_icon" name="Nagram X" />
   <item component="ComponentInfo{nu.gpu.nagram/org.telegram.messenger.DefaultIcon}" drawable="nagram_niello_icon" name="Nagram X" />
+  <item component="ComponentInfo{fork.risin42.nagramx/org.telegram.messenger.DarkBlueIcon}" drawable="nagram" name="Nagram XF" />
   <item component="ComponentInfo{com.wavefront.namegenerator/com.wavefront.nicknamegenerator.MainActivity}" drawable="name_generator" name="Name Generator" />
   <item component="ComponentInfo{com.kotobagames.namelesscat/com.unity3d.player.UnityPlayerActivity}" drawable="nameless_cat" name="Nameless Cat" />
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.NamidaMainActivity}" drawable="namida" name="Namida" />
@@ -12606,6 +12607,7 @@
   <item component="ComponentInfo{sh.ppy.osulazer/md59c875562ee5070384021e1e981f7bd4e.OsuGameActivity}" drawable="osu" name="osu!" />
   <item component="ComponentInfo{ru.nsu.ccfit.zuev.osu/ru.nsu.ccfit.zuev.osu.menu.MainMenuActivity}" drawable="osu" name="osu!droid" />
   <item component="ComponentInfo{ru.nsu.ccfit.zuev.osuplus/ru.nsu.ccfit.zuev.osu.MainActivity}" drawable="osu" name="osu!droid" />
+  <item component="ComponentInfo{ru.nsu.ccfit.zuev.osuplus.gles/ru.nsu.ccfit.zuev.osu.MainActivity}" drawable="osu" name="osu!droid-GLES" />
   <item component="ComponentInfo{sh.ppy.osustream/crc6484b8820ed7fe2f2b.Application}" drawable="osu" name="osu!stream" />
   <item component="ComponentInfo{com.example.bluetoothconnect/com.example.bluetoothconnect.MainActivity}" drawable="generic_shell" name="OTG Keyboard" />
   <item component="ComponentInfo{com.sakethh.otic/com.sakethh.otic.OticActivity}" drawable="otic" name="Otic" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->


<!-- bot: icons -->
## Icons

### Linked
Nagram XF (`fork.risin42.nagramx` → `nagram.svg`)
osu!droid-GLES (`ru.nsu.ccfit.zuev.osuplus.gles` → `osu.svg`)
