### PR TITLE
+5 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -202,6 +202,7 @@
   <item component="ComponentInfo{org.joa.zipperplus7/org.test.flashtest.StartPageActivity}" drawable="_7zipper" name="7Zipper" />
   <item component="ComponentInfo{com.miniclip.eightballpool/zf235d911.x76eca624.k16362b0b.k7549afdc}" drawable="_8_ball_pool" name="8 Ball Pool" />
   <item component="ComponentInfo{com.miniclip.eightballpool/com.miniclip.eightballpool.EightBallPoolActivity}" drawable="_8_ball_pool" name="8 Ball Pool" />
+  <item component="ComponentInfo{jp.chikaharu11.instant_drumpad_tr808/jp.chikaharu11.instant_drumpad_tr808.MainActivity}" drawable="generic_grid_3x3" name="808 Drum Pad" />
   <item component="ComponentInfo{com.ilixa.ebp/com.ilixa.ebp.ui.MainActivity}" drawable="_8bit_photo_lab" name="8Bit Photo Lab" />
   <item component="ComponentInfo{com.abitdo.advance/com.abitdo.advance.activity.SearchActivity}" drawable="_8bitdo" name="8BitDo" />
   <item component="ComponentInfo{nl.browney.nintydayschallenge/nintydayschallenge.MainActivity}" drawable="_90_day_challenge" name="90 Day Challenge" />
@@ -14710,6 +14711,8 @@
   <item component="ComponentInfo{me.timschneeberger.rootlessjamesdsp/me.timschneeberger.rootlessjamesdsp.activity.MainActivity}" drawable="rootless_james_dsp" name="RootlessJamesDSP" />
   <item component="ComponentInfo{me.timschneeberger.rootlessjamesdsp/me.timschneeberger.rootlessjamesdsp.activity.OnboardingActivity}" drawable="rootless_james_dsp" name="RootlessJamesDSP" />
   <item component="ComponentInfo{pl.com.rossmann.centauros/pl.com.rossmann.centauros.splash.SplashActivityV6}" drawable="rossmann" name="Rossmann" />
+  <item component="ComponentInfo{de.rossmann.app.android/de.rossmann.app.android.ui.splash.SplashScreen}" drawable="rossmann" name="Rossmann" />
+  <item component="ComponentInfo{bitnet.hu.rossmann/com.rossmannmobile.MainActivity}" drawable="rossmann" name="Rossmann" />
   <item component="ComponentInfo{ru.kfc.kfc_delivery/com.kfc.MainActivity}" drawable="rostics" name="Rostic's" />
   <item component="ComponentInfo{ru.kfc.kfc_delivery/com.kfc.ui.activities.NativeModuleActivity}" drawable="rostics" name="Rostic's" />
   <item component="ComponentInfo{com.pranavpandey.rotation/com.pranavpandey.rotation.activity.SplashActivity}" drawable="generic_rotation" name="Rotation" />
@@ -19140,6 +19143,7 @@
   <item component="ComponentInfo{myrecorder.voicerecorder.voicememos.audiorecorder.recordingapp/com.myviocerecorder.voicerecorder.ui.activities.SplashActivity}" drawable="generic_voice_recorder_waves" name="Voice Recorder &amp; Voice Memos" />
   <item component="ComponentInfo{com.media.bestrecorder.audiorecorder/com.media.bestrecorder.audiorecorder.NavigationActivity}" drawable="voice_recorder_by_quality_apps" name="Voice Recorder by quality apps" />
   <item component="ComponentInfo{io.xato.voicereverser/io.xato.voicereverser.MainActivity}" drawable="voice_reverser" name="Voice Reverser" />
+  <item component="ComponentInfo{com.prometheusinteractive.voice_launcher/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="generic_microphone" name="Voice Search" />
   <item component="ComponentInfo{com.DevExtras.VoiceTools/crc6424aa7cfad14660ae.SplashActivity}" drawable="generic_microphone" name="Voice Tools" />
   <item component="ComponentInfo{com.DevExtras.VoiceTools/crc64ebabd5372c0ee16b.MainActivity}" drawable="generic_microphone" name="Voice Tools" />
   <item component="ComponentInfo{gpt.voice.chatgpt/gpt.voice.chatgpt.MainActivity}" drawable="voicegpt" name="VoiceGPT" />
@@ -19980,6 +19984,7 @@
   <item component="ComponentInfo{com.twoeightnine.root.xvii/com.twoeightnine.root.xvii.login.LoginActivity}" drawable="xvii" name="xvii" />
   <item component="ComponentInfo{com.owebso.svs.xylemlern/com.penpencil.physicswallah.activity.SplashActivity}" drawable="xylem" name="Xylem" />
   <item component="ComponentInfo{com.owebso.svs.xylemlern/com.penpencil.physicswallah.SplashActivityAliasNormal}" drawable="xylem" name="Xylem" />
+  <item component="ComponentInfo{de.yaacc/de.yaacc.browser.TabBrowserActivity}" drawable="generic_player" name="YAACC" />
   <item component="ComponentInfo{pwa.package/yagi_uda.activity}" drawable="yagi_uda" name="Yagi-Uda" />
   <item component="ComponentInfo{com.yahoo.mobile.client.android.ecauction/.activity.ECSplashScreenActivity}" drawable="yahoo_auctions" name="Yahoo! Auctions ~~ Yahoo!拍賣" />
   <item component="ComponentInfo{com.yahoo.mobile.client.android.ecauction/com.yahoo.mobile.client.android.ecauction.activity.ECSplashScreenActivity}" drawable="yahoo_auctions" name="Yahoo! Auctions ~~ Yahoo!拍賣" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
808 Drum Pad (`jp.chikaharu11.instant_drumpad_tr808` → `generic_grid_3x3.svg`)
Rossmann (`de.rossmann.app.android` → `rossmann.svg`)
Rossmann (`bitnet.hu.rossmann` → `rossmann.svg`)
Voice Search (`com.prometheusinteractive.voice_launcher` → `generic_microphone.svg`)
YAACC (`de.yaacc` → `generic_player.svg`)