### PR TITLE
+6 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -14082,6 +14082,12 @@
   <item component="ComponentInfo{com.tk.quicksearch/com.tk.quicksearch.app.MainActivityAliasDefault}" drawable="quick_search" name="Quick Search" />
   <item component="ComponentInfo{com.tk.quicksearch/com.tk.quicksearch.app.MainActivityAliasMonochromeDark}" drawable="generic_search" name="Quick Search" />
   <item component="ComponentInfo{it.simonesestito.ntiles/it.simonesestito.ntiles.MainSplash}" drawable="quick_settings" name="Quick Settings" />
+  <item component="ComponentInfo{com.google.android.gms/com.google.android.gms.nearby.sharing.settings.SettingsActivity}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share" />
+  <item component="ComponentInfo{com.google.android.gms/com.google.android.gms.nearby.sharing.main.MainActivity}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share" />
+  <item component="ComponentInfo{com.google.android.gms/com.google.android.gms.nearby.sharing.SharingLauncherActivity}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share" />
+  <item component="ComponentInfo{com.google.android.gms/com.google.android.gms.nearby.sharing.ReceiveSurfaceActivity}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share" />
+  <item component="ComponentInfo{com.google.android.gms/com.google.android.gms.nearby.sharing.ShareSheetActivity}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share" />
+  <item component="ComponentInfo{com.google.android.gms/com.google.android.gms.nearby.sharing.ui.DiscoveryActivity}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.QuickShareShortcut}" drawable="quick_share_google_shortcuts_launcher" name="Quick Share (Google Shortcuts Launcher)" />
   <item component="ComponentInfo{com.rhmsoft.edit/com.rhmsoft.edit.activity.MainActivity}" drawable="quickedit" name="QuickEdit" />
   <item component="ComponentInfo{com.rhmsoft.edit.pro/com.rhmsoft.edit.activity.MainActivity}" drawable="quickedit" name="QuickEdit" />


### PR DESCRIPTION
Add the native Google Play Services (GMS) Quick Share components to map directly to the `quick_share_google_shortcuts_launcher` drawable.

Previously, only the third-party GSL (Google Shortcuts Launcher) shortcut component (`com.wstxda.gsl/...`) was mapped to the Quick Share icon, leaving the native GMS activities unthemed/unmapped.

This change maps the following native GMS activity entries:
- com.google.android.gms.nearby.sharing.main.MainActivity
- com.google.android.gms.nearby.sharing.settings.SettingsActivity
- com.google.android.gms.nearby.sharing.SharingLauncherActivity
- com.google.android.gms.nearby.sharing.ReceiveSurfaceActivity
- com.google.android.gms.nearby.sharing.ShareSheetActivity
- com.google.android.gms.nearby.sharing.ui.DiscoveryActivity

<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
6 × Quick Share (`com.google.android.gms` → `quick_share_google_shortcuts_launcher.svg`)