### PR TITLE
+2 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -1101,6 +1101,7 @@
   <item component="ComponentInfo{com.habby.archero/com.habby.archero.UnityPlayerActivity}" drawable="archero" name="Archero" />
   <item component="ComponentInfo{moe.koiverse.archivetune/moe.koiverse.archivetune.MainActivity}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.MainActivity}" drawable="archivetune" name="ArchiveTune" />
+  <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.DefaultIconAlias}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{com.kanedias.archforums/com.kanedias.archforums.MainActivity}" drawable="archlinux_forums" name="Archlinux Forums" />
   <item component="ComponentInfo{com.google.ar.unity.arcore_depth_lab/com.unity3d.player.UnityPlayerActivity}" drawable="arcore_depth_lab" name="ARCore Depth Lab" />
   <item component="ComponentInfo{com.donnnno.arcticons.light/com.donnnno.arcticons.activities.SplashActivity}" drawable="arcticons_line_icons" name="Arcticons Black Icons" />

--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -16003,6 +16003,7 @@
   <item component="ComponentInfo{me.simpleHook/me.simpleHook.ui.activity.MainActivity}" drawable="generic_shell" name="simpleHook" />
   <item component="ComponentInfo{io.simplelogin.android.fdroid/io.simplelogin.android.module.startup.StartupActivity}" drawable="simplelogin" name="SimpleLogin" />
   <item component="ComponentInfo{io.simplelogin.android/io.simplelogin.android.module.startup.StartupActivity}" drawable="simplelogin" name="SimpleLogin" />
+  <item component="ComponentInfo{io.simplelogin.android.fdroid/io.simplelogin.android.MainActivity}" drawable="simplelogin" name="SimpleLogin" />
   <item component="ComponentInfo{com.wbrawner.simplemarkdown.free/com.wbrawner.simplemarkdown.MainActivity}" drawable="simplemarkdown" name="SimpleMarkdown" />
   <item component="ComponentInfo{com.lighttigerxiv.simple.mp/com.lighttigerxiv.simple.mp.compose.activities.main.MainActivity}" drawable="just_player" name="SimpleMP" />
   <item component="ComponentInfo{com.automattic.simplenote/com.automattic.simplenote.NotesActivity}" drawable="simplenote" name="Simplenote" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->
linking archivetune and simplelogin

<!-- bot: icons -->
## Icons

### Linked
ArchiveTune (`moe.rukamori.archivetune` → `archivetune.svg`)
SimpleLogin (`io.simplelogin.android.fdroid` → `simplelogin.svg`)