### PR TITLE
+217 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -221,6 +221,7 @@
   <item component="ComponentInfo{eu.chainfire.liveboot/eu.chainfire.liveboot.MainActivity}" drawable="liveboot" name="[root] LiveBoot" />
   <item component="ComponentInfo{com.iternio.abrpapp/com.iternio.abrpapp.MainActivity}" drawable="a_better_routeplanner_abrp" name="A Better Routeplanner (ABRP)" />
   <item component="ComponentInfo{com.fizzd.connectedworlds/com.unity3d.player.UnityPlayerActivity}" drawable="a_dance_of_fire_and_ice" name="A Dance of Fire and Ice" />
+  <item component="ComponentInfo{com.fizzd.connectedworlds/com.fiveplay.mod.RMS.Recovery}" drawable="a_dance_of_fire_and_ice" name="A Dance of Fire and Ice" />
   <item component="ComponentInfo{com.myelane2_aw/com.myelane2_aw.MyElaneSplash}" drawable="a_and_w" name="A&amp;W" />
   <item component="ComponentInfo{com.myelane2_aw/com.aw.ordering.android.presentation.MainActivity}" drawable="a_and_w" name="A&amp;W" />
   <item component="ComponentInfo{by.a1.selfcare/com.tag.selfcare.tagselfcare.Launcher}" drawable="a1" name="A1" />
@@ -296,6 +297,8 @@
   <item component="ComponentInfo{de.szalkowski.activitylauncher/de.szalkowski.activitylauncher.MainActivity}" drawable="activity_launcher" name="Activity Launcher" />
   <item component="ComponentInfo{de.szalkowski.activitylauncher.rustore_fork/de.szalkowski.activitylauncher.rustore_fork.ui.activity.MainActivity}" drawable="activity_launcher" name="Activity Launcher" />
   <item component="ComponentInfo{de.szalkowski.activitylauncher.oss/de.szalkowski.activitylauncher.MainActivity}" drawable="activity_launcher" name="Activity Launcher" />
+  <item component="ComponentInfo{de.szalkowski.activitylauncher.oss/de.szalkowski.activitylauncher.entrypoint.MainActivity}" drawable="activity_launcher" name="Activity Launcher" />
+  <item component="ComponentInfo{de.szalkowski.activitylauncher/de.szalkowski.activitylauncher.entrypoint.MainActivity}" drawable="activity_launcher" name="Activity Launcher" />
   <item component="ComponentInfo{com.activitymanager/com.sdex.activityrunner.MainActivity}" drawable="activity_manager" name="Activity Manager" />
   <item component="ComponentInfo{wit.android.bcpBankingApp.activoBank/wit.android.bcpBankingApp.ui.activities.SplashScreenActivity}" drawable="activobank" name="ActivoBank" />
   <item component="ComponentInfo{wit.android.bcpBankingApp.activoBank/wit.android.bcpBankingApp.ui.activities.SlidingMenusActivity}" drawable="activobank" name="ActivoBank" />
@@ -403,6 +406,7 @@
   <item component="ComponentInfo{com.agc.toolKit/com.agc.gcam_tools.MainActivity}" drawable="agc_toolkit_pro" name="AGC ToolKit Pro" />
   <item component="ComponentInfo{web.id.isipulsa.appkita/com.w38s.StartupActivity}" drawable="agen_pulsa_termurah" name="Agen Pulsa Termurah" />
   <item component="ComponentInfo{es.aeat.dgc.mobile/es.aeat.dgc.mobile.ui.splash.SplashActivity}" drawable="agencia_tributaria" name="Agencia Tributaria" />
+  <item component="ComponentInfo{es.aeat.dgc.mobile/es.aeat.dgc.mobile.presentation.activities.start.StartActivity}" drawable="agencia_tributaria" name="Agencia Tributaria" />
   <item component="ComponentInfo{br.com.agfmais.android/br.com.agfmais.android.MainActivity}" drawable="agf" name="AGF" />
   <item component="ComponentInfo{com.and96.aggregator_news/com.and96.aggregator_news.MainActivity}" drawable="aggregator_news" name="Aggregator News" />
   <item component="ComponentInfo{com.agoda.mobile.consumer/com.agoda.mobile.consumer.screens.splash.AppLauncherActivity}" drawable="agoda" name="Agoda" />
@@ -421,6 +425,7 @@
   <item component="ComponentInfo{com.chatgpt.aichat.gpt3.aichatbot/com.example.chatgpt.ui.component.splash.SplashActivity}" drawable="ai_chat_ask_assistant" name="AI Chat Ask Assistant" />
   <item component="ComponentInfo{com.cem256.gptdetector/com.cem256.gptdetector.MainActivity}" drawable="ai_detector" name="AI Detector" />
   <item component="ComponentInfo{com.aidungeon/com.aidungeon.MainActivity}" drawable="ai_dungeon" name="AI Dungeon" />
+  <item component="ComponentInfo{com.aidungeon/com.aidungeon.app.MainActivity}" drawable="ai_dungeon" name="AI Dungeon" />
   <item component="ComponentInfo{com.gallery20/com.gallery20.activities.GalleryActivity}" drawable="generic_gallery" name="AI Gallery" />
   <item component="ComponentInfo{com.gallery20/com.gallery20.HomeActivity}" drawable="generic_gallery" name="AI Gallery" />
   <item component="ComponentInfo{com.aiphone.secondphonenumber/ai.braw.aiphone.StartActivity}" drawable="true_phone" name="AI Phone" />
@@ -644,6 +649,7 @@
   <item component="ComponentInfo{com.aloha.browser/com.alohamobile.browser.StarNavyIcon}" drawable="aloha_browser" name="Aloha Browser" />
   <item component="ComponentInfo{com.aloha.browser/com.alohamobile.browser.presentation.launcher.LauncherActivity}" drawable="aloha_browser" name="Aloha Browser" />
   <item component="ComponentInfo{com.alohamobile.browser/com.alohamobile.browser.presentation.launcher.LauncherActivity}" drawable="aloha_browser" name="Aloha Browser" />
+  <item component="ComponentInfo{com.aloha.browser/com.alohamobile.browser.Icon17}" drawable="aloha_browser" name="Aloha Browser" />
   <item component="ComponentInfo{alook.browser/alook.browser.LauncherActivity}" drawable="alook_browser" name="Alook Browser" />
   <item component="ComponentInfo{com.ruet_cse_1503050.ragib.appbackup.pro/com.ruet_cse_1503050.ragib.appbackup.pro.MainActivity}" drawable="alpha_backup_pro" name="Alpha Backup Pro" />
   <item component="ComponentInfo{com.ruet_cse_1503050.ragib.appbackup.pro/com.ruet_cse_1503050.ragib.appbackup.pro.activities.LauncherActivity}" drawable="alpha_backup_pro" name="Alpha Backup Pro" />
@@ -828,6 +834,7 @@
   <item component="ComponentInfo{org.aniplay.app/org.aniplay.app.MainActivity}" drawable="aniplay" name="Aniplay!" />
   <item component="ComponentInfo{com.mxt.anitrend/com.mxt.anitrend.view.activity.index.SplashActivity}" drawable="anitrend" name="AniTrend" />
   <item component="ComponentInfo{com.swiftsoft.anixartd/com.swiftsoft.anixartd.ui.activity.StartActivity}" drawable="anixart" name="Anixart" />
+  <item component="ComponentInfo{com.swiftsoft.anixartd/com.swiftsoft.anixartd.AppIconDefault}" drawable="anixart" name="Anixart" />
   <item component="ComponentInfo{xyz.jmir.tachiyomi.mi/eu.kanade.tachiyomi.ui.main.MainActivity}" drawable="generic_player" name="Aniyomi" />
   <item component="ComponentInfo{xyz.jmir.tachiyomi.mi.debug/eu.kanade.tachiyomi.ui.main.MainActivity}" drawable="generic_player_debug" name="Aniyomi Debug" />
   <item component="ComponentInfo{com.kamwithk.ankiconnectandroid/com.kamwithk.ankiconnectandroid.MainActivity}" drawable="ladb" name="Ankiconnect" />
@@ -1075,6 +1082,7 @@
   <item component="ComponentInfo{cm.aptoide.pt/com.aptoide.amethyst.MainActivity}" drawable="aptoide" name="Aptoide" />
   <item component="ComponentInfo{cm.aptoide.pt/cm.aptoide.pt.view.entry.EntryActivity}" drawable="aptoide" name="Aptoide" />
   <item component="ComponentInfo{cm.aptoide.pt/cm.aptoide.pt.view.MainActivity}" drawable="aptoide" name="Aptoide" />
+  <item component="ComponentInfo{cm.aptoide.pt/com.aptoide.android.aptoidegames.MainActivity}" drawable="aptoide" name="Aptoide" />
   <item component="ComponentInfo{pt.caixamagica.aptoide.uploader/com.aptoide.uploader.MainActivity}" drawable="aptoide_yukleyici" name="Aptoide Yükleyici" />
   <item component="ComponentInfo{com.apusapps.launcher/com.apusapps.launcher.app.DynamicVirtualEntryActivity}" drawable="apus_launcher" name="APUS Launcher" />
   <item component="ComponentInfo{com.lumiunited.aqarahome.play/com.lumiunited.aqara.main.SplashActivity}" drawable="aqara_home" name="Aqara Home" />
@@ -1108,6 +1116,8 @@
   <item component="ComponentInfo{moe.koiverse.archivetune/moe.koiverse.archivetune.MainActivity}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.MainActivity}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.DefaultIconAlias}" drawable="archivetune" name="ArchiveTune" />
+  <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.IconAliasd8836aa281d013ca23229cfc}" drawable="archivetune" name="ArchiveTune" />
+  <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.IconAlias544376e2699c4931e8414c1b}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{com.kanedias.archforums/com.kanedias.archforums.MainActivity}" drawable="archlinux_forums" name="Archlinux Forums" />
   <item component="ComponentInfo{com.google.ar.unity.arcore_depth_lab/com.unity3d.player.UnityPlayerActivity}" drawable="arcore_depth_lab" name="ARCore Depth Lab" />
   <item component="ComponentInfo{com.donnnno.arcticons.light/com.donnnno.arcticons.activities.SplashActivity}" drawable="arcticons_line_icons" name="Arcticons Black Icons" />
@@ -1132,6 +1142,7 @@
   <item component="ComponentInfo{com.ngame.allstar.eu/com.ngame.allstar.SGameActivity}" drawable="arena_of_valor" name="Arena of Valor" />
   <item component="ComponentInfo{com.homeretailgroup.argos.android/com.homeretailgroup.argos.android.splash.SplashActivity_Default}" drawable="argos" name="Argos" />
   <item component="ComponentInfo{com.filtershekanha.argovpn/com.filtershekanha.argovpn.ui.ActivityMain}" drawable="argovpn" name="ArgoVPN" />
+  <item component="ComponentInfo{com.filtershekanha.argovpn/com.filtershekanha.argovpn.ui.activity.MainActivity}" drawable="argovpn" name="ArgoVPN" />
   <item component="ComponentInfo{com.gianlu.aria2app/com.gianlu.aria2app.LoadingActivity}" drawable="aria2app" name="Aria2App" />
   <item component="ComponentInfo{jp.co.arigatobank.kifutown/jp.co.arigatobank.kifutown.MainActivity}" drawable="arigatobank" name="arigatobank" />
   <item component="ComponentInfo{hacker.launcher/aris.hacker.launcher.ui.HomeActivity}" drawable="aris_hacker_launcher" name="Aris Hacker Launcher" />
@@ -1164,6 +1175,7 @@
   <item component="ComponentInfo{at.davidschindler.askus/at.davidschindler.askus.RootActivity}" drawable="askus" name="askUs" />
   <item component="ComponentInfo{nl.devolksbank.asn.bankieren/nl.devolksbank.mobile.banking.splash.SplashActivity}" drawable="sns" name="ASN Bank" />
   <item component="ComponentInfo{com.asos.app/com.asos.app.ui.activities.ConfigActivity}" drawable="asos" name="ASOS" />
+  <item component="ComponentInfo{com.asos.app/com.asos.feature.settings.core.devsettings.ConfigActivity}" drawable="asos" name="ASOS" />
   <item component="ComponentInfo{com.gameloft.android.ANMP.GloftA8HM/com.byfen.archiver.MainActivity}" drawable="asphalt_8_airborne" name="Asphalt 8: Airborne" />
   <item component="ComponentInfo{com.gameloft.android.ANMP.GloftA8HM/com.gameloft.android.ANMP.GloftA8HM.MainActivity}" drawable="asphalt_8_airborne" name="Asphalt 8: Airborne" />
   <item component="ComponentInfo{com.gameloft.android.SAMS.GloftA9SS/com.gameloft.android.SAMS.GloftA9SS.MainActivity}" drawable="asphalt_legends" name="Asphalt Legends" />
@@ -1261,6 +1273,7 @@
   <item component="ComponentInfo{com.bdroid.audiomediaconverter/com.bdroid.audiomediaconverter.activity.LauncherActivity}" drawable="audio_converter" name="Audio Converter" />
   <item component="ComponentInfo{audioeditor.musiceditor.soundeditor.songeditor/app.better.audioeditor.activity.SplashActivity}" drawable="generic_audio_editor" name="Audio Editor" />
   <item component="ComponentInfo{com.shuojie.audioeditor/com.shuojie.audioeditor.activity.SplashActivity}" drawable="generic_audio_editor" name="Audio Editor" />
+  <item component="ComponentInfo{audioeditor.musiceditor.soundeditor.songeditor/com.min.n.MainActivity}" drawable="generic_audio_editor" name="Audio Editor" />
   <item component="ComponentInfo{promotionandeducation.audioguide/com.ryanheise.audioservice.AudioServiceActivity}" drawable="audio_guide" name="Audio Guide" />
   <item component="ComponentInfo{com.appzcloud.audioeditor/com.appzcloud.audioeditor.MainActivity}" drawable="generic_audio_editor" name="Audio MP3 Cutter" />
   <item component="ComponentInfo{com.certified.audionote/com.certified.audionote.ui.main.MainActivity}" drawable="generic_voice" name="Audio Notes" />
@@ -1351,6 +1364,7 @@
   <item component="ComponentInfo{com.joaomgcd.autoweb/com.joaomgcd.autoweb.activity.ActivityMain}" drawable="autoweb" name="AutoWeb" />
   <item component="ComponentInfo{com.zenthek.autozen/app.ui.main.ActivitySplashScreen}" drawable="autozen" name="AutoZen" />
   <item component="ComponentInfo{cz.jamesdeer.free.autotest/cz.jamesdeer.test.activity.SplashScreenActivity}" drawable="autoskola" name="Autoškola" />
+  <item component="ComponentInfo{cz.jamesdeer.free.autotest/cz.jamesdeer.test.activity.MainActivity}" drawable="autoskola" name="Autoškola" />
   <item component="ComponentInfo{org.oxycblt.auxio/org.oxycblt.auxio.MainActivity}" drawable="auxio" name="Auxio" />
   <item component="ComponentInfo{com.kddi.auwellnesspartner/com.kddi.au_wellness.MainActivity}" drawable="au_wellness" name="auウェルネス ~~ au Wellness" />
   <item component="ComponentInfo{com.kddi.android.aumail/com.kddi.android.aumail.MainActivity}" drawable="au_mail" name="auメール ~~ au mail" />
@@ -1506,6 +1520,7 @@
   <item component="ComponentInfo{br.com.bb.android/br.com.bb.android.StartActivity}" drawable="banco_do_brasil_bb" name="Banco do Brasil (BB)" />
   <item component="ComponentInfo{br.com.bb.android/br.com.bb.android.reactnative.ReactLoginActivity}" drawable="banco_do_brasil_bb" name="Banco do Brasil (BB)" />
   <item component="ComponentInfo{br.com.bb.android/br.com.bb.android.ReactNativeActivityAliasNormal}" drawable="banco_do_brasil_bb" name="Banco do Brasil (BB)" />
+  <item component="ComponentInfo{br.com.bb.android/br.com.bb.android.ReactNativeActivityAliasFestaJunina}" drawable="banco_do_brasil_bb" name="Banco do Brasil (BB)" />
   <item component="ComponentInfo{co.com.bancofalabella.mobile.omc/net.technisys.android.core.gui.ui.SplashScreen}" drawable="banco_falabella" name="Banco Falabella" />
   <item component="ComponentInfo{cl.android/net.technisys.android.core.gui.ui.SplashScreen}" drawable="banco_falabella" name="Banco Falabella" />
   <item component="ComponentInfo{per.bf.desa/net.technisys.android.core.gui.ui.SplashScreen}" drawable="banco_falabella" name="Banco Falabella" />
@@ -1736,6 +1751,7 @@
   <item component="ComponentInfo{com.beeper.chat/im.vector.app.features.Alias}" drawable="beeper_cloud" name="Beeper Cloud" />
   <item component="ComponentInfo{com.beeper.ima/com.beeper.chat.booper.MainActivity}" drawable="beeper" name="Beeper Mini" />
   <item component="ComponentInfo{se.dagsappar.beer/se.dagsappar.beer.app.BeerTimeActivity}" drawable="beer_with_me" name="Beer With Me" />
+  <item component="ComponentInfo{se.dagsappar.beer/se.dagsappar.beer.MainActivity}" drawable="beer_with_me" name="Beer With Me" />
   <item component="ComponentInfo{pl.beespeaker/pl.itcraft.beespeaker.MainActivity}" drawable="beespeaker" name="BeeSpeaker" />
   <item component="ComponentInfo{com.transsion.beez/com.transsion.tempo.ui.SplashActivity}" drawable="beez" name="Beez" />
   <item component="ComponentInfo{com.behance.behance/com.behance.network.ui.activities.MainActivity}" drawable="behance" name="Behance" />
@@ -1841,6 +1857,7 @@
   <item component="ComponentInfo{com.tpaay.bigpay/com.tpaay.bigpay.ui.intro.IntroActivity}" drawable="bigpay" name="BigPay" />
   <item component="ComponentInfo{io.github.aria_company_0065.bicycle_computer/io.github.aria_company_0065.bicycle_computer.MainActivity}" drawable="bike_computer" name="Bike Computer" />
   <item component="ComponentInfo{com.bikroy/se.saltside.activity.SplashActivity}" drawable="bikroy" name="Bikroy" />
+  <item component="ComponentInfo{com.bikroy/ng.jiji.app.ui.splash.SplashActivity}" drawable="bikroy" name="Bikroy" />
   <item component="ComponentInfo{ro.stbsa.ticketing/ro.stbsa.ticketing.MainActivity}" drawable="bilet_tb" name="Bilet TB" />
   <item component="ComponentInfo{com.bilibili.app.blue/tv.danmaku.bili.ui.splash.SplashActivity}" drawable="bilibili" name="BiliBili" />
   <item component="ComponentInfo{tv.danmaku.bili/tv.danmaku.bili.ui.splash.SplashActivity}" drawable="bilibili" name="BiliBili" />
@@ -1950,6 +1967,7 @@
   <item component="ComponentInfo{com.bittorrent.client/com.bittorrent.client.Main}" drawable="bittorrent" name="BitTorrent" />
   <item component="ComponentInfo{com.bittorrent.client/com.bittorrent.client.EntryActivity}" drawable="bittorrent" name="BitTorrent" />
   <item component="ComponentInfo{com.bittorrent.client/com.bittorrent.app.Main}" drawable="bittorrent" name="BitTorrent" />
+  <item component="ComponentInfo{com.bittorrent.client/com.bittorrent.app.SplashActivity}" drawable="bittorrent" name="BitTorrent" />
   <item component="ComponentInfo{com.bittorrent.client.pro/com.bittorrent.client.EntryActivity}" drawable="bittorrent_pro" name="BitTorrent Pro" />
   <item component="ComponentInfo{com.bittorrent.client.pro/com.bittorrent.client.Main}" drawable="bittorrent_pro" name="BitTorrent Pro" />
   <item component="ComponentInfo{com.bittorrent.client.pro/com.bittorrent.app.main.MainActivity}" drawable="bittorrent_pro" name="BitTorrent Pro" />
@@ -2053,6 +2071,7 @@
   <item component="ComponentInfo{com.sandboxol.blockymods/com.sandboxol.blockymods.view.activity.flash.SplashActivity}" drawable="blockman_go" name="Blockman Go" />
   <item component="ComponentInfo{com.staplegames.blocksSudokuSGGP/com.staplegames.blocksSudokuSGGP.MainActivity}" drawable="blocks" name="Blocks" />
   <item component="ComponentInfo{co.blocksite/co.blocksite.SplashScreenActivity}" drawable="blocksite" name="BlockSite" />
+  <item component="ComponentInfo{co.blocksite/co.blocksite.splash.SplashScreenActivity}" drawable="blocksite" name="BlockSite" />
   <item component="ComponentInfo{com.greenaddress.greenbits_android_wallet/com.greenaddress.greenbits.ui.PinActivity}" drawable="blockstream" name="Blockstream" />
   <item component="ComponentInfo{com.greenaddress.greenbits_android_wallet/com.blockstream.green.ui.MainActivity}" drawable="blockstream" name="Blockstream" />
   <item component="ComponentInfo{com.greenaddress.greenbits_android_wallet/com.blockstream.green.GreenActivity}" drawable="blockstream" name="Blockstream" />
@@ -2221,6 +2240,7 @@
   <item component="ComponentInfo{com.jakubtomana.discordbotdesinger/io.flutter.embedding.android.FlutterActivity}" drawable="bot_designer" name="Bot Designer" />
   <item component="ComponentInfo{im.thebot.messenger/im.thebot.messenger.BOTStartPage}" drawable="botim" name="Botim" />
   <item component="ComponentInfo{im.thebot.messenger/im.thebot.SplashActivity}" drawable="botim" name="botim" />
+  <item component="ComponentInfo{im.thebot.messenger/im.thebot.SplashAliasDefault}" drawable="botim" name="botim" />
   <item component="ComponentInfo{pampam.ibf2/com.unity3d.player.UnityPlayerActivity}" drawable="bottle_flip_3d" name="Bottle Flip 3D!" />
   <item component="ComponentInfo{com.games.bottle/com.unity3d.player.UnityPlayerActivity}" drawable="bottle_jump_3d" name="Bottle Jump 3D" />
   <item component="ComponentInfo{com.minigamelab.bouncedefense/com.google.firebase.MessagingUnityPlayerActivity}" drawable="bounce_defense" name="Bounce Defense" />
@@ -2279,6 +2299,7 @@
   <item component="ComponentInfo{com.unicostudio.braintest/com.google.android.archive.ReactivateActivity}" drawable="brain_test" name="Brain Test" />
   <item component="ComponentInfo{com.unicostudio.braintest2new/com.google.firebase.MessagingUnityPlayerActivity}" drawable="brain_test_2" name="Brain Test 2" />
   <item component="ComponentInfo{com.unicostudio.braintest2new/com.google.android.archive.ReactivateActivity}" drawable="brain_test_2" name="Brain Test 2" />
+  <item component="ComponentInfo{com.unicostudio.braintest2new/com.clevertap.unity.CleverTapOverrideActivity}" drawable="brain_test_2" name="Brain Test 2" />
   <item component="ComponentInfo{com.unicostudio.braintest3/com.unity3d.player.UnityPlayerActivity}" drawable="brain_test_3" name="Brain Test 3" />
   <item component="ComponentInfo{com.unicostudio.braintest3/com.google.firebase.MessagingUnityPlayerActivity}" drawable="brain_test_3" name="Brain Test 3" />
   <item component="ComponentInfo{com.unicostudio.braintest4/com.google.firebase.MessagingUnityPlayerActivity}" drawable="brain_test_4" name="Brain Test 4" />
@@ -2553,6 +2574,7 @@
   <item component="ComponentInfo{com.adhoclabs.burner/co.adhoclabs.burner.features.home.presentation.ui.MainActivity.DefaultMint}" drawable="burner" name="Burner" />
   <item component="ComponentInfo{com.adhoclabs.burner/com.adhoclabs.burner.MainActivity}" drawable="burner" name="Burner" />
   <item component="ComponentInfo{br.com.projectnetwork.onibus/br.com.projectnetwork.onibus.presenter.map.MapActivity}" drawable="bus_is_coming" name="Bus is Coming" />
+  <item component="ComponentInfo{br.com.projectnetwork.onibus/br.com.projectnetwork.onibus.ui.mapa.MapActivity}" drawable="bus_is_coming" name="Bus is Coming" />
   <item component="ComponentInfo{com.mosko.bus/com.mosko.bus.MainActivity}" drawable="bus_nearby" name="Bus Nearby ~~ אוטובוס קרוב" />
   <item component="ComponentInfo{com.maleo.bussimulatorid/com.byfen.archiver.MainActivity}" drawable="bus_simulator_indonesia" name="Bus Simulator Indonesia" />
   <item component="ComponentInfo{com.maleo.bussimulatorid/com.hendrachannel.MainActivity}" drawable="bus_simulator_indonesia" name="Bus Simulator Indonesia" />
@@ -2585,6 +2607,7 @@
   <item component="ComponentInfo{com.jamworks.bxactions/com.jamworks.bxactions.SettingsHome}" drawable="bxactions" name="bxActions" />
   <item component="ComponentInfo{com.byu.id/com.byu.id.MainActivity}" drawable="by_u" name="by.U" />
   <item component="ComponentInfo{com.byu.id/com.cxos.tsel.byu.MainActivity}" drawable="by_u" name="by.U" />
+  <item component="ComponentInfo{com.byu.id/com.byu.id.MainActivityDefault}" drawable="by_u" name="by.U" />
   <item component="ComponentInfo{com.bybit.app/com.bybit.pro.MainActivity}" drawable="bybit" name="Bybit" />
   <item component="ComponentInfo{io.github.romanvht.byedpi/io.github.dovecoteescapee.byedpi.activities.MainActivity}" drawable="byebyedpi" name="ByeByeDPI" />
   <item component="ComponentInfo{io.github.romanvht.byedpi/io.github.romanvht.byedpi.activities.MainActivity}" drawable="byebyedpi" name="ByeByeDPI" />
@@ -2633,6 +2656,7 @@
   <item component="ComponentInfo{br.com.gabba.Caixa/br.lFeqg6.kRFD27.owRYO2.ui.kz10X0.zV6WX0}" drawable="caixa" name="CAIXA" />
   <item component="ComponentInfo{br.com.gabba.Caixa/br.memQJ5.oXxRX7.vXO4m0.ui.gtGBP9.StartActivity}" drawable="caixa" name="CAIXA" />
   <item component="ComponentInfo{br.com.gabba.Caixa/br.fRsW77.sXBQU8.dxWE84.ui.nTiqf2.rWGis9}" drawable="caixa" name="CAIXA" />
+  <item component="ComponentInfo{br.com.gabba.Caixa/br.rB57t0.cIgGU5.wQkoN0.ui.h1Yhw5.ltbmj5}" drawable="caixa" name="CAIXA" />
   <item component="ComponentInfo{br.gov.caixa.tem/br.gov.caixa.tem.ui.activities.SplashScreenAnimation}" drawable="caixa_tem" name="CAIXA Tem" />
   <item component="ComponentInfo{br.gov.caixa.tem/br.w9077349a.n12795491.q1539203d.ui.m258471f8.pde868716}" drawable="caixa_tem" name="CAIXA Tem" />
   <item component="ComponentInfo{br.gov.caixa.tem/br.c633fe115.y9fbbda38.j2d87e4e2.ui.d1f43a2a6.k5c6e3acc}" drawable="caixa_tem" name="CAIXA Tem" />
@@ -3202,6 +3226,7 @@
   <item component="ComponentInfo{com.chargemap_beta.android/com.chargemap.feature.loading.presentation.LoadingActivity}" drawable="chargemap" name="Chargemap" />
   <item component="ComponentInfo{com.chargemap_beta.android/com.chargemap_beta.android.ChargeMapActivity}" drawable="chargemap" name="Chargemap" />
   <item component="ComponentInfo{com.coulombtech/com.cp.ui.activity.launcher.LauncherActivity}" drawable="chargepoint" name="ChargePoint" />
+  <item component="ComponentInfo{com.coulombtech/com.cp.applauncher.ui.AppLauncherActivity}" drawable="chargepoint" name="ChargePoint" />
   <item component="ComponentInfo{com.charging.fun/com.charging.fun.activities.SplashActivity}" drawable="charging_fun" name="Charging Fun" />
   <item component="ComponentInfo{in.chartr.transit/in.chartr.transit.activities.SplashScreenActivity}" drawable="chartr" name="Chartr" />
   <item component="ComponentInfo{in.chartr.transit/in.chartr.transit.onboarding.SplashScreenActivity}" drawable="chartr" name="Chartr" />
@@ -3349,6 +3374,7 @@
   <item component="ComponentInfo{com.cimbph.app2022/com.ocft.SplashActivity}" drawable="cimb" name="CIMB" />
   <item component="ComponentInfo{com.cimb.sg.clicksMobile/com.cimb.sg.clicksMobile.MainActivity}" drawable="cimb" name="CIMB" />
   <item component="ComponentInfo{com.cimb.cimbocto/my.com.cimbocto.app.MainActivity}" drawable="cimb" name="CIMB OCTO MY" />
+  <item component="ComponentInfo{com.cimb.cimbocto/my.com.cimbocto.app.AppLauncherActivity}" drawable="cimb" name="CIMB OCTO MY" />
   <item component="ComponentInfo{com.naughty.cinegato/com.gxgx.daqiandy.ui.splash.SplashActivity}" drawable="cinegato" name="Cinegato" />
   <item component="ComponentInfo{am.app.cult.cinemastar/am.app.cult.cinemastar.ui.splashscreen.SplashScreenActivity}" drawable="cinema_star" name="Cinema Star" />
   <item component="ComponentInfo{com.apptory.cinemark/com.cinepapaya.ckc_app_flutter.MainActivity}" drawable="cinemark" name="Cinemark" />
@@ -3361,6 +3387,7 @@
   <item component="ComponentInfo{pt.nos.cinemas/pt.nos.cinemas.MainActivity}" drawable="cinemas_nos" name="Cinemas NOS" />
   <item component="ComponentInfo{com.cinemex/com.cinemex.cinemex.views.activities.SplashActivity}" drawable="cinemex" name="Cinemex" />
   <item component="ComponentInfo{com.fivemobile.cineplex/com.cineplex.MainActivity}" drawable="cineplex" name="Cineplex" />
+  <item component="ComponentInfo{com.fivemobile.cineplex/com.fivemobile.cineplex.MainActivity}" drawable="cineplex" name="Cineplex" />
   <item component="ComponentInfo{com.fidloo.cinexplore/com.fidloo.cinexplore.presentation.ui.launcher.LauncherActivity}" drawable="cinexplore" name="Cinexplore" />
   <item component="ComponentInfo{com.fidloo.cinexplore/com.fidloo.cinexplore.app.MainActivity}" drawable="cinexplore" name="Cinexplore" />
   <item component="ComponentInfo{air.Cinepolis/mx.com.ia.cinepolis4.ui.splash.SplashActivity}" drawable="cinepolis" name="Cinépolis" />
@@ -3370,6 +3397,8 @@
   <item component="ComponentInfo{com.wmp.cinepolisbr/com.webedia.optimusprime.ui.splash.SplashActivity}" drawable="cinepolis" name="Cinépolis" />
   <item component="ComponentInfo{com.cinepolis.go/dur3.q92M.QUSE}" drawable="cinepolis" name="Cinépolis Go" />
   <item component="ComponentInfo{com.cinepolis.go/BI4B.nRWf.sMjc}" drawable="cinepolis" name="Cinépolis Go" />
+  <item component="ComponentInfo{com.cinepolis.go/wAZ6x9.hHiQM6.uSl4e3.yODEW4}" drawable="cinepolis" name="Cinépolis Go" />
+  <item component="ComponentInfo{com.cinepolis.go/rP0md4.iRGq56.lWEu00.lnPc45}" drawable="cinepolis" name="Cinépolis Go" />
   <item component="ComponentInfo{so.circle.circle/so.circle.circle.MainActivity}" drawable="circle" name="Circle" />
   <item component="ComponentInfo{com.gohn.shapecutter/com.gohn.shapecutter.ui.activity.MainActivity}" drawable="circle_cutter" name="Circle Cutter" />
   <item component="ComponentInfo{com.modetime.circle/com.modetime.circle.MainActivity}" drawable="asr_voice_recorder" name="Circle Icons" />
@@ -3795,6 +3824,8 @@
   <item component="ComponentInfo{com.coppel.coppelapp/oGCSj5.mKCAZ2.bF7je1.afFQS0.utBYV9.or0VD5}" drawable="bancoppel" name="Coppel" />
   <item component="ComponentInfo{com.coppel.coppelapp/gQFvU6.gesY72.gdKsn1.yDigQ7.r3FH22.eEjfj2}" drawable="bancoppel" name="Coppel" />
   <item component="ComponentInfo{com.coppel.coppelapp/djxOS4.pgL2k6.kC5fa7.seSVe7.bLPYw9.zf0bh8}" drawable="bancoppel" name="Coppel" />
+  <item component="ComponentInfo{com.coppel.coppelapp/kNi8d4.kS8c20.zX5Bw7.uyACj5.zw66L0.d4ipA8}" drawable="bancoppel" name="Coppel" />
+  <item component="ComponentInfo{com.coppel.coppelapp/yHIAY4.yHWUh5.hgMCU4.jTTfa4.eGjxw2.rj0kT1}" drawable="bancoppel" name="Coppel" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.coptic/com.anysoftkeyboard.languagepack.coptic.MainActivity}" drawable="anysoftkeyboard" name="Coptic for AnySoftKeyboard" />
   <item component="ComponentInfo{com.weberdo.apps.copy/com.weberdo.apps.copy.MainActivity}" drawable="copy" name="Copy" />
   <item component="ComponentInfo{com.mediamushroom.copymydata/com.mediamushroom.copymydata.app.SplashActivity}" drawable="copy_my_data" name="Copy My Data" />
@@ -3823,6 +3854,7 @@
   <item component="ComponentInfo{intl.costco.com.mobile.australia/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{intl.costco.com.mobile.uk/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{com.couchsurfing.mobile.android/com.couchsurfing.mobile.ui.WelcomeActivity}" drawable="couchsurfing" name="Couchsurfing" />
+  <item component="ComponentInfo{com.couchsurfing.mobile.android/com.couchsurfing.mobile.MainActivity}" drawable="couchsurfing" name="Couchsurfing" />
   <item component="ComponentInfo{com.jupli.countdowntoanything/com.jupli.countdowntoanything.MainActivity}" drawable="countdown_to_anything" name="Countdown To Anything" />
   <item component="ComponentInfo{me.gira.widget.countdown/me.gira.widget.countdown.MainActivity}" drawable="countdown_widget" name="Countdown Widget" />
   <item component="ComponentInfo{me.gira.widget.countdown/me.gira.widget.countdown.activities.SplashActivity}" drawable="countdown_widget" name="Countdown Widget" />
@@ -3862,6 +3894,7 @@
   <item component="ComponentInfo{uk.co.bnpparibaspf.strategicoam/uk.co.bnpparibaspf.strategicoam.main.MainActivity}" drawable="creation_finance" name="Creation Finance" />
   <item component="ComponentInfo{com.kubix.creative/com.kubix.creative.activity.IntroActivity}" drawable="creativeapp" name="CreativeApp" />
   <item component="ComponentInfo{com.dreamplug.androidapp/com.dreamplug.androidapp.SplashActivity}" drawable="cred" name="CRED" />
+  <item component="ComponentInfo{com.dreamplug.androidapp/com.dreamplug.androidapp.CredFlutterActivity}" drawable="cred" name="CRED" />
   <item component="ComponentInfo{bh.com.credimax.app/bh.com.credimax.app.activity.MainActivity}" drawable="credimax" name="CrediMax" />
   <item component="ComponentInfo{it.caitalia.apphub/com.creditagricole.MainActivity}" drawable="credit_agricole" name="Credit Agricole" />
   <item component="ComponentInfo{com.csg.creditsuisse.twint/ch.twint.payment.ui.activities.start.StartActivity}" drawable="credit_suisse_twint" name="Credit Suisse TWINT" />
@@ -3942,6 +3975,7 @@
   <item component="ComponentInfo{com.froxot.cuscon/com.froxot.cuscon.activities.MainActivity}" drawable="cuscon" name="Cuscon" />
   <item component="ComponentInfo{com.nyx.custom_uploader/com.nyx.custom_uploader.MainActivity}" drawable="custom_uploader" name="Custom Uploader" />
   <item component="ComponentInfo{com.customuse.customuse/com.customuse.customuse.BrowserLauncherActivity}" drawable="customuse" name="Customuse" />
+  <item component="ComponentInfo{com.customuse.customuse/com.customuse.customuse.MainActivity}" drawable="customuse" name="Customuse" />
   <item component="ComponentInfo{com.xprodev.cutcam/org.saturn.splash.sdk.activity.SplashMainActivity}" drawable="cut_cut" name="Cut Cut" />
   <item component="ComponentInfo{com.zeptolab.ctr.ads/com.zeptolab.ctr.CtrApp}" drawable="cut_the_rope" name="Cut the Rope" />
   <item component="ComponentInfo{com.zeptolab.ctror.subscr.tier/com.zeptolab.ctr.CtrApp}" drawable="cut_the_rope" name="Cut the Rope" />
@@ -4002,6 +4036,7 @@
   <item component="ComponentInfo{com.dailyobjects/com.dailyobjects.marche.main.MainActivity}" drawable="dailyobjects" name="DailyObjects" />
   <item component="ComponentInfo{partl.dailypic/partl.dailypic.MainActivity}" drawable="dailypic" name="DailyPic" />
   <item component="ComponentInfo{free.daily.tube.background/free.daily.tube.background.main.MainActivity}" drawable="dailytube" name="DailyTube" />
+  <item component="ComponentInfo{com.magneticchen.daijishou/com.magneticchen.daijishou.ui.activities.RescueActivity}" drawable="daijisho" name="DaiRescue" />
   <item component="ComponentInfo{com.damonplay.damonps2.free/com.damonplay.damonps2.SplashActivity}" drawable="ppsspp" name="DamonPS2" />
   <item component="ComponentInfo{com.damonplay.damonps2.pro.ppsspp/com.damonplay.damonps2.SplashActivity}" drawable="ppsspp_gold" name="DamonPS2 Pro" />
   <item component="ComponentInfo{id.dana/id.dana.onboarding.splash.DanaSplashActivity}" drawable="dana" name="DANA" />
@@ -4058,6 +4093,7 @@
   <item component="ComponentInfo{com.dayoneapp.dayone/com.dayoneapp.dayone.main.SplashActivity}" drawable="day_one_journal" name="Day One Journal" />
   <item component="ComponentInfo{com.daybridge.android/com.daybridge.android.ui.MainActivity}" drawable="daybridge" name="Daybridge" />
   <item component="ComponentInfo{com.dayforce.mobile/com.dayforce.mobile.ui_login.SSOLoginHandlerActivity}" drawable="dayforce" name="Dayforce" />
+  <item component="ComponentInfo{com.dayforce.mobile/com.dayforce.mobile.ui_login.AppStartActivity}" drawable="dayforce" name="Dayforce" />
   <item component="ComponentInfo{net.daylio/net.daylio.OverviewActivity}" drawable="daylio" name="Daylio" />
   <item component="ComponentInfo{net.daylio/net.daylio.activities.OverviewActivity}" drawable="daylio" name="Daylio" />
   <item component="ComponentInfo{com.dazn/com.dazn.splash.view.SplashScreenActivity}" drawable="dazn" name="DAZN" />
@@ -4107,6 +4143,7 @@
   <item component="ComponentInfo{es.treebit.decisionroulette/com.unity3d.player.UnityPlayerActivity}" drawable="decision_roulette" name="Decision Roulette" />
   <item component="ComponentInfo{com.rivafarabi.deckboard.pro/com.rivafarabi.deckboard.pro.MainActivity}" drawable="deckboard_pro" name="Deckboard PRO" />
   <item component="ComponentInfo{com.gm.decolar/com.despegar.whitelabel.home.ui.splash.SplashActivity}" drawable="decolar" name="Decolar" />
+  <item component="ComponentInfo{com.gm.decolar/com.despegar.whitelabel.DefaultLauncher}" drawable="decolar" name="Decolar" />
   <item component="ComponentInfo{com.deen/com.deen.MainActivity}" drawable="deen" name="Deen" />
   <item component="ComponentInfo{com.deepl.mobiletranslator/com.google.android.archive.ReactivateActivity}" drawable="deepl" name="DeepL" />
   <item component="ComponentInfo{com.example.deeplviewer/com.example.deeplviewer.activity.MainActivity}" drawable="deepl" name="DeepL" />
@@ -4125,6 +4162,7 @@
   <item component="ComponentInfo{deezer.android.app/deezer.android.app.DZMidlet}" drawable="deezer" name="Deezer" />
   <item component="ComponentInfo{deezer.android.app/dz.ApplicationScreens}" drawable="deezer" name="Deezer" />
   <item component="ComponentInfo{deezer.android.app/com.deezer.android.ui.activity.LauncherActivityDark}" drawable="deezer" name="Deezer" />
+  <item component="ComponentInfo{deezer.android.app/com.deezer.android.ui.activity.LauncherActivityValentines}" drawable="deezer" name="Deezer" />
   <item component="ComponentInfo{com.defi.wallet/com.defi.wallet.feature.SplashActivity}" drawable="defi_wallet" name="DeFi Wallet" />
   <item component="ComponentInfo{com.fitness.debugger/com.googlefit.tester.MainActivity}" drawable="defit" name="DeFit" />
   <item component="ComponentInfo{nl.degiro.trader/nl.degiro.trader.MainActivity}" drawable="degiro" name="DEGIRO" />
@@ -4193,6 +4231,7 @@
   <item component="ComponentInfo{com.candelalabs.devbytes/com.candelalabs.devbytes.ComposeMainActivityDefault}" drawable="devbytes" name="DevBytes" />
   <item component="ComponentInfo{com.candelalabs.devbytes/com.candelalabs.devbytes.ComposeMainActivity}" drawable="devbytes" name="DevBytes" />
   <item component="ComponentInfo{com.candelalabs.devbytes/com.candelalabs.devbytes.ui.main.view.activities.MainActivity}" drawable="devbytes" name="DevBytes" />
+  <item component="ComponentInfo{com.candelalabs.devbytes/com.candelalabs.devbytes.ComposeMainActivityFrozen}" drawable="devbytes" name="DevBytes" />
   <item component="ComponentInfo{flar2.devcheck/flar2.devcheck.ui.MainActivity2}" drawable="devcheck" name="DevCheck" />
   <item component="ComponentInfo{flar2.devcheck/flar2.devcheck.MainActivity}" drawable="devcheck" name="DevCheck" />
   <item component="ComponentInfo{flar2.devcheck/flar2.devcheck.SplashActivity}" drawable="devcheck" name="DevCheck" />
@@ -4408,6 +4447,7 @@
   <item component="ComponentInfo{com.dkbcodefactory.banking/com.dkbcodefactory.banking.screens.splash.SplashActivity}" drawable="dkb" name="DKB" />
   <item component="ComponentInfo{com.dkbcodefactory.banking/com.dkbcodefactory.banking.screens.home.HomeActivity}" drawable="dkb" name="DKB" />
   <item component="ComponentInfo{com.dkbcodefactory.banking/com.dkbcodefactory.banking.screens.BankingAppActivity}" drawable="dkb" name="DKB" />
+  <item component="ComponentInfo{com.dkbcodefactory.banking/com.dkbcodefactory.banking.RoutingDefault}" drawable="dkb" name="DKB" />
   <item component="ComponentInfo{com.starfinanz.mobile.android.dkbpushtan/com.starfinanz.mobile.android.dkbpushtan.DKBPushTan}" drawable="dkb_tan2go" name="DKB-TAN2go" />
   <item component="ComponentInfo{be.dkv.dkvbelgium/be.dkv.dkvbelgium.MainActivity}" drawable="copy" name="DKV Insurance" />
   <item component="ComponentInfo{de.deutschlandfunk.dlfaudiothek/de.deutschlandradio.app.MainActivity}" drawable="dlf" name="Dlf" />
@@ -4442,6 +4482,7 @@
   <item component="ComponentInfo{com.skydot.docxreader.docx.docxviewer.document.doc.office.viewer.reader.word/com.skydot.docxreader.ui.ActivityMain}" drawable="docx_reader" name="Docx Reader" />
   <item component="ComponentInfo{com.skydot.docxreader.docx.docxviewer.document.doc.office.viewer.reader.word/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="docx_reader" name="Docx Reader" />
   <item component="ComponentInfo{com.alldocumentreader.office.viewer.filesreader/com.alldocumentreader.office.viewer.filesreader.activities.SplashScreenActivity}" drawable="document_reader" name="Docx Reader" />
+  <item component="ComponentInfo{com.alldocumentreader.office.viewer.filesreader/com.alldocumentreader.office.viewer.filesreader.activities.RouterScreen}" drawable="docx_reader" name="Docx Reader" />
   <item component="ComponentInfo{com.dodo.app.twa/com.dodo.app.twa.LauncherActivity}" drawable="dodo" name="Dodo" />
   <item component="ComponentInfo{ru.dodopizza.app/ru.dodopizza.app.presentation.main.MainActivity}" drawable="dodo_pizza" name="Dodo Pizza" />
   <item component="ComponentInfo{ru.dodopizza.app/ru.dodopizza.app.presentation.splash.SplashActivity}" drawable="dodo_pizza" name="Dodo Pizza" />
@@ -4540,6 +4581,7 @@
   <item component="ComponentInfo{com.co.dominos/com.dominos.loadingscreen.InitialLaunchActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{cl.dominospizza.dominoschile/cl.dominospizza.dominoschile.SplashScreenActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{com.molo.dominos/com.dominos.loadingscreen.InitialLaunchActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
+  <item component="ComponentInfo{zena.dominos/com.dominos.loadingscreen.InitialLaunchActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{com.LoopGames.Domino/com.unity3d.player.UnityPlayerActivity}" drawable="dominoes" name="Dominoes" />
   <item component="ComponentInfo{com.LoopGames.Domino/com.google.firebase.MessagingUnityPlayerActivity}" drawable="dominoes" name="Dominoes" />
   <item component="ComponentInfo{pl.dominium/pl.dominium.feature.main.MainActivity}" drawable="dominos_pizza" name="Domino’s Pizza" />
@@ -4700,6 +4742,7 @@
   <item component="ComponentInfo{com.drip/com.drip.MainActivity}" drawable="drip" name="drip" />
   <item component="ComponentInfo{mx.drivepp.drive/mx.driveapp.MainActivity}" drawable="drive" name="Drive" />
   <item component="ComponentInfo{com.drive2/com.drive2.v3.ui.activity.StartupActivity}" drawable="drive2" name="DRIVE2" />
+  <item component="ComponentInfo{com.drive2/com.drive2.splash.StartupActivity}" drawable="drive2" name="DRIVE2" />
   <item component="ComponentInfo{com.softwarebakery.drivedroid/com.softwarebakery.drivedroid.MainActivity}" drawable="drivedroid" name="DriveDroid" />
   <item component="ComponentInfo{com.drivee.taxi.rides/com.drivee.taxi.rides.ui.splash.SplashActivity}" drawable="drivee" name="Drivee" />
   <item component="ComponentInfo{com.androidfung.drminfo/com.androidfung.drminfo.MobileActivity}" drawable="drm_info" name="DRM Info" />
@@ -4729,6 +4772,7 @@
   <item component="ComponentInfo{com.collegehumor.chdropout/tv.vhx.LauncherActivity}" drawable="dropout" name="Dropout" />
   <item component="ComponentInfo{com.languagedrops.drops.international/com.languagedrops.drops.international.MainActivity}" drawable="drops" name="Drops" />
   <item component="ComponentInfo{org.yoki.android.drops/org.yoki.android.buienalarm.activity.LaunchActivity}" drawable="buienalarm" name="Drops" />
+  <item component="ComponentInfo{org.yoki.android.drops/org.yoki.android.buienalarm.launcher.LaunchActivity}" drawable="buienalarm" name="Drops" />
   <item component="ComponentInfo{com.drops.icons/com.drops.icons.MainActivity}" drawable="drops_icons" name="Drops Icons" />
   <item component="ComponentInfo{com.languagedrops.drops.learn.learning.speak.language.english.british.gb.words/com.languagedrops.drops.international.MainActivity}" drawable="drops_learn_british_english" name="Drops: Learn British English" />
   <item component="ComponentInfo{com.ttxapps.dropsync/com.ttxapps.sync.app.MainActivity}" drawable="dropsync" name="Dropsync" />
@@ -4761,6 +4805,7 @@
   <item component="ComponentInfo{com.olxmena.horizontal/pl.olx.activities.TakeOverActivityMena}" drawable="dubizzle" name="dubizzle" />
   <item component="ComponentInfo{com.dubizzle.horizontal/com.dubizzle.horizontal.activities.routing.RoutingActivity}" drawable="dubizzle" name="dubizzle" />
   <item component="ComponentInfo{com.empg.olxkw/com.empg.olxkw.MainActivity}" drawable="dubizzle" name="dubizzle" />
+  <item component="ComponentInfo{com.olxmena.horizontal/com.olxmena.horizontal.MainActivity}" drawable="dubizzle" name="dubizzle" />
   <item component="ComponentInfo{com.duckduckgo.mobile.android/com.duckduckgo.app.launch.LaunchActivity}" drawable="duckduckgo" name="DuckDuckGo" />
   <item component="ComponentInfo{com.duckduckgo.mobile.android/com.duckduckgo.app.launch.LauncherBlack}" drawable="duckduckgo" name="DuckDuckGo" />
   <item component="ComponentInfo{com.duckduckgo.mobile.android/com.duckduckgo.app.launch.LauncherBlue}" drawable="duckduckgo" name="DuckDuckGo" />
@@ -4837,6 +4882,13 @@
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakSaverLauncher2}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.SeasonalLauncher3}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.SeasonalLauncher2}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakFrozenLauncher1ExclamationMarks}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakFrozenLauncher2Snowflake}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakFrozenLauncher2}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakFrozenLauncher2IceCube}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakFrozenLauncher2FrozenFace}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakSaverLauncher4Hourglass}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.BackgroundedLauncher}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.rstgames.durak/com.rstgames.durak.StartActivity}" drawable="durak_online" name="Durak Online" />
   <item component="ComponentInfo{com.rstgames.durak/com.rstgames.durak.jvsFjEBbonfbs}" drawable="durak_online" name="Durak Online" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.dutch_oss/com.anysoftkeyboard.languagepack.dutch_oss.MainActivity}" drawable="anysoftkeyboard" name="Dutch for AnySoftKeyboard" />
@@ -4882,6 +4934,7 @@
   <item component="ComponentInfo{com.corelink.earfun/com.corelink.earfun.page.login.WelcomeActivity}" drawable="earfun" name="EarFun" />
   <item component="ComponentInfo{com.corelink.earfun/com.corelink.earfun.page.activity.LoadingActivity}" drawable="earfun" name="EarFun" />
   <item component="ComponentInfo{us.current.android/com.current.android.feature.seasonalTheming.alias.DefaultLauncherAlias}" drawable="earn" name="Earn" />
+  <item component="ComponentInfo{us.current.android/com.current.android.feature.seasonalTheming.alias.IndependenceDayLauncherAlias}" drawable="earn" name="Earn" />
   <item component="ComponentInfo{com.afkettler.earth/com.afkettler.earth.LauncherActivity}" drawable="generic_earth" name="Earth &amp; Moon" />
   <item component="ComponentInfo{com.afkettler.pro.earth/com.afkettler.earth.LauncherActivity}" drawable="generic_earth_pro" name="Earth &amp; Moon Pro" />
   <item component="ComponentInfo{com.miui.miwallpaper.earth/com.miui.miwallpaper.earth.MainActivity}" drawable="earth_super_wallpapers_configuration" name="Earth Super Wallpapers Configuration" />
@@ -5061,6 +5114,7 @@
   <item component="ComponentInfo{us.nobarriers.elsa/us.nobarriers.elsa.screens.launcher.LauncherV2Screen}" drawable="elsa_speak" name="ELSA Speak" />
   <item component="ComponentInfo{us.nobarriers.elsa/us.nobarriers.elsa.screens.launcher.AppIconLauncherActivity}" drawable="elsa_speak" name="ELSA Speak" />
   <item component="ComponentInfo{us.nobarriers.elsa/us.nobarriers.elsa.screens.launcher.LauncherActivity}" drawable="elsa_speak" name="ELSA Speak" />
+  <item component="ComponentInfo{us.nobarriers.elsa/us.nobarriers.elsa.MainActivity}" drawable="elsa_speak" name="ELSA Speak" />
   <item component="ComponentInfo{de.elster.elstersecure.app/com.secunet.protect4use.app.JniActivity}" drawable="elstersecure" name="ElsterSecure" />
   <item component="ComponentInfo{no.vg.lab.zapp/no.vg.lab.zapp.MainActivity}" drawable="elton" name="Elton" />
   <item component="ComponentInfo{no.applics.hafslund/no.applics.hafslund.MainActivity}" drawable="elvia" name="Elvia" />
@@ -5090,6 +5144,7 @@
   <item component="ComponentInfo{com.emirates.ek.android/com.emirates.startup.StartupActivity}" drawable="emirates" name="Emirates" />
   <item component="ComponentInfo{com.flow.mobile/com.flow.mobile.MainActivity}" drawable="emochi" name="Emochi" />
   <item component="ComponentInfo{com.flow.mobile/com.flow.mobile.ui.SplashActvity}" drawable="emochi" name="Emochi" />
+  <item component="ComponentInfo{com.flow.mobile/com.flow.mobile.ui.SplashActivity}" drawable="emochi" name="Emochi" />
   <item component="ComponentInfo{com.sixwaves.emojipop/.GameActivity}" drawable="emoji_pop" name="Emoji Pop" />
   <item component="ComponentInfo{futuristicgoo.emotic/futuristicgoo.emotic.MainActivity}" drawable="emotic" name="Emotic" />
   <item component="ComponentInfo{info.justoneplanet.android.kaomoji/info.justoneplanet.android.kaomoji.MainActivity}" drawable="emoticon_dictionary" name="Emoticon Dictionary" />
@@ -5147,6 +5202,7 @@
   <item component="ComponentInfo{com.entel.movil/com.entel.movil.MainActivity}" drawable="entel" name="Entel" />
   <item component="ComponentInfo{vn.com.encapital.arrow/vn.com.encapital.arrow.MainActivity}" drawable="entrade_x" name="EnTrade X" />
   <item component="ComponentInfo{me.entri.entrime/me.entri.entrime.activities.Splash}" drawable="entri" name="Entri" />
+  <item component="ComponentInfo{me.entri.entrime/me.entri.entrime.IconNormal}" drawable="entri" name="Entri" />
   <item component="ComponentInfo{com.entrust.identityGuard.mobile/com.entrust.identityGuard.mobile.MainActivity}" drawable="entrust_identity" name="Entrust Identity" />
   <item component="ComponentInfo{no.entur/no.entur.MainActivity}" drawable="entur" name="Entur" />
   <item component="ComponentInfo{no.entur/no.entur.SplashActivity}" drawable="entur" name="Entur" />
@@ -5301,6 +5357,7 @@
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.vpn.ui.SplashActivity}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.splash.SplashActivity}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.vpn.splash.ClassicAlias}" drawable="expressvpn" name="ExpressVPN" />
+  <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.vpn.splash.NeonAlias}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.AmethystIcon}" drawable="exteragram" name="exteraGram" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.AuroraIcon}" drawable="exteragram" name="exteraGram" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.CyberpunkIcon}" drawable="exteragram" name="exteraGram" />
@@ -5425,6 +5482,7 @@
   <item component="ComponentInfo{com.miraclegames.farlight84/com.epicgames.ue4.SplashActivity}" drawable="farlight_84" name="Farlight 84" />
   <item component="ComponentInfo{mx.com.fahorro2/com.app.farmaciasdelahorro.farmacias_del_ahorro.MainActivity}" drawable="farmacias_del_ahorro" name="Farmacias del Ahorro" />
   <item component="ComponentInfo{mx.com.fahorro2/qHBoE5.ync2l2.zjUNg5.nXZE35}" drawable="farmacias_del_ahorro" name="Farmacias del Ahorro" />
+  <item component="ComponentInfo{mx.com.fahorro2/j3BSZ7.xzVNo4.tgTLI2.uPafr2}" drawable="farmacias_del_ahorro" name="Farmacias del Ahorro" />
   <item component="ComponentInfo{com.pharmacysa.farmaciasapp/com.pharmacysa.farmaciasapp.MainActivity}" drawable="farmacias" name="Farmácias" />
   <item component="ComponentInfo{com.pharmacysa.farmaciasapp/com.pharmacysa.farmaciasapp.view.SplashScreenActivity}" drawable="farmacias" name="Farmácias" />
   <item component="ComponentInfo{com.netflix.Speedtest/com.netflix.Speedtest.MainActivity}" drawable="fast" name="FAST" />
@@ -5605,6 +5663,7 @@
   <item component="ComponentInfo{yuh.yuh.finelock/yuh.yuh.finelock.T}" drawable="fine_lock" name="Fine Lock" />
   <item component="ComponentInfo{yuh.yuh.finelock/yuh.yuh.finelock.M}" drawable="fine_lock" name="Fine Lock" />
   <item component="ComponentInfo{com.fintech.life/com.fintech.splash.SplashActivity}" drawable="fineasy" name="Fineasy" />
+  <item component="ComponentInfo{com.fintech.life/com.pallet.splash.SplashActivity}" drawable="fineasy" name="Fineasy" />
   <item component="ComponentInfo{com.fineco.it/it.fineco.finecoevolution.view.splash.SplashActivity}" drawable="fineco" name="Fineco" />
   <item component="ComponentInfo{com.fineco.it/com.fineco.it.Splash}" drawable="fineco" name="Fineco" />
   <item component="ComponentInfo{com.overlook.android.fing/com.overlook.android.fing.SplashActivity}" drawable="fing" name="Fing" />
@@ -5648,6 +5707,7 @@
   <item component="ComponentInfo{org.mozilla.firefox/org.mozilla.firefox.AppFlaming}" drawable="firefox" name="Firefox" />
   <item component="ComponentInfo{org.mozilla.firefox/org.mozilla.firefox.AppMinimal}" drawable="firefox_minimal" name="Firefox" />
   <item component="ComponentInfo{org.mozilla.firefox/org.mozilla.firefox.AppCool}" drawable="firefox" name="Firefox" />
+  <item component="ComponentInfo{org.mozilla.firefox/org.mozilla.firefox.AppCuddling}" drawable="firefox" name="Firefox" />
   <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.search.SearchActivity}" drawable="firefox_beta" name="Firefox Beta" />
   <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.gecko.BrowserApp}" drawable="firefox_beta" name="Firefox Beta" />
   <item component="ComponentInfo{org.mozilla.firefox_beta/org.mozilla.firefox_beta.App}" drawable="firefox_beta" name="Firefox Beta" />
@@ -5790,6 +5850,7 @@
   <item component="ComponentInfo{rocks.poopjournal.flashy/rocks.poopjournal.flashy.MainActivity}" drawable="flashy" name="Flashy" />
   <item component="ComponentInfo{com.jazibkhan.equalizer/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="flat_equalizer" name="Flat Equalizer" />
   <item component="ComponentInfo{com.jazibkhan.equalizer/com.jazibkhan.equalizer.ui.activities.MainActivity}" drawable="flat_equalizer" name="Flat Equalizer" />
+  <item component="ComponentInfo{com.jazibkhan.equalizer/com.jazibkhan.equalizer.ui.activities.SplashActivity}" drawable="flat_equalizer" name="Flat Equalizer" />
   <item component="ComponentInfo{com.flat.evo.iconpack/com.flat.evo.iconpack.activities.SplashActivity}" drawable="generic_shell" name="Flat Evo Icons" />
   <item component="ComponentInfo{com.bocharov.xposed.fscb/com.bocharov.xposed.fscb.settings.Main}" drawable="flat_style_colored_bars" name="Flat Style Colored Bars" />
   <item component="ComponentInfo{de.xcom.flatexat/de.xcom.flatexat.ui.SplashActivity}" drawable="flatexsecure" name="flatex next AT" />
@@ -5799,6 +5860,7 @@
   <item component="ComponentInfo{my.com.lits.flexiparking2/my.com.lits.flexiparking2.MainActivity}" drawable="flexi_parking" name="Flexi Parking" />
   <item component="ComponentInfo{com.presley.flexify/com.presley.flexify.MainActivity}" drawable="flexify" name="Flexify" />
   <item component="ComponentInfo{com.flickr.android/com.yahoo.mobile.client.android.flickr.ui.misc.LoginActivity}" drawable="flickr" name="Flickr" />
+  <item component="ComponentInfo{com.flickr.android/com.flickr.android.MainActivity}" drawable="flickr" name="Flickr" />
   <item component="ComponentInfo{com.flightaware.android.liveFlightTracker/com.flightaware.android.liveFlightTracker.splash.SplashActivity}" drawable="flightaware" name="FlightAware" />
   <item component="ComponentInfo{com.flightaware.android.liveFlightTracker/com.flightaware.android.liveFlightTracker.activities.MainActivity}" drawable="flightaware" name="FlightAware" />
   <item component="ComponentInfo{com.flightradar24free/com.flightradar24free.feature.splash.view.SplashActivity}" drawable="flightradar24" name="Flightradar24" />
@@ -5828,9 +5890,12 @@
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.SilverIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.BBDIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.GrwmSaleIconAlias}" drawable="flipkart" name="Flipkart" />
+  <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.GoatSaleIconAlias}" drawable="flipkart" name="Flipkart" />
+  <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.SASALELEIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipperdevices.app/com.flipperdevices.singleactivity.impl.SingleActivity}" drawable="flipper" name="Flipper" />
   <item component="ComponentInfo{nl.flitsmeister/nl.flitsmeister.FM_SIMPLE_BLUE}" drawable="flitsmeister" name="Flitsmeister" />
   <item component="ComponentInfo{nl.flitsmeister/nl.flitsmeister.SPEED_CAM_3D}" drawable="flitsmeister" name="Flitsmeister" />
+  <item component="ComponentInfo{nl.flitsmeister/nl.flitsmeister.FM_SIMPLE_WHITE}" drawable="flitsmeister" name="Flitsmeister" />
   <item component="ComponentInfo{de.flixbus.app/de.meinfernbus.Main}" drawable="flixbus" name="FlixBus" />
   <item component="ComponentInfo{de.flixbus.app/de.flixbus.app.Main}" drawable="flixbus" name="FlixBus" />
   <item component="ComponentInfo{com.flo.ayakkabi/app.presentation.main.MainActivity}" drawable="flo" name="FLO" />
@@ -5851,6 +5916,7 @@
   <item component="ComponentInfo{dev.patrickgold.florisboard.debug/dev.patrickgold.florisboard.SettingsLauncherAlias}" drawable="florisboard_debug" name="FlorisBoard Debug" />
   <item component="ComponentInfo{com.anticor.flossy/com.anticor.flossy.activities.SplashActivity}" drawable="flossy_icons" name="Flossy Icons" />
   <item component="ComponentInfo{ar.com.cablevision.attv.android.myminerva/ar.com.cablevision.attv.android.myminerva.view.ui.SplashActivity}" drawable="flow" name="Flow" />
+  <item component="ComponentInfo{io.github.aedev.flow/io.github.aedev.flow.IconFlowRed}" drawable="flow" name="Flow" />
   <item component="ComponentInfo{io.github.aedev.flow/io.github.aedev.flow.MainActivity}" drawable="flow_by_aedev" name="Flow by aedev" />
   <item component="ComponentInfo{io.github.aedev.flow/io.github.aedev.flow.IconDynamic}" drawable="flow_by_aedev" name="Flow by aedev" />
   <item component="ComponentInfo{io.github.aedev.flow/io.github.aedev.flow.IconMonochrome}" drawable="flow_by_aedev" name="Flow by aedev" />
@@ -6292,6 +6358,7 @@
   <item component="ComponentInfo{com.mobilefootie.wc2010/com.fotmob.android.ui.MainActivityWrapper}" drawable="fotmob" name="FotMob" />
   <item component="ComponentInfo{com.mobilefootie.wc2010/com.mobilefootie.fotmob.gui.v2.MainActivityWrapper}" drawable="fotmob" name="FotMob" />
   <item component="ComponentInfo{com.mobilefootie.wc2010/com.fotmob.android.icons.AppIconInter}" drawable="fotmob" name="FotMob" />
+  <item component="ComponentInfo{com.mobilefootie.wc2010/com.fotmob.android.icons.AppIconManchesterCity}" drawable="fotmob" name="FotMob" />
   <item component="ComponentInfo{com.santaragione.fotonicaiOS/com.santaragione.fotonicaiOS.ExtendedUnityActivity}" drawable="fotonica" name="FOTONICA" />
   <item component="ComponentInfo{videoeditor.videomaker.slideshow.fotoplay/videoeditor.videomaker.slideshow.fotoplay.activity.ShowActivity}" drawable="fotoplay" name="FotoPlay" />
   <item component="ComponentInfo{com.everimaging.photoeffectstudio/com.everimaging.fotor.SplashActivity}" drawable="fotor" name="Fotor" />
@@ -6329,6 +6396,7 @@
   <item component="ComponentInfo{com.fredmeyer.mobile/com.kroger.mobile.BannerSelectionActivity}" drawable="fred_meyer" name="Fred Meyer" />
   <item component="ComponentInfo{finalimage.Freddy_Fresh/finalimage.Freddy_Fresh.MainActivity}" drawable="freddy_fresh" name="FREDDY FRESH" />
   <item component="ComponentInfo{fr.free.moncomptefree/com.android.root.ApplicationMainActivity}" drawable="free" name="Free" />
+  <item component="ComponentInfo{fr.free.moncomptefree/presentation.newfree.root.common.ui.ApplicationMainActivity}" drawable="free" name="Free" />
   <item component="ComponentInfo{com.hsv.freeadblockerbrowser/com.google.android.apps.chrome.Main}" drawable="abp_for_samsung_internet" name="Free Adblocker Browser" />
   <item component="ComponentInfo{com.freebasics/com.facebook.iorg.app.activity.IorgLauncherActivity}" drawable="free_basics" name="Free Basics" />
   <item component="ComponentInfo{org.woheller69.browser/de.baumann.browser.activity.BrowserActivity}" drawable="free_browser" name="FREE Browser" />
@@ -6379,6 +6447,7 @@
   <item component="ComponentInfo{uk.co.freeview.android/uk.co.freeview.android.features.registration.splash.SplashActivity}" drawable="freeview" name="Freeview" />
   <item component="ComponentInfo{f.f.freezer/f.f.freezer.MainActivity}" drawable="deezer" name="Freezer" />
   <item component="ComponentInfo{nep.timeline.freezer/nep.timeline.freezer.MainActivity}" drawable="airfrozen" name="Freezer" />
+  <item component="ComponentInfo{nep.timeline.freezer/nep.timeline.freezer.activity.MainActivityAlias}" drawable="airfrozen" name="Freezer" />
   <item component="ComponentInfo{livio.pack.lang.fr_FR/livio.pack.lang.fr_FR.DictionaryView}" drawable="french_dictionary" name="French Dictionary" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.french/com.anysoftkeyboard.languagepack.french.MainActivity}" drawable="anysoftkeyboard" name="French for AnySoftKeyboard" />
   <item component="ComponentInfo{com.jujinkim.frequaw/com.jujinkim.frequaw.ui.MainActivity}" drawable="frequaw" name="Frequaw" />
@@ -6522,6 +6591,7 @@
   <item component="ComponentInfo{com.xiaoji.egggame/com.xj.app.DeepLinkRouterActivity}" drawable="gamehub" name="GameHub" />
   <item component="ComponentInfo{com.xiaoji.egggame/com.xj.app.SplashActivity}" drawable="gamehub" name="GameHub" />
   <item component="ComponentInfo{gamehub.lite/com.xj.app.DeepLinkRouterActivity}" drawable="gamehub" name="GameHub" />
+  <item component="ComponentInfo{com.xiaoji.egggame/com.xiaoji.egggame.MainActivity}" drawable="gamehub" name="GameHub" />
   <item component="ComponentInfo{app.gamenative/app.gamenative.MainActivityAliasDefault}" drawable="gamenative" name="GameNative" />
   <item component="ComponentInfo{com.chimera.saturday.evogamepadtester/com.chimera.saturday.evogamepadtester.controller.Home}" drawable="gamepad_tester" name="Gamepad Tester" />
   <item component="ComponentInfo{ru.elron.gamepadtester/ru.elron.gamepadtester.ui.main.MainActivity}" drawable="gamepad_tester_by_elron" name="Gamepad tester by elron" />
@@ -6711,6 +6781,8 @@
   <item component="ComponentInfo{sk.slsp.georgego/at.beeone.george.splashscreen.SplashScreenVariantRainbow}" drawable="george" name="George" />
   <item component="ComponentInfo{cz.csas.georgego/at.beeone.george.splashscreen.SplashScreenVariantJuniorHalloween}" drawable="george" name="George" />
   <item component="ComponentInfo{hr.erstebank.george/at.beeone.george.splashscreen.SplashScreenVariantDefault}" drawable="george" name="George" />
+  <item component="ComponentInfo{ro.bcr.georgego/at.beeone.george.app.splashscreen.SplashScreenVariantDefault}" drawable="george" name="George" />
+  <item component="ComponentInfo{at.erstebank.george/at.beeone.george.splashscreen.SplashScreenVariantRed}" drawable="george" name="George" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.georgian/com.anysoftkeyboard.languagepack.georgian.MainActivity}" drawable="anysoftkeyboard" name="Georgian for AnySoftKeyboard" />
   <item component="ComponentInfo{io.geph.android/io.geph.android.MainActivity}" drawable="geph" name="Geph" />
   <item component="ComponentInfo{livio.pack.lang.de_DE/livio.pack.lang.de_DE.DictionaryView}" drawable="german_dictionary" name="German Dictionary" />
@@ -6737,6 +6809,7 @@
   <item component="ComponentInfo{sg.getgo.booking/sg.getgo.booking.entry.initial.InitialActivity}" drawable="getgo" name="GetGo" />
   <item component="ComponentInfo{com.getir/com.getir.core.feature.splash.SplashActivity}" drawable="getir" name="getir" />
   <item component="ComponentInfo{com.android.geto/com.android.geto.MainActivity}" drawable="geto" name="Geto" />
+  <item component="ComponentInfo{com.android.geto/com.android.geto.activity.main.MainActivity}" drawable="geto" name="Geto" />
   <item component="ComponentInfo{com.gettaxi.android/com.gettaxi.android.redesign.ui.gett.GettActivity}" drawable="gett" name="Gett" />
   <item component="ComponentInfo{com.gettr.gettr/org.getter.MainActivity}" drawable="gettr" name="GETTR" />
   <item component="ComponentInfo{com.getyourguide.android/com.getyourguide.InitDumpActivity}" drawable="getyourguide" name="GetYourGuide" />
@@ -6792,6 +6865,7 @@
   <item component="ComponentInfo{com.global.player/com.thisisglobal.guacamole.main.views.SplashActivity}" drawable="global_player" name="Global Player" />
   <item component="ComponentInfo{com.heytap.quicksearchbox/com.heytap.quicksearchbox.ui.activity.SearchHomeActivity}" drawable="global_search" name="Global Search" />
   <item component="ComponentInfo{com.global66.cards/com.tns.NativeScriptActivity}" drawable="global66" name="Global66" />
+  <item component="ComponentInfo{com.global66.cards/com.global66.cards.MainActivity}" drawable="global66" name="Global66" />
   <item component="ComponentInfo{com.globe.electric/com.smart.ThingSplashActivity}" drawable="globe_suite" name="Globe Suite" />
   <item component="ComponentInfo{ph.com.globe.globeonesuperapp/ph.com.globe.globeonesuperapp.BaseActivity}" drawable="globeone" name="GlobeOne" />
   <item component="ComponentInfo{ph.com.globe.globeonesuperapp/ph.com.globe.globeonesuperapp.BaseActivityDefault}" drawable="globeone" name="GlobeOne" />
@@ -6889,6 +6963,7 @@
   <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.handsfree.HandsFreeLauncherActivity}" drawable="google" name="Google" />
   <item component="ComponentInfo{com.google.android.googlequicksearchbox/com.google.android.googlequicksearchbox.MainActivity}" drawable="google" name="Google" />
   <item component="ComponentInfo{com.android.quicksearchbox/com.android.quicksearchbox.SearchActivity}" drawable="google" name="Google" />
+  <item component="ComponentInfo{com.google.android.apps.searchlite/com.google.android.googlequicksearchbox.SearchActivity}" drawable="google" name="Google" />
   <item component="ComponentInfo{com.google.android.apps.enterprise.cpanel/com.google.android.apps.enterprise.cpanel.activities.EntryPointActivity}" drawable="google_admin" name="Google Admin" />
   <item component="ComponentInfo{com.google.android.apps.adwords/com.google.android.apps.adwords.home.InitialLoadingActivity}" drawable="google_ads" name="Google Ads" />
   <item component="ComponentInfo{com.google.android.apps.adwords/com.google.android.apps.adwords.InitialLoadingActivity}" drawable="google_ads" name="Google Ads" />
@@ -7253,7 +7328,9 @@
   <item component="ComponentInfo{com.grabtaxi.passenger/com.myteksi.passenger.v3.splash.SplashActivity}" drawable="grab" name="Grab" />
   <item component="ComponentInfo{com.grabtaxi.passenger/com.grab.pax.newface.common.alias.RayaLauncherAlias}" drawable="grab" name="Grab" />
   <item component="ComponentInfo{com.grabtaxi.passenger/com.grab.pax.newface.common.alias.IdRamadanLauncherAlias}" drawable="grab" name="Grab" />
+  <item component="ComponentInfo{com.grabtaxi.passenger/com.grab.pax.newface.common.alias.GlobalYearEndLauncherAlias}" drawable="grab" name="Grab" />
   <item component="ComponentInfo{com.grabtaxi.driver2/com.grab.driver.app.ui.v5.activities.landing.splash.SplashScreen}" drawable="grab" name="Grab Driver" />
+  <item component="ComponentInfo{com.grabtaxi.driver2/com.grab.driver.splashscreen.screen.SplashScreen}" drawable="grab" name="Grab Driver" />
   <item component="ComponentInfo{io.grabr/io.grabr.MainActivity}" drawable="grabr" name="Grabr" />
   <item component="ComponentInfo{com.anticor.grabyspin/com.anticor.grabyspin.activities.SplashActivity}" drawable="graby_spin_ui_icons" name="Graby Spin UI Icons" />
   <item component="ComponentInfo{com.anticor.graby/com.anticor.graby.activities.SplashActivity}" drawable="graby_ui_icons" name="Graby UI Icons" />
@@ -7366,6 +7443,7 @@
   <item component="ComponentInfo{com.grindrapp.android/com.grindrapp.android.HomeActivityNotes}" drawable="grindr" name="Grindr" />
   <item component="ComponentInfo{com.grindrapp.android/com.grindrapp.android.activity.SplashActivity}" drawable="grindr" name="Grindr" />
   <item component="ComponentInfo{com.grindrapp.android/com.grindrapp.android.HomeActivityOriginal}" drawable="grindr" name="Grindr" />
+  <item component="ComponentInfo{com.grindrapp.android/com.grindrapp.android.HomeActivityP35}" drawable="grindr" name="Grindr" />
   <item component="ComponentInfo{com.grindrapp.android/com.grindrapp.android.HomeActivityChatRed}" drawable="grindr_chat_icon" name="Grindr Chat Icon" />
   <item component="ComponentInfo{com.grindrapp.android/com.grindrapp.android.HomeActivityPhoneBlack}" drawable="generic_dialer" name="Grindr Phone" />
   <item component="ComponentInfo{com.shub39.grit/com.shub39.grit.app.MainActivity}" drawable="grit" name="Grit" />
@@ -7386,6 +7464,7 @@
   <item component="ComponentInfo{com.groupme.android/com.groupme.android.HomeActivity}" drawable="groupme" name="GroupMe" />
   <item component="ComponentInfo{com.groupon/com.groupon.home.main.activities.Carousel}" drawable="groupon" name="Groupon" />
   <item component="ComponentInfo{com.groupon/com.groupon.activity.TodaysDeal}" drawable="groupon" name="Groupon" />
+  <item component="ComponentInfo{com.groupon/com.groupon.MainActivity}" drawable="groupon" name="Groupon" />
   <item component="ComponentInfo{com.nextbillion.groww/com.nextbillion.groww.MainActivitycom.nextbillion.groww}" drawable="groww" name="Groww" />
   <item component="ComponentInfo{com.nextbillion.groww/com.nextbillion.groww.MainActivity}" drawable="groww" name="Groww" />
   <item component="ComponentInfo{com.nextbillion.groww/com.nextbillion.groww.genesys.loginsignup.activities.LoginActivity}" drawable="groww" name="Groww" />
@@ -7411,6 +7490,7 @@
   <item component="ComponentInfo{de.indie42.guessiron/de.indie42.guessiron.MainActivity}" drawable="guessiron" name="GuessIron" />
   <item component="ComponentInfo{com.porg.gugal/com.porg.gugal.MainActivity}" drawable="gugal" name="Gugal" />
   <item component="ComponentInfo{fr.ecoemballage.guidedutri/com.citeo.gdtr.MainActivity}" drawable="guide_du_tri" name="Guide du tri" />
+  <item component="ComponentInfo{fr.ecoemballage.guidedutri/com.citeo.citeo.MainActivity}" drawable="guide_du_tri" name="Guide du tri" />
   <item component="ComponentInfo{com.gg.guilded/com.guilded.guildedapp.MainActivity}" drawable="guilded" name="Guilded" />
   <item component="ComponentInfo{com.ovelin.guitartuna/com.unity3d.player.UnityPlayerNativeActivity}" drawable="guitartuna" name="GuitarTuna" />
   <item component="ComponentInfo{com.ovelin.guitartuna/com.unity3d.player.UnityPlayerActivity}" drawable="guitartuna" name="GuitarTuna" />
@@ -7468,6 +7548,7 @@
   <item component="ComponentInfo{com.hcceg.veg.compassionfree/com.sisow.hcvg.healthydiningguide.app.splash.ui.SplashScreenActivity}" drawable="happycow" name="HappyCow" />
   <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.allfunction.LaunchActivity}" drawable="happymod" name="HappyMod" />
   <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.main.LaunchActivity}" drawable="happymod" name="HappyMod" />
+  <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.main.SplashAdActivity}" drawable="happymod" name="HappyMod" />
   <item component="ComponentInfo{io.github.dorumrr.happytaxes/io.github.dorumrr.happytaxes.MainActivity}" drawable="happytaxes" name="HappyTaxes" />
   <item component="ComponentInfo{net.alkafeel.mcb/net.alkafeel.mcb.Splashscreen}" drawable="haqibat_almumin" name="Haqibat Almumin" />
   <item component="ComponentInfo{com.simon.harmonichackernews/com.simon.harmonichackernews.MainActivity}" drawable="harmonic" name="Harmonic" />
@@ -7663,6 +7744,7 @@
   <item component="ComponentInfo{it.homobile.ho/it.nttdata.vodafonelean.splash.SplashActivity}" drawable="ho" name="ho." />
   <item component="ComponentInfo{air.com.gamebrain.hocus/air.com.gamebrain.hocus.AppEntry}" drawable="hocus" name="hocus." />
   <item component="ComponentInfo{com.talpa.hibrowser/com.talpa.hibrowser.framework.ui.HiStartActivity}" drawable="hola_browser" name="Hola Browser" />
+  <item component="ComponentInfo{com.talpa.hibrowser/com.tmroom.gogo.SplashActivity}" drawable="hola_browser" name="Hola Browser" />
   <item component="ComponentInfo{org.hola.gpslocation/org.hola.gpslocation.map_activity}" drawable="hola_fake_gps" name="Hola Fake GPS" />
   <item component="ComponentInfo{com.holafly.holafly/com.holafly.holafly.MainActivity}" drawable="holafly" name="Holafly" />
   <item component="ComponentInfo{io.voodoo.holeio/com.google.firebase.MessagingUnityPlayerActivity}" drawable="hole_io" name="Hole.io" />
@@ -7776,6 +7858,7 @@
   <item component="ComponentInfo{nz.co.vista.android.movie/nz.co.vista.android.movie.abc.feature.splash.SplashActivity}" drawable="hoyts" name="HOYTS" />
   <item component="ComponentInfo{nz.co.vista.android.movie/au.com.hoyts.app.MainActivity}" drawable="hoyts" name="HOYTS" />
   <item component="ComponentInfo{com.drivetrackplusrefuel/com.drivetrackplusrefuel.splash.GlanceActivity}" drawable="hp_pay" name="HP PAY" />
+  <item component="ComponentInfo{com.drivetrackplusrefuel/com.drivetrackplusrefuel.GlanceActivityDefault}" drawable="hp_pay" name="HP PAY" />
   <item component="ComponentInfo{com.hp.android.printservice/com.hp.android.printservice.launcher.SplashActivity}" drawable="hp_print_service" name="HP Print Service" />
   <item component="ComponentInfo{com.hp.android.printservice/com.hp.android.printservice.launcher.WelcomeActivity}" drawable="hp_print_service" name="HP Print Service" />
   <item component="ComponentInfo{com.hp.printercontrol/com.google.android.archive.ReactivateActivity}" drawable="generic_printer" name="HP Smart" />
@@ -7803,6 +7886,7 @@
   <item component="ComponentInfo{my.com.hsbc.hsbcmalaysia/com.hsbc.mobilebanking.splash.SplashActivity}" drawable="hsbc" name="HSBC" />
   <item component="ComponentInfo{ar.com.hsbc.hsbcargentina/ar.com.hsbc.hsbcargentina.launcher_65e0b989a067a1a81cefbde4be4b29db38c5ddc75594ff81885b1782d7a3a003}" drawable="hsbc" name="HSBC" />
   <item component="ComponentInfo{ar.com.hsbc.hsbcargentina/ar.com.hsbc.hsbcargentina.MainActivity}" drawable="hsbc" name="HSBC" />
+  <item component="ComponentInfo{sg.com.hsbc.hsbcsingapore/com.hsbc.mobilebanking.ui.PlatformHubDashboardActivity}" drawable="hsbc" name="HSBC" />
   <item component="ComponentInfo{com.hsbc.expat.hsbcexpat/com.hsbc.mobilebanking.splash.SplashActivity}" drawable="hsbc" name="HSBC Expat" />
   <item component="ComponentInfo{fi.hsl.app/fi.hsl.app.MainActivity}" drawable="hsl" name="HSL" />
   <item component="ComponentInfo{hsr.moran.mtheme.pack/hsr.moran.mtheme.pack.MainActivity}" drawable="honkai_star_rail" name="HSRTheme" />
@@ -7991,6 +8075,7 @@
   <item component="ComponentInfo{com.drdisagree.iconify.foss/com.drdisagree.iconify.SplashActivity}" drawable="iconify" name="Iconify" />
   <item component="ComponentInfo{com.drdisagree.iconify.foss/com.drdisagree.iconify.SplashActivityRetro}" drawable="iconify" name="Iconify" />
   <item component="ComponentInfo{com.drdisagree.iconify.foss/com.drdisagree.iconify.SplashActivityThemed}" drawable="iconify" name="Iconify" />
+  <item component="ComponentInfo{com.drdisagree.iconify/com.drdisagree.iconify.app.MainActivity}" drawable="iconify" name="Iconify" />
   <item component="ComponentInfo{com.drdisagree.iconify.debug/com.drdisagree.iconify.SplashActivityRetro}" drawable="iconify" name="Iconify Debug" />
   <item component="ComponentInfo{com.drdisagree.iconify.debug/com.drdisagree.iconify.SplashActivity}" drawable="iconify" name="Iconify Debug" />
   <item component="ComponentInfo{com.anysoftkeyboard.theme.ics/com.anysoftkeyboard.theme.ics.MainActivity}" drawable="anysoftkeyboard" name="ICS Theme for AnySoftKeyboard" />
@@ -8074,6 +8159,7 @@
   <item component="ComponentInfo{com.vidmar.pti/com.vidmar.pti.SplashScreen}" drawable="generic_pdf_square" name="Image to PDF" />
   <item component="ComponentInfo{com.readpdf.pdfreader.pdfviewer/com.readpdf.pdfreader.pdfviewer.view.activity.SplashActivity}" drawable="generic_pdf_file" name="Image to PDF" />
   <item component="ComponentInfo{pdf.converter.imagetopdf.jpgtopdf.createpdf/pdf.converter.imagetopdf.jpgtopdf.createpdf.pdfviewer.onemb.imagetopdf.ui.splash.SplashActivity}" drawable="generic_pdf_file" name="Image to PDF Converter" />
+  <item component="ComponentInfo{com.readpdf.pdfreader.pdfviewer/com.readpdf.pdfreader.pdfviewer.view.activity.splash.FoSplashActivity}" drawable="generic_pdf_file" name="Image to PDF Converter" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/com.t8rin.imagetoolbox.app.presentation.AppActivity}" drawable="image_toolbox" name="Image Toolbox" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.app.presentation.AppActivity}" drawable="image_toolbox" name="Image Toolbox" />
   <item component="ComponentInfo{ru.tech.imageresizershrinker/ru.tech.imageresizershrinker.presentation.AppActivity}" drawable="image_toolbox" name="Image Toolbox" />
@@ -8144,6 +8230,7 @@
   <item component="ComponentInfo{com.csam.icici.bank.imobile/com.csam.icici.bank.imobile.IMOBILE}" drawable="imobile_pay" name="iMobile Pay" />
   <item component="ComponentInfo{com.imod.technobankai/com.imod.technobankai.mainactivity}" drawable="imod_pro" name="iMOD Pro" />
   <item component="ComponentInfo{com.mm.android.smartlifeiot/com.mm.android.easy4ip.SplashActivity}" drawable="imou_life" name="Imou Life" />
+  <item component="ComponentInfo{com.mm.android.smartlifeiot/com.mm.android.ims.SplashActivity}" drawable="imou_life" name="Imou Life" />
   <item component="ComponentInfo{com.ibkr.impact.app/com.ibkr.impact.activity.launcher.LauncherActivity}" drawable="impact" name="IMPACT" />
   <item component="ComponentInfo{pl.wasko.android.mpk/pl.wasko.android.mpk.activities.MapActivity}" drawable="impk" name="iMPK" />
   <item component="ComponentInfo{pt.cosmicode.imposter/pt.cosmicode.imposter.MainActivity}" drawable="impostor" name="Impostor" />
@@ -8185,6 +8272,7 @@
   <item component="ComponentInfo{com.brakefield.idfree/com.brakefield.idfree.ActivityStartup}" drawable="infinite_design" name="Infinite Design" />
   <item component="ComponentInfo{com.jernung.infinite.jpn/com.jernung.infinite.jpn.MainActivity}" drawable="infinite_japanese" name="Infinite Japanese" />
   <item component="ComponentInfo{com.grykuby.minesweeper/com.unity3d.player.UnityPlayerActivity}" drawable="generic_minesweeper" name="Infinite Minesweeper" />
+  <item component="ComponentInfo{com.grykuby.minesweeper/com.google.firebase.MessagingUnityPlayerActivity}" drawable="generic_minesweeper" name="Infinite Minesweeper" />
   <item component="ComponentInfo{com.brakefield.painter/com.brakefield.painter.activities.ActivityStartup}" drawable="infinite_painter" name="Infinite Painter" />
   <item component="ComponentInfo{com.prineside.tdi2/com.prineside.tdi2.AndroidLauncher}" drawable="infinitode_2" name="Infinitode 2" />
   <item component="ComponentInfo{ml.docilealligator.infinityforreddit/ml.docilealligator.infinityforreddit.activities.MainActivity}" drawable="infinity" name="Infinity" />
@@ -8269,6 +8357,7 @@
   <item component="ComponentInfo{com.instagram.android/com.instagram.android.iconone}" drawable="instagram" name="Instagram" />
   <item component="ComponentInfo{com.instagram.android/com.instagram.mainactivity.LauncherActivity}" drawable="instagram" name="Instagram" />
   <item component="ComponentInfo{com.instagram.android/com.OM7753.gold.icon1}" drawable="instagram" name="Instagram" />
+  <item component="ComponentInfo{com.instagram.android/com.instagram.android.activity.MainTabActivity15}" drawable="instagram" name="Instagram" />
   <item component="ComponentInfo{com.instagram.lite/com.facebook.lite.MainActivity}" drawable="instagram" name="Instagram Lite" />
   <item component="ComponentInfo{com.instagram.lite/com.instagram.lite.IgLiteActivity}" drawable="instagram" name="Instagram Lite" />
   <item component="ComponentInfo{dev.zwander.installwithoptions/dev.zwander.installwithoptions.MainActivity}" drawable="install_with_options" name="Install with Options" />
@@ -8603,6 +8692,7 @@
   <item component="ComponentInfo{de.prosiebensat1digital.seventv/de.joyn.mobile.app.splash.SplashActivity}" drawable="joyn" name="Joyn" />
   <item component="ComponentInfo{at.zappn/de.joyn.mobile.app.splash.SplashActivity}" drawable="joyn" name="Joyn" />
   <item component="ComponentInfo{music.ytstream.youtify/com.ryanheise.audioservice.AudioServiceActivity}" drawable="joytify" name="Joytify" />
+  <item component="ComponentInfo{music.ytstream.youtify/music.apps.youtify.MainActivity}" drawable="joytify" name="Joytify" />
   <item component="ComponentInfo{jp.jpmob.app/jp.jpmob.app.MainActivity}" drawable="jp_smart_sim" name="JP SMART SIM" />
   <item component="ComponentInfo{com.aconvert.jpg2pdf/com.aconvert.jpg2pdf.MainActivity}" drawable="generic_pdf_square" name="JPG to PDF Converter" />
   <item component="ComponentInfo{jp.co.jreast/jp.co.jreast.jreastapp.commuter.launchscreen.LaunchScreenActivity}" drawable="jr_east" name="JR East" />
@@ -8622,6 +8712,7 @@
   <item component="ComponentInfo{io.jumptask.app/io.jt.app.MainActivity}" drawable="jumptask" name="JumpTask" />
   <item component="ComponentInfo{net.wooga.junes_journey_hidden_object_mystery_game/net.wooga.junes_journey.WoogaUnityPlayerActivity}" drawable="junes_journey" name="June's Journey" />
   <item component="ComponentInfo{studio14.application.juno/com.candybar.dev.activities.SplashActivity}" drawable="juno_icons" name="Juno Icons" />
+  <item component="ComponentInfo{studio14.application.juno/com.one4studio.iconpack.MainActivity}" drawable="juno_icons" name="Juno Icons" />
   <item component="ComponentInfo{money.jupiter/money.jupiter.MainActivity}" drawable="jupiter" name="Jupiter" />
   <item component="ComponentInfo{money.jupiter/money.jupiter.MainActivityDefault}" drawable="jupiter" name="Jupiter" />
   <item component="ComponentInfo{money.jupiter/money.jupiter.MainActivityWorldCup}" drawable="jupiter" name="Jupiter" />
@@ -8750,6 +8841,7 @@
   <item component="ComponentInfo{com.elasticrock.keepscreenon/com.elasticrock.keepscreenon.MainActivity}" drawable="keep_screen_on" name="Keep Screen On" />
   <item component="ComponentInfo{eu.davidweis.keepscreenon/com.elasticrock.keepscreenon.MainActivity}" drawable="keep_screen_on" name="Keep Screen On" />
   <item component="ComponentInfo{com.elasticrock.keepscreenon/com.elasticrock.keepscreenon.ui.MainActivity}" drawable="keep_screen_on" name="Keep Screen On" />
+  <item component="ComponentInfo{eu.davidweis.keepscreenon/com.elasticrock.keepscreenon.ui.MainActivity}" drawable="keep_screen_on" name="Keep Screen On" />
   <item component="ComponentInfo{com.keepa.mobile/com.tns.NativeScriptActivity}" drawable="keepa" name="Keepa" />
   <item component="ComponentInfo{keepass2android.keepass2android/md5f0702f468598c68ce18586502249fb40.KeePass}" drawable="keepass2android" name="Keepass2Android" />
   <item component="ComponentInfo{keepass2android.keepass2android/md5b85ab5ea2545156b0f09600c184a5178.KeePass}" drawable="keepass2android" name="Keepass2Android" />
@@ -8788,6 +8880,7 @@
   <item component="ComponentInfo{org.kexp.android/org.kexp.radio.activity.MainActivity}" drawable="kexp" name="KEXP" />
   <item component="ComponentInfo{io.github.vvb2060.keyattestation/io.github.vvb2060.keyattestation.home.HomeActivity}" drawable="key_attestation" name="Key Attestation" />
   <item component="ComponentInfo{com.kunzisoft.hardware.key/com.kunzisoft.hardware.key.SettingActivity}" drawable="key_driver" name="Key Driver" />
+  <item component="ComponentInfo{com.kunzisoft.hardware.key/com.kunzisoft.hardware.key.presentation.AppActivity}" drawable="key_driver" name="Key Driver" />
   <item component="ComponentInfo{io.github.sds100.keymapper/io.github.sds100.keymapper.SplashActivity}" drawable="key_mapper" name="Key Mapper" />
   <item component="ComponentInfo{io.github.sds100.keymapper/io.github.sds100.keymapper.MainActivity}" drawable="key_mapper" name="Key Mapper" />
   <item component="ComponentInfo{com.artemchep.keyguard/com.artemchep.keyguard.android.MainActivity}" drawable="keyguard_for_bitwarden" name="Keyguard for Bitwarden" />
@@ -8866,6 +8959,7 @@
   <item component="ComponentInfo{com.nanoequipment.kfc/com.nanoequipment.kfc.MainActivity}" drawable="kfc" name="KFC" />
   <item component="ComponentInfo{com.kfc.mobile/com.kfc.mobile.MainActivity}" drawable="kfc" name="KFC" />
   <item component="ComponentInfo{com.kfcnz.orderserv/com.kfcnz.orderserv.MainActivity}" drawable="kfc" name="KFC" />
+  <item component="ComponentInfo{com.kfc.nl.mobileapp/com.kfc.nl.mobileapp.MainActivity}" drawable="kfc" name="KFC" />
   <item component="ComponentInfo{luke.kfz/luke.kfz.MainActivity}" drawable="kfz_kennzeichen" name="KFZ-Kennzeichen" />
   <item component="ComponentInfo{com.khalti/com.khalti.MainActivity}" drawable="khalti_digital_wallet" name="Khalti Digital Wallet" />
   <item component="ComponentInfo{com.khalti/com.khalti.intro.splash.SplashActivity}" drawable="khalti_digital_wallet" name="Khalti Digital Wallet" />
@@ -8900,6 +8994,7 @@
   <item component="ComponentInfo{net.kilimall.shop/net.kilimall.shop.part.splash.WelcomeActivity}" drawable="kilimall" name="Kilimall" />
   <item component="ComponentInfo{com.tafayor.killall/com.tafayor.killall.MainActivity}" drawable="killapps" name="KillApps" />
   <item component="ComponentInfo{com.easybrain.killer.sudoku.free/com.easybrain.template.SplashActivity}" drawable="generic_sudoku" name="Killer Sudoku" />
+  <item component="ComponentInfo{com.easybrain.killer.sudoku.free/com.easybrain.killer.sudoku.free.SplashActivity}" drawable="generic_sudoku" name="Killer Sudoku" />
   <item component="ComponentInfo{com.moonshot.kimichat/com.moonshot.kimichat.MainActivity}" drawable="kimi" name="KIMI" />
   <item component="ComponentInfo{com.kimovil.app/com.kimovil.app.MainActivity}" drawable="kimovil" name="Kimovil" />
   <item component="ComponentInfo{com.nexstreaming.app.kinemasterfree/com.kinemaster.app.screen.splash.SplashActivity}" drawable="kinemaster" name="KineMaster" />
@@ -8988,6 +9083,7 @@
   <item component="ComponentInfo{org.xbmc.kodi/org.xbmc.kodi.Splash}" drawable="kodi" name="Kodi" />
   <item component="ComponentInfo{org.xbmc.kodi/org.xbmc.kodi.Main}" drawable="kodi" name="Kodi" />
   <item component="ComponentInfo{ca.koho/ca.koho.MainActivity}" drawable="koho" name="KOHO" />
+  <item component="ComponentInfo{ca.koho/ca.koho.LauncherActivity}" drawable="koho" name="KOHO" />
   <item component="ComponentInfo{pl.koleo/pl.astarium.koleo.ui.startscreen.StartScreenActivity}" drawable="koleo" name="KOLEO" />
   <item component="ComponentInfo{pl.koleo/pl.astarium.koleo.ui.main.MainActivity}" drawable="koleo" name="KOLEO" />
   <item component="ComponentInfo{com.chooloo.www.koler/com.chooloo.www.koler.ui.main.MainActivity}" drawable="generic_dialer" name="Koler" />
@@ -9001,6 +9097,7 @@
   <item component="ComponentInfo{de.komoot.android/de.komoot.android.ui.inspiration.InspirationActivity}" drawable="komoot" name="komoot" />
   <item component="ComponentInfo{de.komoot.android/de.komoot.android.ui.RootActivity}" drawable="komoot" name="komoot" />
   <item component="ComponentInfo{de.komoot.android/de.komoot.android.ui.RootActivityDefault}" drawable="komoot" name="Komoot" />
+  <item component="ComponentInfo{de.komoot.android/de.komoot.android.ui.RootActivityClassic}" drawable="komoot" name="Komoot" />
   <item component="ComponentInfo{org.kustom.konsole/org.kustom.konsole.KonsoleActivity}" drawable="konsole_kustom_apk_creator" name="Konsole Kustom APK Creator" />
   <item component="ComponentInfo{hu.gov.mfa.konzinfo.utazom.v2.android/com.rr.utazom.utazom_app.MainActivity}" drawable="konzinfo_utazom" name="Konzinfo Utazom" />
   <item component="ComponentInfo{net.koofr.app/net.koofr.android.app.account.LoginActivity}" drawable="koofr" name="Koofr" />
@@ -9022,6 +9119,7 @@
   <item component="ComponentInfo{com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge/com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge.MainActivitySuper811}" drawable="kotak811" name="Kotak811" />
   <item component="ComponentInfo{com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge/com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge.MainActivityHaze}" drawable="kotak811" name="Kotak811" />
   <item component="ComponentInfo{com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge/com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge.MainActivityDaylight}" drawable="kotak811" name="Kotak811" />
+  <item component="ComponentInfo{com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge/com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge.MainActivityKotakOld}" drawable="kotak811" name="Kotak811" />
   <item component="ComponentInfo{org.koitharu.kotatsu/org.koitharu.kotatsu.main.ui.MainActivity}" drawable="kotatsu" name="Kotatsu" />
   <item component="ComponentInfo{org.koitharu.kotatsu.nightly/org.koitharu.kotatsu.main.ui.MainActivity}" drawable="kotatsu_nightly" name="Kotatsu Nightly" />
   <item component="ComponentInfo{com.koton.app/com.koton.app.MainActivity}" drawable="koton" name="Koton" />
@@ -9245,6 +9343,8 @@
   <item component="ComponentInfo{nickrout.lenslauncher/nickrout.lenslauncher.ui.SettingsActivity}" drawable="lens_launcher" name="Lens Launcher" />
   <item component="ComponentInfo{com.lensa.app/com.lensa.original}" drawable="lensa" name="Lensa" />
   <item component="ComponentInfo{com.lenskart.app/com.lenskart.app.main.ui.SplashActivity}" drawable="lenskart" name="Lenskart" />
+  <item component="ComponentInfo{com.lenskart.app/com.lenskart.app.main.ui.InIconActivityAlias}" drawable="lenskart" name="Lenskart" />
+  <item component="ComponentInfo{com.lenskart.app/com.lenskart.app.main.ui.DefaultIconActivityAlias}" drawable="lenskart" name="Lenskart" />
   <item component="ComponentInfo{at.nerbrothers.SuperJump/at.nerbrothers.SuperJump.SuperJump}" drawable="leps_world" name="Lep's World" />
   <item component="ComponentInfo{at.ner.lepsWorld2/at.ner.lepsWorld2.LepsWorld2}" drawable="leps_world_2" name="Lep's World 2" />
   <item component="ComponentInfo{at.ner.lepsWorld3Plus/at.ner.lepsWorld3Plus.LepsWorld3}" drawable="leps_world_3" name="Lep's World 3" />
@@ -9262,6 +9362,7 @@
   <item component="ComponentInfo{com.letterboxd.letterboxd/com.letterboxd.letterboxd.ui.activities.PopularActivity}" drawable="letterboxd" name="Letterboxd" />
   <item component="ComponentInfo{com.letterboxd.letterboxd/com.letterboxd.letterboxd.MainActivity}" drawable="letterboxd" name="Letterboxd" />
   <item component="ComponentInfo{com.letterboxd.letterboxd/com.letterboxd.letterboxd.MainActivity_icon_whitesquall}" drawable="letterboxd" name="Letterboxd" />
+  <item component="ComponentInfo{com.letterboxd.letterboxd/com.letterboxd.letterboxd.MainActivity_icon_blackswan}" drawable="letterboxd" name="Letterboxd" />
   <item component="ComponentInfo{com.letyshops/com.lampa.letyshops.view.activity.SplashActivity}" drawable="letyshops" name="LetyShops" />
   <item component="ComponentInfo{com.letyshops/com.letyshops.presentation.view.activity.SplashActivity}" drawable="letyshops" name="LetyShops" />
   <item component="ComponentInfo{level.game/level.game.MainActivity}" drawable="level" name="Level" />
@@ -9622,6 +9723,7 @@
   <item component="ComponentInfo{com.op.lspdoze/com.op.lspdoze.ui.MainActivity}" drawable="generic_shell" name="LSPDoze" />
   <item component="ComponentInfo{org.lsposed.manager/org.lsposed.manager.ui.activity.MainActivity}" drawable="lspatch_lsposed" name="LSPosed" />
   <item component="ComponentInfo{com.android.shell/org.lsposed.manager.ui.activity.MainActivity}" drawable="lspatch_lsposed" name="LSPosed" />
+  <item component="ComponentInfo{org.lsposed.manager/org.lsposed.manager.ui.activity.ComposeActivity}" drawable="lspatch_lsposed" name="LSPosed" />
   <item component="ComponentInfo{lt.registrucentras.ltid/crc6419820ee77e27dddd.MainActivity}" drawable="lt_id" name="LT ID" />
   <item component="ComponentInfo{io.mdp43140.ltecleaner/io.mdp43140.ltecleaner.MainActivity}" drawable="lte_cleaner" name="LTE Cleaner" />
   <item component="ComponentInfo{net.simplyadvanced.ltediscovery/com2020.ltediscovery.ui.LtedMainActivity}" drawable="lte_discovery" name="LTE Discovery" />
@@ -9731,6 +9833,7 @@
   <item component="ComponentInfo{com.mada.madapay/com.emcrey.app.activities.SupportActivity}" drawable="mada_pay" name="mada Pay" />
   <item component="ComponentInfo{be.cad.made.in.belgium/be.cad.made.in.belgium.MainActivity}" drawable="made_in" name="Made in" />
   <item component="ComponentInfo{com.maybank2u.life/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="mae" name="MAE" />
+  <item component="ComponentInfo{com.maybank2u.life/com.maybank2u.life.BootSplashActivity}" drawable="mae" name="MAE" />
   <item component="ComponentInfo{com.aswat.carrefouruae/com.aswat.carrefouruae.feature.splash.view.activity.SplashActivity}" drawable="maf_carrefour" name="MAF Carrefour" />
   <item component="ComponentInfo{com.aswat.carrefouruae/com.aswat.carrefouruae.mafretail_app.MainActivity}" drawable="maf_carrefour" name="MAF Carrefour" />
   <item component="ComponentInfo{software.indi.android.mpd/software.indi.android.mpd.client.splash.SplashActivity}" drawable="mafa" name="MAFA" />
@@ -9795,6 +9898,7 @@
   <item component="ComponentInfo{com.tripledot.tile.dynasty/com.unity3d.player.UnityPlayerActivity}" drawable="generic_mahjong" name="Mahjong Tile Dynasty" />
   <item component="ComponentInfo{com.nebula.mahjongtile/com.unity3d.player.UnityPlayerActivity}" drawable="generic_mahjong" name="Mahjong Wonders" />
   <item component="ComponentInfo{com.MahsaNet.MahsaNG/com.v2ray.ang.ui.MainActivity}" drawable="mahsang" name="MahsaNG" />
+  <item component="ComponentInfo{com.MahsaNet.MahsaNG/com.v2ray.ang.feature.main.MainActivity}" drawable="mahsang" name="MahsaNG" />
   <item component="ComponentInfo{md.maib.maibank/md.maib.app.maibank.splash.SplashActivity}" drawable="maibank" name="maibank" />
   <item component="ComponentInfo{foundation.e.mail/com.fsck.k9.activity.MessageList}" drawable="generic_email" name="Mail" />
   <item component="ComponentInfo{foundation.e.mail/foundation.e.mail.activity.Accounts}" drawable="generic_email" name="Mail" />
@@ -9947,6 +10051,7 @@
   <item component="ComponentInfo{com.taxsee.taxsee/com.taxsee.base.ui.activities.SplashScreen}" drawable="maxim" name="maxim" />
   <item component="ComponentInfo{com.taxsee.taxsee/com.taxsee.taxsee.ui.activities.SplashScreen}" drawable="maxim" name="maxim" />
   <item component="ComponentInfo{com.taxsee.taxsee/com.taxsee.ui.activities.TaxseeActivity}" drawable="maxim" name="maxim" />
+  <item component="ComponentInfo{com.taxsee.taxsee/com.taxsee.taxsee.AppIcon2}" drawable="maxim" name="maxim" />
   <item component="ComponentInfo{lt.maxima.aciu/lt.maxima.aciu.LauncherActivity}" drawable="maxima" name="Maxima" />
   <item component="ComponentInfo{lv.maxima/lt.maxima.aciu.LauncherActivity}" drawable="maxima" name="Maxima" />
   <item component="ComponentInfo{com.softtech.parakod/com.softtech.parakod.splash.SplashActivity}" drawable="maximum" name="Maximum" />
@@ -10008,6 +10113,7 @@
   <item component="ComponentInfo{pt.mcdonalds/pt.mcdonalds.android.ui.intro.splash.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdonalds.mcdonaldsgt/com.mcdelivery.MainActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdonalds.gma.cn/com.mcdonalds.gma.cn.activity.LaunchActivity.cny}" drawable="mcdonalds" name="McDonald's" />
+  <item component="ComponentInfo{il.co.inmanage.mcdonalds/il.co.inmanage.mcdonalds.activities.UnifiedMcActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mysports.branded.mcfit/com.mysports.branded.mcfit.ms_mobile_app_mcfit.MainActivity}" drawable="mcfit" name="McFIT" />
   <item component="ComponentInfo{com.mysports.branded.mcfit/com.mysports.branded.premium.MainActivity}" drawable="mcfit" name="McFIT" />
   <item component="ComponentInfo{nz.co.solus.Kotui.Manawatu/solus.Libraries.MainActivity}" drawable="mchl_feilding" name="MCHL Feilding" />
@@ -10063,6 +10169,7 @@
   <item component="ComponentInfo{tv.medal.recorder.game/tv.medal.recorder.game.presentation.DashboardActivity}" drawable="medal" name="Medal" />
   <item component="ComponentInfo{tv.medal.recorder/tv.medal.ui.LaunchActivity.Green}" drawable="medal" name="Medal" />
   <item component="ComponentInfo{tv.medal.recorder/tv.medal.ui.LaunchActivity.White}" drawable="medal" name="Medal" />
+  <item component="ComponentInfo{tv.medal.recorder/tv.medal.ui.LaunchActivity.Reverse}" drawable="medal" name="Medal" />
   <item component="ComponentInfo{de.medflex.app.flutter/de.medflex.app.flutter.MainActivity}" drawable="medflex" name="medflex" />
   <item component="ComponentInfo{com.mediaon.apt/com.mediaon.apt.MainActivity}" drawable="media_on" name="Media ON" />
   <item component="ComponentInfo{de.benzac.msx/de.benzac.tvx.activities.MainActivity}" drawable="media_station_x" name="Media Station X" />
@@ -10174,6 +10281,10 @@
   <item component="ComponentInfo{com.mercadolibre/com.mercadolibre.activities.SplashActivity}" drawable="mercado_libre" name="Mercado Libre" />
   <item component="ComponentInfo{com.mercadolibre/com.mercadolibre.SplashActivityAliasDefault}" drawable="mercado_libre" name="Mercado Libre" />
   <item component="ComponentInfo{com.mercadolibre/com.mercadolibre.SplashActivityAliasApril}" drawable="mercado_libre" name="Mercado Libre" />
+  <item component="ComponentInfo{com.mercadolibre/com.google.android.archive.ReactivateActivity}" drawable="mercado_libre" name="Mercado Libre" />
+  <item component="ComponentInfo{com.mercadolibre/com.mercadolibre.SplashActivityAliasMundialOfficialFifa}" drawable="mercado_libre" name="Mercado Libre" />
+  <item component="ComponentInfo{com.mercadolibre/com.mercadolibre.SplashActivityAliasMundialBra}" drawable="mercado_libre" name="Mercado Libre" />
+  <item component="ComponentInfo{com.mercadolibre/com.mercadolibre.SplashActivityAliasMundialMex}" drawable="mercado_libre" name="Mercado Libre" />
   <item component="ComponentInfo{com.mercadopago.wallet/com.mercadopago.wallet.splash.SplashActivity}" drawable="mercado_pago" name="Mercado Pago" />
   <item component="ComponentInfo{com.mercadopago.wallet/com.mercadopago.wallet.splashscreen.SplashScreenActivity}" drawable="mercado_pago" name="Mercado Pago" />
   <item component="ComponentInfo{com.mercadopago.wallet/com.mercadopago.wallet.AccountSummaryActivity}" drawable="mercado_pago" name="Mercado Pago" />
@@ -10192,6 +10303,7 @@
   <item component="ComponentInfo{com.merriamwebster/com.merriamwebster.dictionary.activity.dictionary.DictionaryActivity}" drawable="merriam_webster_dictionary" name="Merriam-Webster Dictionary" />
   <item component="ComponentInfo{com.merriamwebster.premium/com.merriamwebster.dictionary.activity.dictionary.DictionaryActivity}" drawable="merriam_webster_dictionary_premium" name="Merriam-Webster Dictionary Premium" />
   <item component="ComponentInfo{com.geeksville.mesh/com.geeksville.mesh.MainActivity}" drawable="meshtastic" name="Meshtastic" />
+  <item component="ComponentInfo{com.geeksville.mesh/org.meshtastic.app.MainActivity}" drawable="meshtastic" name="Meshtastic" />
   <item component="ComponentInfo{com.verizon.messaging.vzmsgs/com.verizon.mms.ui.activity.Provisioning}" drawable="garmin_messenger" name="Message+" />
   <item component="ComponentInfo{com.transsion.smartmessage/com.android.messaging.ui.conversationlist.ConversationListActivity}" drawable="messages" name="Messages" />
   <item component="ComponentInfo{foundation.e.message/com.moez.QKSMS.feature.main.MainActivity}" drawable="messages" name="Messages" />
@@ -10371,6 +10483,7 @@
   <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.TestAlias2}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.TestAlias8}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{es.vodafone.mobile.mivodafone/com.tsse.spain.myvodafone.splash.view.VfSplashActivity}" drawable="my_vodafone" name="Mi Vodafone" />
+  <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.ExpAlias1}" drawable="mi_video" name="Mi Vídeo" />
   <item component="ComponentInfo{com.xiaomi.router/com.xiaomi.router.module.splash.SplashActivity}" drawable="mi_wi_fi" name="Mi Wi-Fi" />
   <item component="ComponentInfo{com.jlong.miccheck/com.jlong.miccheck.MainActivity}" drawable="miccheck" name="MicCheck" />
   <item component="ComponentInfo{com.michatapp.im/com.michatapp.launch.LaunchActivity}" drawable="michat" name="MiChat" />
@@ -10408,6 +10521,7 @@
   <item component="ComponentInfo{com.microsoft.copilot/com.google.android.archive.ReactivateActivity}" drawable="microsoft_copilot" name="Microsoft Copilot" />
   <item component="ComponentInfo{com.microsoft.copilot/com.microsoft.sapphire.app.main.SapphireMainActivity}" drawable="microsoft_copilot" name="Microsoft Copilot" />
   <item component="ComponentInfo{com.microsoft.copilot/com.microsoft.shappire.app.main.ShappireMainActivity}" drawable="microsoft_copilot" name="Microsoft Copilot" />
+  <item component="ComponentInfo{com.microsoft.copilot/com.microsoft.copilotn.MainActivityDefault}" drawable="microsoft_copilot" name="Microsoft Copilot" />
   <item component="ComponentInfo{com.microsoft.scmx/com.microsoft.defender.ux.activity.MDMainActivity}" drawable="microsoft_defender" name="Microsoft Defender" />
   <item component="ComponentInfo{com.microsoft.designer/com.microsoft.designer.app.home.view.launch.DesignerLoginActivity}" drawable="microsoft_designer" name="Microsoft Designer" />
   <item component="ComponentInfo{com.microsoft.emmx/com.google.android.apps.chrome.Main}" drawable="microsoft_edge" name="Microsoft Edge" />
@@ -10550,6 +10664,7 @@
   <item component="ComponentInfo{com.mojang.minecraftperclone/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftpx/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.hanver.wdsj/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
+  <item component="ComponentInfo{com.mojang.minecraftpe/com.me.game.pmupdatesdk.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecrafttrialpe/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft Trial" />
   <item component="ComponentInfo{com.panu/com.panu.SplashScreenActivity}" drawable="generic_minesweeper" name="Minesweeper" />
   <item component="ComponentInfo{Draziw.Button.Mines/minesweeper.Button.Mines.BoardViewActivity}" drawable="generic_minesweeper" name="Minesweeper" />
@@ -10586,6 +10701,7 @@
   <item component="ComponentInfo{com.jndapp.iconpack.minimalist/com.jndapp.iconpack.minimalist.activities.SplashActivity}" drawable="minimalist_icons" name="Minimalist Icons" />
   <item component="ComponentInfo{com.jndapp.iconpack.minimalist/com.jndapp.iconpack.minimalist.MainActivity}" drawable="minimalist_icons" name="Minimalist Icons" />
   <item component="ComponentInfo{com.qqlabs.minimalistlauncher/com.qqlabs.minimalistlauncher.ui.MainActivity}" drawable="minimalist_phone" name="minimalist phone" />
+  <item component="ComponentInfo{com.qqlabs.minimalistlauncher/com.qqlabs.minimalistlauncher.ui.MainActivityNoHome}" drawable="minimalist_phone" name="minimalist phone" />
   <item component="ComponentInfo{com.rippedthemer.minimus.app/com.rippedthemer.minimus.app.MainActivity}" drawable="minimus_icons" name="Minimus Icons" />
   <item component="ComponentInfo{com.gameloft.android.ANMP.GloftDMHM/com.gameloft.android.ANMP.GloftDMHM.MainActivity}" drawable="minion_rush" name="Minion Rush" />
   <item component="ComponentInfo{com.gameloft.android.ANMP.GloftDMHM/com.gameloft.android.ANMP.GloftDMHM.MinionRushUnity}" drawable="minion_rush" name="Minion Rush" />
@@ -10601,6 +10717,7 @@
   <item component="ComponentInfo{com.miui.theme.lite/com.miui.theme.lite.WallpaperPickerActivity}" drawable="mint_themes" name="Mint Themes" />
   <item component="ComponentInfo{com.minutecryptic.app/com.minutecryptic.app.MainActivity}" drawable="minute_cryptic" name="Minute Cryptic" />
   <item component="ComponentInfo{it.docplanner/com.app.MainActivity}" drawable="doctoralia" name="MioDottore" />
+  <item component="ComponentInfo{it.docplanner/it.docplanner.MainActivity}" drawable="doctoralia" name="MioDottore" />
   <item component="ComponentInfo{com.mioto.mioto/com.foco.mioto.activities.SplashActivity}" drawable="mioto" name="MIOTO" />
   <item component="ComponentInfo{com.mipermit.android/com.mipermit.android.activity.HomeActivity}" drawable="mipermit" name="MiPermit" />
   <item component="ComponentInfo{ru.nspk.mirpay/ru.nspk.mirpay.b34rqwEd1vSkvA}" drawable="mir_pay" name="Mir Pay" />
@@ -10643,6 +10760,7 @@
   <item component="ComponentInfo{com.gitlab.mudlej.MjPdfReader/com.gitlab.mudlej.MjPdfReader.LauncherAlias}" drawable="mj_pdf" name="MJ PDF" />
   <item component="ComponentInfo{foundation.e.pdfviewer/com.gsnathan.pdfviewer.LauncherAlias}" drawable="generic_pdf_square" name="MJ PDF" />
   <item component="ComponentInfo{foundation.e.pdfviewer/com.gitlab.mudlej.MjPdfReader.ui.main.MainActivity}" drawable="generic_pdf_square" name="MJ PDF" />
+  <item component="ComponentInfo{com.gitlab.mudlej.MjPdfReader/com.gitlab.mudlej.MjPdfReader.Launcher}" drawable="mj_pdf" name="MJ PDF" />
   <item component="ComponentInfo{com.javiersantos.mlmanager/com.javiersantos.mlmanager.activities.MainActivity}" drawable="ml_manager" name="ML Manager" />
   <item component="ComponentInfo{com.javiersantos.mlmanagerpro/com.javiersantos.mlmanager.activities.MainActivity}" drawable="ml_manager_pro" name="ML Manager Pro" />
   <item component="ComponentInfo{app.mlauncher/com.github.droidworksstudio.mlauncher.MainActivity}" drawable="mlauncher" name="mLauncher" />
@@ -10983,6 +11101,7 @@
   <item component="ComponentInfo{tdp.app.col/tdp.app.col.MainActivity}" drawable="movistar" name="Movistar" />
   <item component="ComponentInfo{movistar.android.app/movistar.android.app.MainActivity}" drawable="movistar" name="Movistar" />
   <item component="ComponentInfo{com.telefonica.movistar/com.telefonica.movistar.MainActivity}" drawable="movistar" name="Movistar" />
+  <item component="ComponentInfo{com.otecel.mimovistar/com.otecel.mimovistar.MainActivity}" drawable="movistar" name="Movistar" />
   <item component="ComponentInfo{es.plus.yomvi/com.movistar.android.views.HomeActivity}" drawable="movistar_plus_plus" name="Movistar Plus+" />
   <item component="ComponentInfo{com.movistar.cl.base/com.telefonica.es.miwifi.activities.SplashActivity}" drawable="fritzapp_wi_fi" name="Movistar Smart WiFi" />
   <item component="ComponentInfo{com.sec.android.app.latin.launcher.movistar.contenidos/com.sec.android.app.latin.launcher.movistar.contenidos.Launcher}" drawable="movistar" name="Movistar Store" />
@@ -11256,6 +11375,7 @@
   <item component="ComponentInfo{com.vna.service.vvm/com.tmobile.vvm.application.activity.setup.WelcomeActivity}" drawable="my_visual_voicemail" name="My Visual Voicemail" />
   <item component="ComponentInfo{com.vna.service.vvm/com.vna.service.vvm.activity.setup.WelcomeActivity}" drawable="my_visual_voicemail" name="My Visual Voicemail" />
   <item component="ComponentInfo{com.vnp.myvinaphone/com.vnp.myvinaphone.activities.WelcomeApplication}" drawable="my_vnpt" name="My VNPT" />
+  <item component="ComponentInfo{com.vnp.myvinaphone/com.vnp.myvinaphone.Default}" drawable="my_vnpt" name="My VNPT" />
   <item component="ComponentInfo{za.co.vodacom.android.app/com.myvodacomx.MainActivity}" drawable="my_vodafone" name="My Vodacom" />
   <item component="ComponentInfo{com.vodafone.android/nl.vodafoneziggo.oneapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{com.emeint.android.myservices/com.emeint.android.myservices.ui.screens.splash.DefaultLauncher}" drawable="my_vodafone" name="My Vodafone" />
@@ -11304,6 +11424,7 @@
   <item component="ComponentInfo{com.zentity.vodafone/com.zentity.vodafone.SplashScreenActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{al.myvodafone.android/com.oneapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{au.com.vodafone.mobile.gss/com.vfmobileapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
+  <item component="ComponentInfo{com.VodafoneIreland.MyVodafone/com.oneapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{com.vodafone.selfservis/com.vodafone.selfservis.FiveGAlias}" drawable="_5g_only" name="My Vodafone 5G" />
   <item component="ComponentInfo{fr.meteo/fr.meteo.activity.SplashscreenActivity_}" drawable="my_weather" name="My Weather" />
   <item component="ComponentInfo{com.myworkoutplan.myworkoutplan/com.myworkoutplan.myworkoutplan.MainActivity}" drawable="my_workout_plan" name="My Workout Plan" />
@@ -11314,6 +11435,7 @@
   <item component="ComponentInfo{ie.months.my48/ie.app48months.ui.SplashActivity}" drawable="my48" name="My48" />
   <item component="ComponentInfo{ie.months.my48/ie.months.my48.MainActivity}" drawable="my48" name="My48" />
   <item component="ComponentInfo{my.com.sevenelevenmy.app/my.com.seveneleven.presentation.activity.SplashActivity}" drawable="_7_eleven" name="My7E" />
+  <item component="ComponentInfo{my.com.sevenelevenmy.app/my.com.sevenelevenmy.app.MainActivity}" drawable="_7_eleven" name="My7E" />
   <item component="ComponentInfo{com.aakash.myaakashapp/com.aakash.myaakashapp.splashscreen.activity.SplashActivity}" drawable="myaakash" name="myAakash" />
   <item component="ComponentInfo{ro.telekom.myaccount/com.telekom.oneapp.launcher.components.launcher.LauncherActivity}" drawable="t_mobile" name="MyAccount Telekom" />
   <item component="ComponentInfo{com.resmed.myair/com.resmed.mon.AliasDefaultActivity}" drawable="myair" name="myAir" />
@@ -11335,6 +11457,7 @@
   <item component="ComponentInfo{com.gcam.guides/com.app.gcamguides.activity.ActivitySplash}" drawable="generic_camera" name="MyCam Guides" />
   <item component="ComponentInfo{com.octoze.camu.mycamuapp/com.octoze.camu.mycamuapp.LoginActivity}" drawable="mycamu" name="MyCamu" />
   <item component="ComponentInfo{com.octoze.mycamu_web_lite/com.octoze.mycamutwa.features.main.MainActivity}" drawable="mycamu" name="MyCamu" />
+  <item component="ComponentInfo{com.octoze.mycamu_web_lite/com.octoze.mycamutwa.features.splashactivity.SplashActivity}" drawable="mycamu" name="MyCamu" />
   <item component="ComponentInfo{ge.beeline.odp/ge.beeline.odp.activities.SplashScreenActivity}" drawable="mycellfie" name="MyCellfie" />
   <item component="ComponentInfo{ge.beeline.odp/com.olsoft.splash.presentation.SplashScreenActivity}" drawable="mycellfie" name="MyCellfie" />
   <item component="ComponentInfo{epic.mychart.android/epic.mychart.android.library.prelogin.SplashActivity}" drawable="mychart" name="MyChart" />
@@ -11423,6 +11546,7 @@
   <item component="ComponentInfo{com.myntra.android/com.myntra.android.SplashActivity}" drawable="myntra" name="Myntra" />
   <item component="ComponentInfo{com.myntra.android/com.myntra.android.activities.react.ReactActivity.EORS_DEC_WINTER}" drawable="myntra" name="Myntra" />
   <item component="ComponentInfo{com.myntra.android/com.myntra.android.activities.react.ReactActivity.MBB_PRIMARY}" drawable="myntra" name="Myntra" />
+  <item component="ComponentInfo{com.myntra.android/com.myntra.android.activities.react.ReactActivity.EORS_JUNE_2026}" drawable="myntra" name="Myntra" />
   <item component="ComponentInfo{nz.co.vista.android.movie.odeoncinemas/nz.co.vista.android.movie.abc.feature.splash.SplashActivity}" drawable="myodeon" name="myODEON" />
   <item component="ComponentInfo{com.ncloudtech.cloudoffice/com.ncloudtech.cloudoffice.android.myfm.launch.LaunchActivity}" drawable="myoffice_documents" name="MyOffice Documents" />
   <item component="ComponentInfo{com.ncloudtech.cloudoffice/com.ncloudtech.cloudoffice.NewIcons}" drawable="myoffice_documents" name="MyOffice Documents" />
@@ -11474,6 +11598,7 @@
   <item component="ComponentInfo{com.tsel.telkomselku/com.tsel.telkomselku.presentation.dynamiciframe.DynamicIframeActivity}" drawable="mytelkomsel" name="MyTelkomsel" />
   <item component="ComponentInfo{com.aesthetic.iconpack.iconchanger/com.suntech.snapkit.newui.activity.preview.ViewFlashActivity}" drawable="icon_changer" name="MyTheme" />
   <item component="ComponentInfo{eu.smartpatient.mytherapy/eu.smartpatient.mytherapy.feature.account.presentation.onboarding.WelcomeActivity}" drawable="mytherapy" name="MyTherapy" />
+  <item component="ComponentInfo{eu.smartpatient.mytherapy/eu.smartpatient.mytherapy.onboarding.WelcomeActivity}" drawable="mytherapy" name="MyTherapy" />
   <item component="ComponentInfo{com.mytnb.mytnb/crc6460070f4268f70078.MainActivity}" drawable="mytnb" name="myTNB" />
   <item component="ComponentInfo{com.mytnb.mytnb/crc6463630ac9575d390d.LaunchViewActivity}" drawable="mytnb" name="myTNB" />
   <item component="ComponentInfo{com.mytnb.mytnb/crc64b9df9d9c671f393c.LaunchViewActivity}" drawable="mytnb" name="myTNB" />
@@ -11516,6 +11641,8 @@
   <item component="ComponentInfo{com.n26brasil.app/io.flutter.embedding.android.FlutterFragmentActivity}" drawable="n26" name="N26" />
   <item component="ComponentInfo{de.number26.android/de.number26.machete.android.refactor.presentation.settings.customize_icon.launch_aliases.TealActivityLauncher}" drawable="n26" name="N26" />
   <item component="ComponentInfo{de.number26.android/com.n26.home.presentation.HomeActivity}" drawable="n26" name="N26" />
+  <item component="ComponentInfo{de.number26.android/de.number26.machete.android.refactor.presentation.settings.customize_icon.launch_aliases.PrideActivityLauncher}" drawable="n26" name="N26" />
+  <item component="ComponentInfo{de.number26.android/de.number26.machete.android.refactor.presentation.settings.customize_icon.launch_aliases.BlackActivityLauncher}" drawable="n26" name="N26" />
   <item component="ComponentInfo{au.com.nab.mobile/LauncherActivityAlias.Default}" drawable="nab" name="NAB" />
   <item component="ComponentInfo{com.xda.nachonotch/com.xda.nachonotch.MainActivity}" drawable="nacho_notch" name="Nacho Notch" />
   <item component="ComponentInfo{com.devbaltasarq.nadamillas/com.devbaltasarq.nadamillas.ui.MainActivity}" drawable="nadamillas" name="nadamillas" />
@@ -11546,6 +11673,7 @@
   <item component="ComponentInfo{nu.gpu.nagram/org.telegram.messenger.BlueIcon}" drawable="nagram_niello_icon" name="Nagram X" />
   <item component="ComponentInfo{nu.gpu.nagram/org.telegram.messenger.NielloIcon}" drawable="nagram_niello_icon" name="Nagram X" />
   <item component="ComponentInfo{nu.gpu.nagram/org.telegram.messenger.DefaultIcon}" drawable="nagram_niello_icon" name="Nagram X" />
+  <item component="ComponentInfo{nu.gpu.nagram/org.telegram.messenger.DarkBlueIcon}" drawable="nagram_niello_icon" name="Nagram X" />
   <item component="ComponentInfo{fork.risin42.nagramx/org.telegram.messenger.DarkBlueIcon}" drawable="nagram" name="Nagram XF" />
   <item component="ComponentInfo{com.wavefront.namegenerator/com.wavefront.nicknamegenerator.MainActivity}" drawable="name_generator" name="Name Generator" />
   <item component="ComponentInfo{com.kotobagames.namelesscat/com.unity3d.player.UnityPlayerActivity}" drawable="nameless_cat" name="Nameless Cat" />
@@ -11555,6 +11683,7 @@
   <item component="ComponentInfo{com.msob7y.namida.snapshot/com.msob7y.namida.snapshot.DefaultIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.ShadeIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.NamiweenIcon}" drawable="namida" name="Namida" />
+  <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.OokamiIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{in.juspay.nammayatri/in.juspay.mobility.MainActivity}" drawable="namma_yatri" name="Namma Yatri" />
   <item component="ComponentInfo{in.juspay.nammayatri/com.mobility.movingtech.MainActivity}" drawable="namma_yatri" name="Namma Yatri" />
   <item component="ComponentInfo{com.kazufukurou.nanji/com.kazufukurou.nanji.ui.MainActivity}" drawable="nanji_clock_widget" name="Nanji Clock Widget" />
@@ -11614,6 +11743,7 @@
   <item component="ComponentInfo{com.nextcx.nays/com.isbank.nextcx.ui.deeplink.DeepLinkActivity}" drawable="nays" name="Nays" />
   <item component="ComponentInfo{com.nextcx.nays/com.isbank.nextcx.DeepLinkActivityDefault}" drawable="nays" name="Nays" />
   <item component="ComponentInfo{com.ea.gp.nbamobile/com.ea.game.nba.NBAMainActivity}" drawable="nba_live" name="NBA LIVE" />
+  <item component="ComponentInfo{com.ea.gp.nbamobile/com.ea.mako.nbanext.NBANextMainActivity}" drawable="nba_live" name="NBA Live" />
   <item component="ComponentInfo{de.jbservices.nc_passwords_app/io.flutter.embedding.android.FlutterFragmentActivity}" drawable="nc_passwords" name="NC Passwords" />
   <item component="ComponentInfo{de.jbservices.nc_passwords_app/de.jbservices.nc_passwords_app.MainActivity}" drawable="nc_passwords" name="NC Passwords" />
   <item component="ComponentInfo{com.dar.nclientv2/com.dar.nclientv2.components.launcher.LauncherCalculator}" drawable="nclient" name="NClientV2" />
@@ -11824,6 +11954,7 @@
   <item component="ComponentInfo{com.nfl.fantasy.core.android/com.nfl.fantasy.core.android.activities.MainActivity}" drawable="nfl_fantasy" name="NFL Fantasy" />
   <item component="ComponentInfo{im.nfc.nfsee/im.nfc.nfsee.MainActivity}" drawable="nfsee" name="NFSee" />
   <item component="ComponentInfo{com.neaglebank/com.neaglebank.MainActivity}" drawable="ng_cash" name="NG.CASH" />
+  <item component="ComponentInfo{com.neaglebank/xxHAZ2.rikTr8.zxixR4}" drawable="ng_cash" name="NG.CASH" />
   <item component="ComponentInfo{gov.pianzong.androidnga/gov.pianzong.androidnga.activity.LoadingActivity}" drawable="nga" name="NGA" />
   <item component="ComponentInfo{gov.pianzong.androidnga/com.qihoo.util.StartActivity}" drawable="nga" name="NGA" />
   <item component="ComponentInfo{gov.pianzong.androidnga/gov.pianzong.androidnga.Splash_0}" drawable="nga" name="NGA" />
@@ -12028,6 +12159,7 @@
   <item component="ComponentInfo{com.teslacoilsw.launcherclientproxy/com.teslacoilsw.launcherclientproxy.MainActivity}" drawable="nova_google_companion" name="Nova Google Companion" />
   <item component="ComponentInfo{is.nova.app/is.nova.app.MainActivity}" drawable="nova_iceland" name="Nova Iceland" />
   <item component="ComponentInfo{cs14.pixelperfect.iconpack.nova/com.candybar.dev.activities.SplashActivity}" drawable="nova_icons" name="Nova Icons" />
+  <item component="ComponentInfo{cs14.pixelperfect.iconpack.nova/com.one4studio.iconpack.MainActivity}" drawable="nova_icons" name="Nova Icons" />
   <item component="ComponentInfo{com.teslacoilsw.launcher/com.exple.gexing.qianm.MainActivity}" drawable="nova_launcher" name="Nova Launcher" />
   <item component="ComponentInfo{com.teslacoilsw.launcher/com.android.launcher2.Launcher}" drawable="nova_launcher" name="Nova Launcher" />
   <item component="ComponentInfo{com.teslacoilsw.launcher/com.android.launcher3.LauncherWallpaperPickerActivity}" drawable="nova_launcher" name="Nova Launcher" />
@@ -12075,6 +12207,7 @@
   <item component="ComponentInfo{nl.ns.android.activity/nl.ns.android.activity.reisplanner.ReisplannerActivity}" drawable="ns" name="NS" />
   <item component="ComponentInfo{nl.ns.android.activity/nl.ns.android.activity.start.StartActivity}" drawable="ns" name="NS" />
   <item component="ComponentInfo{nl.ns.android.activity/nl.ns.feature.startup.start.StartActivity}" drawable="ns" name="NS" />
+  <item component="ComponentInfo{nl.ns.android.activity/nl.ns.app.shell.startup.start.StartActivity}" drawable="ns" name="NS" />
   <item component="ComponentInfo{nl.nshispeed/nl.nsinternational.mobile.android.startup.StartupActivity}" drawable="ns" name="NS International" />
   <item component="ComponentInfo{in.gov.scholarships.nspotr/in.gov.scholarships.nspotr.ui.activities.SplashScreenActivity}" drawable="nsp_otr" name="NSP OTR" />
   <item component="ComponentInfo{thanhletranngoc.calculator.pro/thanhletranngoc.calculator.pro.activities.MainActivity}" drawable="generic_calculator_plus_minus_multi_equal" name="NT Calculator" />
@@ -12217,6 +12350,7 @@
   <item component="ComponentInfo{com.swmansion.dajspisac/com.swmansion.dajspisac.MainActivity}" drawable="odrabiamy_pl" name="Odrabiamy.pl" />
   <item component="ComponentInfo{com.odysee.app/com.odysee.app.MainActivity}" drawable="odysee" name="Odysee" />
   <item component="ComponentInfo{com.odysee.floss/com.odysee.floss.MainActivity}" drawable="odysee" name="Odysee" />
+  <item component="ComponentInfo{com.odysee.floss/com.odysee.app.MainActivity}" drawable="odysee" name="Odysee" />
   <item component="ComponentInfo{network.openex.hub/network.openex.hub.MainActivity}" drawable="oex" name="OEX" />
   <item component="ComponentInfo{com.offerup/com.offerup.android.splash.SplashActivity}" drawable="offerup" name="OfferUp" />
   <item component="ComponentInfo{com.offerup/com.offerup.MainActivity}" drawable="offerup" name="OfferUp" />
@@ -12340,6 +12474,7 @@
   <item component="ComponentInfo{org.olympic.app.mobile/org.olympic.app.main.OlympicsActivity}" drawable="olympics" name="Olympics" />
   <item component="ComponentInfo{com.ticno.olymptrade/com.space307.feature_launch.presentation.LaunchActivity}" drawable="olymptrade" name="Olymptrade" />
   <item component="ComponentInfo{omegle.tv/omegle.tv.SplashActivity}" drawable="ometv" name="OmeTV" />
+  <item component="ComponentInfo{omegle.tv/com.omegle.tv.SplashActivity}" drawable="ometv" name="OmeTV" />
   <item component="ComponentInfo{com.omgbricks/com.omgbricks.MainActivity}" drawable="omgbricks" name="omgbricks" />
   <item component="ComponentInfo{sg.omi/omi.AliasDefault}" drawable="omi" name="Omi" />
   <item component="ComponentInfo{sg.omi.mi/omi.AliasDefault}" drawable="omi" name="Omi" />
@@ -12572,14 +12707,17 @@
   <item component="ComponentInfo{com.opera.browser.afin/com.miui.android.apps.chrome.Main}" drawable="opera" name="Opera" />
   <item component="ComponentInfo{com.opera.browser/com.opera.Launcher9}" drawable="opera" name="Opera" />
   <item component="ComponentInfo{com.opera.browser/com.opera.Launcher2}" drawable="opera" name="Opera" />
+  <item component="ComponentInfo{com.opera.browser/com.opera.Launcher11}" drawable="opera" name="Opera" />
   <item component="ComponentInfo{com.opera.browser.beta/com.opera.android.OperaStartActivity}" drawable="opera_beta" name="Opera Beta" />
   <item component="ComponentInfo{com.opera.browser.beta/com.opera.Opera}" drawable="opera_beta" name="Opera Beta" />
   <item component="ComponentInfo{com.opera.browser.beta/com.opera.Launcher5}" drawable="opera_beta" name="Opera Beta" />
   <item component="ComponentInfo{com.opera.browser.beta/com.opera.Launcher6}" drawable="opera_beta" name="Opera Beta" />
+  <item component="ComponentInfo{com.opera.browser.beta/com.opera.Launcher7}" drawable="opera_beta" name="Opera Beta" />
   <item component="ComponentInfo{com.opera.gx/com.opera.gx.MainActivity}" drawable="opera_gx" name="Opera GX" />
   <item component="ComponentInfo{com.opera.mini.native/com.opera.mini.android.Browser}" drawable="opera_mini" name="Opera Mini" />
   <item component="ComponentInfo{com.opera.mini.native/com.opera.android.Default}" drawable="opera_mini" name="Opera Mini" />
   <item component="ComponentInfo{com.opera.mini.native.beta/com.opera.mini.android.Browser}" drawable="opera_mini_beta" name="Opera Mini Beta" />
+  <item component="ComponentInfo{com.opera.mini.native.beta/com.opera.android.Default}" drawable="opera_mini_beta" name="Opera Mini Beta" />
   <item component="ComponentInfo{com.opera.app.news/com.opera.android.startup.NewsStartActivity}" drawable="opera_news" name="Opera News" />
   <item component="ComponentInfo{com.opera.touch/com.opera.touch.MainActivity}" drawable="opera" name="Opera Touch" />
   <item component="ComponentInfo{com.opodo.reisen/com.odigeo.app.android.navigator.SplashNavigator}" drawable="opodo" name="Opodo" />
@@ -12636,6 +12774,7 @@
   <item component="ComponentInfo{org.torproject.android/org.torproject.android.settings.SettingsPreferences}" drawable="orbot" name="Orbot" />
   <item component="ComponentInfo{org.torproject.android/org.torproject.android.ui.OrbotLogActivity}" drawable="orbot" name="Orbot" />
   <item component="ComponentInfo{org.torproject.android/org.torproject.android.main.OrbotAlt4}" drawable="orbot" name="Orbot" />
+  <item component="ComponentInfo{org.torproject.android/org.torproject.android.main.OrbotAlt3}" drawable="orbot" name="Orbot" />
   <item component="ComponentInfo{com.orderkuota.app/com.w38s.StartupActivity}" drawable="orderkuota" name="Orderkuota" />
   <item component="ComponentInfo{com.nousguide.android.orftvthek/com.nousguide.android.orftvthek.feature.relaunch.MainActivity}" drawable="orf_on" name="ORF ON" />
   <item component="ComponentInfo{app.organicmaps/app.organicmaps.DownloadResourcesActivity}" drawable="organic_maps" name="Organic Maps" />
@@ -12931,6 +13070,7 @@
   <item component="ComponentInfo{com.Yiming.PC/com.byfen.archiver.MainActivity}" drawable="pc_simulator" name="PC Simulator" />
   <item component="ComponentInfo{com.Yiming.PC/io.unity.sdk.android.UnityLauncher}" drawable="pc_simulator" name="PC Simulator" />
   <item component="ComponentInfo{com.Yiming.PC/com.unity3d.player.UnityPlayerActivity}" drawable="pc_simulator" name="PC Simulator" />
+  <item component="ComponentInfo{com.Yiming.PC/com.releasedata.ReleaseDataActivity.SplashActivityKing}" drawable="pc_simulator" name="PC Simulator" />
   <item component="ComponentInfo{de.pca.pca_kantine/de.pca.pca_kantine.MainActivity}" drawable="generic_silverware" name="PCA Kantine" />
   <item component="ComponentInfo{com.emanuelef.remote_capture/com.google.android.archive.ReactivateActivity}" drawable="pcapdroid" name="PCAPdroid" />
   <item component="ComponentInfo{com.pcapdroid.mitm/com.pcapdroid.mitm.MainActivity}" drawable="pcapdroid" name="PCAPdroid" />
@@ -13283,6 +13423,8 @@
   <item component="ComponentInfo{com.cardinalblue.piccollage.google/com.cardinalblue.piccollage.activities.MainActivity}" drawable="piccollage" name="PicCollage" />
   <item component="ComponentInfo{com.yellowpepper.pichincha/com.yellowpepper.pichincha.MainActivity}" drawable="pichincha" name="Pichincha" />
   <item component="ComponentInfo{pe.pichincha.bm/pe.pichincha.bm.screens.splash.SplashActivity}" drawable="pichincha" name="Pichincha" />
+  <item component="ComponentInfo{com.yellowpepper.pichincha/bTKLf2.u4HVD0.vLDgx4.snsjt3}" drawable="pichincha" name="Pichincha" />
+  <item component="ComponentInfo{com.yellowpepper.pichincha/yrnu49.hBV8e1.lQN6u9.cwC2K3}" drawable="pichincha" name="Pichincha" />
   <item component="ComponentInfo{ubirider.ubirider/ubirider.ubirider.SplashActivity}" drawable="pick" name="Pick" />
   <item component="ComponentInfo{com.pickme.passenger/com.pickme.passenger.MainActivity}" drawable="pickme" name="PickMe" />
   <item component="ComponentInfo{com.pickme.passenger/com.pickme.passenger.feature.account.presentation.LandingActivity}" drawable="pickme" name="PickMe" />
@@ -13362,6 +13504,7 @@
   <item component="ComponentInfo{com.pashapuma.pix.material.dark/com.pashapuma.pix.material.dark.activities.SplashActivity}" drawable="pix_material_dark_icons" name="Pix Material Dark Icons" />
   <item component="ComponentInfo{com.pashapuma.pix.material.dark/com.pashapuma.pix.material.dark.activities.MainActivity}" drawable="pix_material_dark_icons" name="Pix Material Dark Icons" />
   <item component="ComponentInfo{com.pashapuma.pix.material.iconpack/com.pashapuma.pix.material.iconpack.activities.SplashActivity}" drawable="pix_material_icons" name="Pix Material Icons" />
+  <item component="ComponentInfo{com.pashapuma.pix.material.iconpack/com.pashapuma.pix.material.iconpack.activities.MainActivity}" drawable="pix_material_icons" name="Pix Material Icons" />
   <item component="ComponentInfo{com.pashapuma.pix.material.you.iconpack/com.pashapuma.pix.material.you.iconpack.activities.MainActivity}" drawable="pix_material_you_icons" name="Pix Material You Icons" />
   <item component="ComponentInfo{com.pashapuma.pix.material.you.iconpack/com.jojoy.delegate.JojoyInstallerActivity}" drawable="pix_material_you_icons" name="Pix Material You Icons" />
   <item component="ComponentInfo{com.pashapuma.pix.material.you.iconpack/com.pashapuma.pix.material.you.iconpack.activities.SplashActivity}" drawable="pix_material_you_icons" name="Pix Material You Icons" />
@@ -13385,6 +13528,7 @@
   <item component="ComponentInfo{com.jaween.paint/com.jaween.paint.MainActivity}" drawable="pixel_brush" name="Pixel Brush" />
   <item component="ComponentInfo{twelve.clock.mibrahim/twelve.clock.mibrahim.MainActivity}" drawable="pixel_clock_widgets" name="Pixel Clock Widgets" />
   <item component="ComponentInfo{twelve.clock.mibrahim/twelve.clock.mibrahim.Thebase}" drawable="pixel_clock_widgets" name="Pixel Clock Widgets" />
+  <item component="ComponentInfo{twelve.clock.mibrahim/twelve.clock.mibrahim.TheNewbase}" drawable="pixel_clock_widgets" name="Pixel Clock Widgets" />
   <item component="ComponentInfo{com.mkm.pew/com.mkm.pew.MainActivity}" drawable="tgmonet_theme" name="Pixel Emoji Wallpaper" />
   <item component="ComponentInfo{ru.pt.iconpack.pixel/ru.pt.iconpack.pixel.activities.MainActivity}" drawable="pixel_icons" name="Pixel Icons" />
   <item component="ComponentInfo{ru.pt.iconpack.pixel/ru.pt.iconpack.pixel.activities.Check_GDPR}" drawable="pixel_icons" name="Pixel Icons" />
@@ -13526,6 +13670,7 @@
   <item component="ComponentInfo{org.plantnet/org.plantnet.MainActivity}" drawable="plantnet" name="PlantNet" />
   <item component="ComponentInfo{com.ea.game.pvz2_row/com.popcap.PvZ2.PvZ2GameActivity}" drawable="plants_vs_zombies_2" name="Plants vs Zombies 2" />
   <item component="ComponentInfo{com.ea.game.pvz2_na/com.popcap.PvZ2.PvZ2GameActivity}" drawable="plants_vs_zombies_2" name="Plants vs Zombies 2" />
+  <item component="ComponentInfo{com.ea.game.pvz2_row/com.me.game.pmupdatesdk.MainActivity}" drawable="plants_vs_zombies_2" name="Plants Vs Zombies 2" />
   <item component="ComponentInfo{com.ea.game.pvzfree_row/com.ea.game.pvzfree_row.COPPAActivity}" drawable="plants_vs_zombies" name="Plants vs. Zombies" />
   <item component="ComponentInfo{com.ea.game.pvzfree_row/com.ea.game.pvzfree_row.PvZActivity}" drawable="plants_vs_zombies" name="Plants vs. Zombies" />
   <item component="ComponentInfo{ch.baker.planner/ch.baker.planner.MainActivity}" drawable="plany" name="Plany" />
@@ -13953,6 +14098,7 @@
   <item component="ComponentInfo{ru.protonmod.next/ch.protonvpn.android.RoutingActivity}" drawable="proton_vpn" name="ProtonMOD-Next" />
   <item component="ComponentInfo{com.propel.ebenefits/com.propel.ebenefits.MainActivity}" drawable="providers" name="Providers" />
   <item component="ComponentInfo{be.belgacom.hello/com.mendix.nativetemplate.MainActivity}" drawable="proximus_plus" name="Proximus+" />
+  <item component="ComponentInfo{be.belgacom.hello/com.proximus.proximusplus.MainActivity}" drawable="proximus_plus" name="Proximus+" />
   <item component="ComponentInfo{com.proxmox.app.pve_flutter_frontend/com.proxmox.app.pve_flutter_frontend.MainActivity}" drawable="proxmox" name="Proxmox" />
   <item component="ComponentInfo{com.network.proxy/com.network.proxy.MainActivity}" drawable="c001apk" name="ProxyPin" />
   <item component="ComponentInfo{nl.wimbokkers.psalmen/nl.wimbokkers.psalmen.MainActivity}" drawable="psalmboek" name="Psalmboek" />
@@ -13993,6 +14139,7 @@
   <item component="ComponentInfo{com.azefsw.purchasedapps/com.azefsw.purchasedapps.ui.startup.StartupActivity}" drawable="purchased_apps" name="Purchased Apps" />
   <item component="ComponentInfo{free.tube.premium.advanced.tuber/free.tube.premium.advanced.tuber.main.MainActivity}" drawable="pure_tuber" name="Pure Tuber" />
   <item component="ComponentInfo{pure.lite.browser/com.vs.browser.MainActivity}" drawable="pure_web_browser" name="Pure Web Browser" />
+  <item component="ComponentInfo{pure.lite.browser/com.pure.browser.MainActivity}" drawable="pure_web_browser" name="Pure Web Browser" />
   <item component="ComponentInfo{com.drakeet.purewriter/.WriterActivity}" drawable="pure_writer" name="Pure Writer" />
   <item component="ComponentInfo{com.drakeet.purewriter/com.drakeet.purewriter.WriterActivity}" drawable="pure_writer" name="Pure Writer" />
   <item component="ComponentInfo{tv.orange/tv.twitch.android.app.core.LandingActivity}" drawable="purple_tv" name="PurpleTV" />
@@ -14106,6 +14253,7 @@
   <item component="ComponentInfo{qrcode.qrcodescanner.qrcodereader.barcode.barcodescanner/com.superfast.qrcode.activity.SplashActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
   <item component="ComponentInfo{com.a1pha.qrcodescanner/com.a1pha.qrcodescanner.MainActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
   <item component="ComponentInfo{qr.code.scanner.qr.code.reader/com.gamma.barcodeapp.ui.BarcodeCaptureActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
+  <item component="ComponentInfo{qrcodescanner.barcodescanner.qrscanner.qrcodereader/qrcodescanner.barcodescanner.qrscanner.qrcodereader.page.launcher.WelcomeActivity}" drawable="generic_qr_reader" name="QR Code Scanner" />
   <item component="ComponentInfo{com.dshatz.qrtile/com.dshatz.qrtile.QrDialog}" drawable="qrky" name="QR Code Scanner Tile" />
   <item component="ComponentInfo{la.droid.qr/la.droid.qr.Tabs}" drawable="qr_droid" name="QR Droid" />
   <item component="ComponentInfo{la.droid.qr/la.droid.qr.DeCamara}" drawable="qr_droid" name="QR Droid" />
@@ -14242,6 +14390,7 @@
   <item component="ComponentInfo{com.radio.fmradio/com.radio.fmradio.activities.SplashActivityAliasMain}" drawable="generic_fm_radio" name="Radio FM" />
   <item component="ComponentInfo{com.radiofrance.radio.radiofrance.android/com.radiofrance.kmp.application.MainActivity}" drawable="radio_france" name="Radio France" />
   <item component="ComponentInfo{com.radiofrance.radio.radiofrance.android/com.radiofrance.radio.radiofrance.android.screen.splash.SplashActivity}" drawable="radio_france" name="Radio France" />
+  <item component="ComponentInfo{com.radiofrance.radio.radiofrance.android/com.radiofrance.app.android_mobile.MainActivity}" drawable="radio_france" name="Radio France" />
   <item component="ComponentInfo{com.jonathanpuckey.radiogarden/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="radio_garden" name="Radio Garden" />
   <item component="ComponentInfo{com.jonathanpuckey.radiogarden/com.jonathanpuckey.radiogarden.MainActivity}" drawable="radio_garden" name="Radio Garden" />
   <item component="ComponentInfo{pl.radioyanosik.radio/pl.radioyanosik.radio.MainActivity}" drawable="generic_player" name="Radio Yanosik" />
@@ -14352,6 +14501,7 @@
   <item component="ComponentInfo{com.readermobile/com.readermobile.MainActivity}" drawable="readwise" name="Readwise" />
   <item component="ComponentInfo{com.readwise/com.readwise.MainActivity}" drawable="readwise" name="Readwise" />
   <item component="ComponentInfo{im.argent.contractwalletclient/im.argent.contractwalletclient.screens.StartupActivity}" drawable="ready" name="Ready" />
+  <item component="ComponentInfo{im.argent.contractwalletclient/co.ready.app.screens.StartupActivity}" drawable="ready" name="Ready" />
   <item component="ComponentInfo{com.devgary.ready/com.devgary.ready.application.ReadyApplication}" drawable="ready_for_reddit" name="Ready For Reddit" />
   <item component="ComponentInfo{com.devgary.ready/com.devgary.ready.activity.MainActivity}" drawable="ready_for_reddit" name="Ready For Reddit" />
   <item component="ComponentInfo{com.devgary.ready/com.devgary.ready.activity.ReadyDrawerActivity}" drawable="ready_for_reddit" name="Ready For Reddit" />
@@ -14463,6 +14613,7 @@
   <item component="ComponentInfo{com.reddit.frontpage/launcher.wallstreet}" drawable="reddit" name="Reddit" />
   <item component="ComponentInfo{com.reddit.frontpage/launcher.pixels}" drawable="reddit" name="Reddit" />
   <item component="ComponentInfo{com.reddit.frontpage.rvx/launcher.default}" drawable="reddit" name="Reddit" />
+  <item component="ComponentInfo{com.reddit.frontpage/launcher.worldcup2026}" drawable="reddit" name="Reddit" />
   <item component="ComponentInfo{com.andrewshu.android.reddit/com.andrewshu.android.reddit.MainActivity}" drawable="reddit_is_fun" name="reddit is fun" />
   <item component="ComponentInfo{com.andrewshu.android.redditdonation/com.andrewshu.android.reddit.MainActivity}" drawable="reddit_is_fun" name="reddit is fun golden platinum" />
   <item component="ComponentInfo{pt.beware.myrne/pt.beware.myrne.MainActivity}" drawable="rede_expressos" name="Rede Expressos" />
@@ -14487,6 +14638,7 @@
   <item component="ComponentInfo{com.dot.gallery/com.dot.gallery.MainActivity}" drawable="refra" name="ReFra" />
   <item component="ComponentInfo{com.dot.gallery/com.dot.gallery.feature_node.presentation.main.MainActivity}" drawable="refra" name="ReFra" />
   <item component="ComponentInfo{com.dot.gallery/com.dot.gallery.Launcher_Gallery}" drawable="refra" name="ReFra" />
+  <item component="ComponentInfo{com.dot.gallery/com.dot.gallery.Launcher_ReFra}" drawable="refra" name="ReFra" />
   <item component="ComponentInfo{ai.regainapp/ai.blox100.HomePageActivity}" drawable="regain" name="Regain" />
   <item component="ComponentInfo{com.fandango.regal/com.fandango.regal.activity.LauncherActivity}" drawable="regal" name="Regal" />
   <item component="ComponentInfo{com.fandango.regal/com.regal.activity.LauncherActivity}" drawable="regal" name="Regal" />
@@ -14618,6 +14770,7 @@
   <item component="ComponentInfo{de.rewe.app.mobile/de.rewe.app.view.MainActivity}" drawable="rewe" name="REWE" />
   <item component="ComponentInfo{de.rewe.app.mobile/de.rewe.app.app.view.MainActivity}" drawable="rewe" name="REWE" />
   <item component="ComponentInfo{ai.rezona.app/ai.rezona.app.ui.SplashActivity}" drawable="rezona" name="Rezona" />
+  <item component="ComponentInfo{ai.rezona.app/com.example.rezona_flutter.MainActivity}" drawable="rezona" name="Rezona" />
   <item component="ComponentInfo{com.mantz_it.rfanalyzer/com.mantz_it.rfanalyzer.ui.MainActivity}" drawable="spectroid" name="RF Analyzer" />
   <item component="ComponentInfo{com.mantz_it.rfanalyzer/com.mantz_it.rfanalyzer.MainActivity}" drawable="spectroid" name="RF Analyzer" />
   <item component="ComponentInfo{br.com.valid.rges/com.example.digital_credential.MainActivity}" drawable="rg_digital" name="RG Digital" />
@@ -14632,6 +14785,7 @@
   <item component="ComponentInfo{ridmik.news/com.ridmik.rc.newsic.MainActivity}" drawable="ridmik_news" name="Ridmik News" />
   <item component="ComponentInfo{com.goodwy.contacts/com.goodwy.contacts.activities.SplashActivity.Orange}" drawable="right_contacts" name="Right Contacts" />
   <item component="ComponentInfo{com.goodwy.contacts/com.goodwy.contacts.activities.SplashActivity.Original}" drawable="right_contacts" name="Right Contacts" />
+  <item component="ComponentInfo{com.goodwy.contacts/com.goodwy.contacts.activities.SplashActivity.One}" drawable="right_contacts" name="Right Contacts" />
   <item component="ComponentInfo{com.goodwy.dialer/com.goodwy.dialer.activities.SplashActivity.Orange}" drawable="generic_dialer" name="Right Dialer" />
   <item component="ComponentInfo{com.goodwy.dialer/com.goodwy.dialer.activities.SplashActivity.Original}" drawable="generic_dialer" name="Right Dialer" />
   <item component="ComponentInfo{com.goodwy.filemanager/com.goodwy.filemanager.activities.SplashActivity.Original}" drawable="generic_files" name="Right Files" />
@@ -14652,6 +14806,7 @@
   <item component="ComponentInfo{com.herman.ringtone/com.herman.ringtone.MusicPicker}" drawable="ringtone_maker" name="Ringtone Maker" />
   <item component="ComponentInfo{ringtonemaker.musiccutter.customringtones.freeringtonemaker/app.better.ringtone.activity.SplashActivity}" drawable="generic_audio_editor" name="Ringtone Maker" />
   <item component="ComponentInfo{com.androidrocker.audiocutter/com.androidrocker.audiocutter.MySplashActivity}" drawable="sony_music" name="Ringtone Maker" />
+  <item component="ComponentInfo{com.herman.ringtone/com.herman.ringtone.ui.picker.MusicPickerActivity}" drawable="ringtone_maker" name="Ringtone Maker" />
   <item component="ComponentInfo{hibernate.v2.ringtonerandomizer/hibernate.v2.ringtonerandomizer.ui.activity.MainActivity}" drawable="ringtone_randomizer" name="Ringtone Randomizer" />
   <item component="ComponentInfo{com.leonidbuzmacov.ringtonerotator/com.leonidbuzmacov.ringtonerotator.MainActivity}" drawable="music_player" name="Ringtone Rotator" />
   <item component="ComponentInfo{com.riotgames.mobile.leagueconnect/com.riotgames.mobile.leagueconnect.ui.MainActivity}" drawable="riot" name="Riot" />
@@ -14674,6 +14829,7 @@
   <item component="ComponentInfo{com.robinhood.android/com.robinhood.android.activity.WelcomeActivity}" drawable="robinhood" name="Robinhood" />
   <item component="ComponentInfo{com.robinhood.gateway/com.robinhood.gateway.GatewayLauncherActivity}" drawable="robinhood" name="Robinhood" />
   <item component="ComponentInfo{com.robinhood.money/com.robinhood.money.MainActivity}" drawable="robinhood" name="Robinhood" />
+  <item component="ComponentInfo{com.robinhood.money/com.robinhood.money.MainActivityBanking}" drawable="robinhood" name="Robinhood" />
   <item component="ComponentInfo{com.roblox.client/com.roblox.client.ActivitySplash}" drawable="roblox" name="Roblox" />
   <item component="ComponentInfo{com.roblox.client/com.roblox.client.startup.ActivitySplash}" drawable="roblox" name="Roblox" />
   <item component="ComponentInfo{com.roblox.client.samsunggalaxy/com.roblox.client.startup.ActivitySplash}" drawable="roblox" name="Roblox" />
@@ -14732,6 +14888,7 @@
   <item component="ComponentInfo{bitnet.hu.rossmann/com.rossmannmobile.MainActivity}" drawable="rossmann" name="Rossmann" />
   <item component="ComponentInfo{ru.kfc.kfc_delivery/com.kfc.MainActivity}" drawable="rostics" name="Rostic's" />
   <item component="ComponentInfo{ru.kfc.kfc_delivery/com.kfc.ui.activities.NativeModuleActivity}" drawable="rostics" name="Rostic's" />
+  <item component="ComponentInfo{ru.kfc.kfc_delivery/ru.kfc.kfc_delivery.MainActivity}" drawable="rostics" name="Rostic's" />
   <item component="ComponentInfo{com.pranavpandey.rotation/com.pranavpandey.rotation.activity.SplashActivity}" drawable="generic_rotation" name="Rotation" />
   <item component="ComponentInfo{org.crape.rotationcontrol/org.crape.rotationcontrol.RotationControlActivity}" drawable="generic_rotation" name="Rotation Control" />
   <item component="ComponentInfo{de.felixnuesse.extract/ca.pkay.rcloneexplorer.Activities.MainActivity}" drawable="round_sync" name="Round Sync" />
@@ -14824,6 +14981,7 @@
   <item component="ComponentInfo{com.jazibkhan.noiseuncanceller/com.jazibkhan.noiseuncanceller.ui.activities.main.MainActivity}" drawable="safe_headphones" name="Safe Headphones" />
   <item component="ComponentInfo{com.jazibkhan.noiseuncanceller/com.jazibkhan.noiseuncanceller.MainActivity}" drawable="safe_headphones" name="Safe Headphones" />
   <item component="ComponentInfo{org.privacymatters.safespace/org.privacymatters.safespace.AuthActivity}" drawable="safe_space" name="Safe Space" />
+  <item component="ComponentInfo{org.privacymatters.safespace/org.privacymatters.safespace.auth.AuthActivity}" drawable="safe_space" name="Safe Space" />
   <item component="ComponentInfo{com.safeboda.passenger/com.safeboda.presentation.ui.splash.StartActivity}" drawable="safeboda" name="SafeBoda" />
   <item component="ComponentInfo{com.safeincloud/com.safeincloud.ui.EntryActivity}" drawable="safeincloud" name="SafeInCloud" />
   <item component="ComponentInfo{com.safeincloud.free/com.safeincloud.ui.EntryActivity}" drawable="safeincloud" name="SafeInCloud" />
@@ -14885,6 +15043,7 @@
   <item component="ComponentInfo{com.sec.android.app.popupcalculator/.Calculator}" drawable="generic_calculator_minus_multi_plus_equal" name="Samsung Calculator" />
   <item component="ComponentInfo{com.sec.android.app.popupcalculator/com.sec.android.app.popupcalculator.Calculator}" drawable="generic_calculator_minus_multi_plus_equal" name="Samsung Calculator" />
   <item component="ComponentInfo{com.samsung.android.scan3d/com.android.camera.CameraLauncher}" drawable="generic_camera" name="Samsung Camera" />
+  <item component="ComponentInfo{com.samsung.android.scan3d/com.google.android.apps.cameralite.capture.CaptureActivity}" drawable="generic_camera" name="Samsung Camera" />
   <item component="ComponentInfo{com.samsung.android.app.cameraassistant/com.samsung.android.app.cameraassistant.MainActivity}" drawable="samsung_camera_assistant" name="Samsung Camera Assistant" />
   <item component="ComponentInfo{com.samsung.android.scloud/com.samsung.android.scloud.app.ui.splash.SplashActivity}" drawable="samsung_cloud_for_wear_os" name="Samsung Cloud for Wear OS" />
   <item component="ComponentInfo{com.samsung.android.scloud/com.samsung.android.scloud.app.ui.splash.launcher}" drawable="samsung_cloud_for_wear_os" name="Samsung Cloud for Wear OS" />
@@ -15040,6 +15199,7 @@
   <item component="ComponentInfo{com.samsung.shop/com.samsung.shop.MainActivity}" drawable="samsung_shop" name="Samsung Shop" />
   <item component="ComponentInfo{com.samsung.ecomm/com.samsung.ecomm.MainActivity}" drawable="samsung_shop" name="Samsung Shop" />
   <item component="ComponentInfo{com.samsungar.shop/com.samsungar.shop.MainActivity}" drawable="samsung_shop" name="Samsung Shop" />
+  <item component="ComponentInfo{com.samsung.ecomm/com.samsung.ecomm.global.shop_app.MainActivity}" drawable="samsung_shop" name="Samsung Shop" />
   <item component="ComponentInfo{com.samsung.android.app.searchwidget/com.samsung.android.app.searchwidget.ui.FeedsActivity}" drawable="generic_search" name="Samsung Smart Search" />
   <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.ui.launch.LauncherActivity}" drawable="samsung_smart_switch" name="Samsung Smart Switch" />
   <item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.DistributionActivity}" drawable="samsung_smart_switch" name="Samsung Smart Switch" />
@@ -15142,6 +15302,7 @@
   <item component="ComponentInfo{com.sbs.ondemand.android/com.sbs.ondemand.MainActivity}" drawable="sbs_on_demand" name="SBS On Demand" />
   <item component="ComponentInfo{capital.scalable.droid/capital.scalable.droid.overlay.cockpit.screen.CockpitActivity}" drawable="scalable_capital" name="Scalable Capital" />
   <item component="ComponentInfo{capital.scalable.droid/capital.scalable.droid.redesign.screens.cockpit.CockpitActivity}" drawable="scalable_capital" name="Scalable Capital" />
+  <item component="ComponentInfo{capital.scalable.droid/capital.scalable.droid.cockpit.overlay.cockpit.gatekeeper.GatekeeperActivity}" drawable="scalable_capital" name="Scalable Capital" />
   <item component="ComponentInfo{com.scalapay.scalapay_customer_app/com.scalapay.scalapay_customer_app.MainActivity}" drawable="scalapay" name="Scalapay" />
   <item component="ComponentInfo{sg.gov.scamshield/sg.gov.scamshield.MainActivity}" drawable="scamshield" name="ScamShield" />
   <item component="ComponentInfo{com.mediatek.camera.scan/com.mediatek.camera.HxyQrCodeActivity}" drawable="scanner" name="scan" />
@@ -15184,6 +15345,7 @@
   <item component="ComponentInfo{taco.scoop/taco.scoop.ui.activity.MainActivity}" drawable="scoop" name="Scoop" />
   <item component="ComponentInfo{com.trubeacon.scooters_mobile_android/com.scooterscoffee.ui.main.MainActivity}" drawable="scooters_coffee" name="Scooter's Coffee" />
   <item component="ComponentInfo{sh.cfw.utility/sh.cfw.utility.activities.ScannerActivity}" drawable="scooterhacking_utility" name="ScooterHacking Utility" />
+  <item component="ComponentInfo{sh.cfw.utility/sh.cfw.utility_flutter.MainActivity}" drawable="scooterhacking_utility" name="ScooterHacking Utility" />
   <item component="ComponentInfo{com.szabolcsarvai.scorecounter/com.szabolcsarvai.scorecounter.feature.splash.SplashActivity}" drawable="score_counter" name="Score Counter" />
   <item component="ComponentInfo{ua.napps.scorekeeper/ua.napps.scorekeeper.app.MainActivity}" drawable="score_counter_by_napps" name="Score Counter by napps" />
   <item component="ComponentInfo{net.aasuited.scrabbleassistant/net.aasuited.belotescore.ui.activity.gamemanagement.GameManagementActivity}" drawable="score_keeper_for_scrabble" name="Score Keeper for SCRABBLE" />
@@ -15263,6 +15425,7 @@
   <item component="ComponentInfo{id.co.bankbkemobile.digitalbank/com.shopee.bke.digitalbank.ui.enasahh1136912392}" drawable="seabank" name="SeaBank" />
   <item component="ComponentInfo{id.co.bankbkemobile.digitalbank/id.co.bankbkemobile.digitalbank.haneaoa.hshoone80026869}" drawable="seabank" name="SeaBank" />
   <item component="ComponentInfo{id.co.bankbkemobile.digitalbank/com.shopee.bke.digitalbank.ui.neshoas1136912392}" drawable="seabank" name="SeaBank" />
+  <item component="ComponentInfo{id.co.bankbkemobile.digitalbank/com.shopee.bke.digitalbank.ui.ohhshan1136912392}" drawable="seabank" name="SeaBank" />
   <item component="ComponentInfo{com.junkfood.seal/com.junkfood.seal.MainActivity}" drawable="seal" name="Seal" />
   <item component="ComponentInfo{com.junkfood.seal.preview/com.junkfood.seal.MainActivity}" drawable="seal" name="Seal Preview" />
   <item component="ComponentInfo{com.hkapps.sealdownloader/com.hkapps.sealdownloader.activities.SplashScreen}" drawable="sealx_downloader" name="SealX Downloader" />
@@ -16112,6 +16275,7 @@
   <item component="ComponentInfo{com.raed.drawing/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="sketchbook_lite" name="Sketchbook Lite" />
   <item component="ComponentInfo{pro.sketchware/pro.sketchware.activities.main.activities.MainActivity}" drawable="sketchware" name="Sketchware" />
   <item component="ComponentInfo{com.corecoders.skitracks/com.corecoders.skitracks.ui.main.MainActivity}" drawable="ski_tracks" name="Ski Tracks" />
+  <item component="ComponentInfo{com.corecoders.skitracks/com.corecoders.skitracks.ui.main.SplashActivity}" drawable="ski_tracks" name="Ski Tracks" />
   <item component="ComponentInfo{net.skiley.mobile/net.skiley.mobile.MainActivity}" drawable="skiley" name="Skiley" />
   <item component="ComponentInfo{cc.skiline.android/cc.skiline.android.screens.startup.StartupActivity}" drawable="skiline" name="Skiline" />
   <item component="ComponentInfo{com.skillshare.Skillshare/com.skillshare.Skillshare.client.main.view.MainActivity}" drawable="skillshare" name="Skillshare" />
@@ -16164,6 +16328,7 @@
   <item component="ComponentInfo{com.Slack/com.Slack.ui.HomeActivity}" drawable="slack" name="Slack" />
   <item component="ComponentInfo{com.Slack/slack.app.ui.HomeActivity}" drawable="slack" name="Slack" />
   <item component="ComponentInfo{com.Slack/slack.features.home.HomeActivity}" drawable="slack" name="Slack" />
+  <item component="ComponentInfo{com.Slack/slack.app.HomeActivity}" drawable="slack" name="Slack" />
   <item component="ComponentInfo{com.humble.SlayTheSpire/com.android.support.MainActivity}" drawable="slay_the_spire" name="Slay the Spire" />
   <item component="ComponentInfo{com.humble.SlayTheSpire/android.app.NativeActivity}" drawable="slay_the_spire" name="Slay the Spire" />
   <item component="ComponentInfo{com.urbandroid.sleep/com.urbandroid.sleep.alarmclock.AlarmClock}" drawable="sleep_as_android" name="Sleep as Android" />
@@ -16347,6 +16512,7 @@
   <item component="ComponentInfo{com.snaptube.premium/com.snaptube.premium.activity.MainExploreAlias}" drawable="snaptube" name="Snaptube" />
   <item component="ComponentInfo{com.snb.alahlimobile/com.snb.alahlimobile.MainActivity}" drawable="snb" name="SNB" />
   <item component="ComponentInfo{be.sncbnmbs.b2cmobapp/be.sncbnmbs.b2cmobapp.MainActivity}" drawable="sncb_nmbs" name="SNCB/NMBS" />
+  <item component="ComponentInfo{be.sncbnmbs.b2cmobapp/be.sncbnmbs.b2cmobapp.SplashActivity}" drawable="sncb_nmbs" name="SNCB/NMBS" />
   <item component="ComponentInfo{com.vsct.vsc.mobile.horaireetresa.android/com.vsct.vsc.mobile.horaireetresa.android.activity.SplashActivity}" drawable="sncf_connect" name="SNCF Connect" />
   <item component="ComponentInfo{com.vsct.vsc.mobile.horaireetresa.android/com.evoyageurs.invictus.flutter.MainActivity}" drawable="sncf_connect" name="SNCF Connect" />
   <item component="ComponentInfo{com.explusalpha.Snes9xPlus/com.imagine.BaseActivity}" drawable="snes9x_ex" name="Snes9x EX+" />
@@ -16510,6 +16676,7 @@
   <item component="ComponentInfo{com.soundcloud.android.revanced/com.soundcloud.android.launcher.LauncherActivity}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.soundcloud.android/com.google.android.archive.ReactivateActivity}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.luna.music/com.soundcloud.android.launcher.LauncherActivity}" drawable="soundcloud" name="SoundCloud" />
+  <item component="ComponentInfo{com.soundcloud.android/com.soundcloud.android.launcher.LauncherActivityChromeIconAlias}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.google.android.archive.ReactivateActivity}" drawable="soundcore" name="Soundcore" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.oceanwing.soundcore.activity.SelectCategoryNewActivity}" drawable="soundcore" name="Soundcore" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.oceanwing.soundcore.activity.WelcomeActivity}" drawable="soundcore" name="Soundcore" />
@@ -16661,6 +16828,7 @@
   <item component="ComponentInfo{com.blacksquircle.ui/com.blacksquircle.ui.application.activity.MainActivity}" drawable="squircle_ce" name="Squircle CE" />
   <item component="ComponentInfo{com.blacksquircle.ui/com.blacksquircle.ui.application.MainActivity}" drawable="squircle_ce" name="Squircle CE" />
   <item component="ComponentInfo{com.sram.armyknife/com.sram.armyknifecore.MainActivity}" drawable="sram_axs" name="SRAM AXS" />
+  <item component="ComponentInfo{com.sram.armyknife/com.sram.armyknife.app.MainActivity}" drawable="sram_axs" name="SRAM AXS" />
   <item component="ComponentInfo{com.srmist.studentportal/com.srmist.studentportal.MainActivity}" drawable="srmist_scope" name="SRMIST Scope" />
   <item component="ComponentInfo{kr.co.ssg/kr.co.ssg.activity.etc.MainActivity}" drawable="ssg_com" name="SSG.COM" />
   <item component="ComponentInfo{app.sshtproject/com.dtunnel.presenter.MainActivity}" drawable="ssh_t_project_vpn" name="SSH T PROJECT VPN" />
@@ -16678,6 +16846,7 @@
   <item component="ComponentInfo{me.tylerbwong.stack/me.tylerbwong.stack.ui.MainActivity}" drawable="stack_for_stack_overflow" name="Stack for Stack Overflow" />
   <item component="ComponentInfo{com.area120.paperwork/com.google.area120.paperwork.android.main.MainActivity}" drawable="stack_pdf_scanner" name="Stack: PDF Scanner" />
   <item component="ComponentInfo{wien.at.live/at.wien.live.ui.MainActivity}" drawable="stadt_wien" name="Stadt Wien" />
+  <item component="ComponentInfo{org.klimabuendnis.Stadtradeln/org.klimabuendnis.stadtradeln.MainActivity}" drawable="stadtradeln" name="STADTRADELN" />
   <item component="ComponentInfo{org.klimabuendnis.Stadtradeln/org.klimabuendnis.stadtradeln.ui.startup.StartupActivity}" drawable="stadtradeln" name="STADTRADELN ~~ CITY CYCLING" />
   <item component="ComponentInfo{org.klimabuendnis.Stadtradeln/org.klimabuendnis.stadtradeln.StartupActivity}" drawable="stadtradeln" name="STADTRADELN ~~ CITY CYCLING" />
   <item component="ComponentInfo{com.standardnotes/com.standardnotes.MainActivity}" drawable="standard_notes" name="Standard Notes" />
@@ -16824,6 +16993,7 @@
   <item component="ComponentInfo{de.loicezt.stickers/de.loicezt.stickers.MainActivity}" drawable="stickers" name="Stickers" />
   <item component="ComponentInfo{com.wastickerapps.stickerstore/com.example.samplestickerapp.SplashScreen}" drawable="stickify" name="Stickify" />
   <item component="ComponentInfo{com.mindy.grap1/com.unity3d.player.UnityPlayerActivity}" drawable="stickman_hook" name="Stickman Hook" />
+  <item component="ComponentInfo{com.mindy.grap1/com.google.firebase.MessagingUnityPlayerActivity}" drawable="stickman_hook" name="Stickman Hook" />
   <item component="ComponentInfo{com.PlayMax.playergames/com.unity3d.player.UnityPlayerActivity}" drawable="stickman_party" name="Stickman Party" />
   <item component="ComponentInfo{com.angkorworld.note/com.angkorworld.memo.activities.MainActivity}" drawable="samsung_notes" name="Sticky Notepad" />
   <item component="ComponentInfo{com.stimuler/com.stimuler.MainActivity}" drawable="stimuler" name="Stimuler" />
@@ -16878,6 +17048,7 @@
   <item component="ComponentInfo{com.stremio.one/com.stremio.android.MainActivity}" drawable="stremio" name="Stremio" />
   <item component="ComponentInfo{zapsolutions.strike/zapsolutions.strike.activity.main.MainActivity}" drawable="strike_bitcoin" name="STRIKE: BITCOIN" />
   <item component="ComponentInfo{com.stripe.android.dashboard/com.stripe.dashboard.ui.launch.MainActivity}" drawable="stripe" name="Stripe" />
+  <item component="ComponentInfo{com.stripe.android.dashboard/com.stripe.android.dashboard.MainActivity}" drawable="stripe" name="Stripe" />
   <item component="ComponentInfo{com.zidsoft.flashlight/com.zidsoft.flashlight.main.MainActivity}" drawable="strobe" name="Strobe" />
   <item component="ComponentInfo{io.strongapp.strong/io.strongapp.strong.ui.main.MainActivity}" drawable="strong" name="Strong" />
   <item component="ComponentInfo{io.strongapp.strong/io.strongapp.strong.MainActivity}" drawable="strong" name="Strong" />
@@ -17213,6 +17384,7 @@
   <item component="ComponentInfo{com.talabat/com.talabat.LandingScreen}" drawable="talabat" name="talabat" />
   <item component="ComponentInfo{com.talabat/com.talabat.MainActivityDefault}" drawable="talabat" name="talabat" />
   <item component="ComponentInfo{com.talabat/com.talabat.MainActivityRamadan}" drawable="talabat" name="talabat" />
+  <item component="ComponentInfo{com.talabat/com.talabat.MainActivityUae}" drawable="talabat" name="talabat" />
   <item component="ComponentInfo{com.talana.next/com.talana.next.view.splash.SplashActivity}" drawable="asus_gallery" name="Talana Next" />
   <item component="ComponentInfo{co.talenta/co.talenta.modul.splash.SplashActivity}" drawable="talenta" name="Talenta" />
   <item component="ComponentInfo{com.talkatone.android/com.talkatone.vedroid.Loading}" drawable="generic_dialer" name="Talkatone" />
@@ -17296,6 +17468,7 @@
   <item component="ComponentInfo{com.ryzmedia.tatasky/com.ryzmedia.tatasky.splash.SplashActivity}" drawable="tata_play" name="Tata Play" />
   <item component="ComponentInfo{com.tatasky.binge/com.tatasky.binge.AppSplashActivityDefault}" drawable="tata_play_binge" name="Tata Play Binge" />
   <item component="ComponentInfo{com.tatasky.binge/com.tatasky.binge.ui.features.splash.AppSplashActivity}" drawable="tata_play_binge" name="Tata Play Binge" />
+  <item component="ComponentInfo{com.tatasky.binge/com.tatasky.binge.AppSplashActivityWorldCup}" drawable="tata_play_binge" name="Tata Play Binge" />
   <item component="ComponentInfo{sk.tb.ib.tatraandroid/sk.tb.ib.tatraandroid.landing.TatraLauncherActivity}" drawable="tatra_banka" name="Tatra banka" />
   <item component="ComponentInfo{de.taxfix/de.taxfix.MainActivity}" drawable="taxfix" name="Taxfix" />
   <item component="ComponentInfo{ca.skex.taxicoop5191/ca.skex.taxicoop.controler.home.MainActivity}" drawable="taxi_coop" name="Taxi Coop" />
@@ -17430,6 +17603,7 @@
   <item component="ComponentInfo{com.telmex.mitelmex/com.icom.telmex.ui.splash.SplashActivity}" drawable="telmex" name="Telmex" />
   <item component="ComponentInfo{com.telus.mywifi/com.telus.mywifi.screens.main.MainActivity}" drawable="telus_connect" name="TELUS Connect" />
   <item component="ComponentInfo{com.babylon.telushealth/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="telus_health_mycare" name="TELUS Health MyCare" />
+  <item component="ComponentInfo{com.babylon.telushealth/com.babylon.cyrus.MainActivity}" drawable="telus_health_mycare" name="TELUS Health MyCare" />
   <item component="ComponentInfo{v.d.d.answercall/v.d.d.answercall.MainFrActivity}" drawable="generic_dialer" name="Teléfono" />
   <item component="ComponentInfo{com.tempmail/com.tempmail.splash.SplashActivity}" drawable="temp_mail" name="Temp Mail" />
   <item component="ComponentInfo{com.tempmail/com.tempmail.activities.splash.SplashActivity}" drawable="temp_mail" name="Temp Mail" />
@@ -17519,6 +17693,7 @@
   <item component="ComponentInfo{com.enflick.android.TextNow/com.enflick.android.TextNow.activities.WelcomeActivity}" drawable="textnow" name="TextNow" />
   <item component="ComponentInfo{com.enflick.android.TextNow/authorization.ui.AuthorizationActivity}" drawable="textnow" name="TextNow" />
   <item component="ComponentInfo{com.enflick.android.TextNow/com.enflick.android.TextNow.appicon.winter}" drawable="textnow" name="TextNow" />
+  <item component="ComponentInfo{com.enflick.android.TextNow/com.enflick.android.TextNow.appicon.pride}" drawable="textnow" name="TextNow" />
   <item component="ComponentInfo{com.gogii.textplus/com.nextplus.android.activity.SplashScreenActivity}" drawable="textplus" name="textPlus" />
   <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1de9b6_bare}" drawable="textra_sms" name="Textra SMS" />
   <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff448aff}" drawable="textra_sms" name="Textra SMS" />
@@ -17797,6 +17972,7 @@
   <item component="ComponentInfo{com.sysops.thenx/com.sysops.thenx.parts.routing.RoutingActivity}" drawable="thenx" name="Thenx" />
   <item component="ComponentInfo{com.sysops.thenx/com.sysops.thenx.parts.splash.SplashActivity}" drawable="thenx" name="Thenx" />
   <item component="ComponentInfo{info.flowersoft.theotown.theotown/info.flowersoft.theotown.theotown.MainActivity}" drawable="theotown" name="TheoTown" />
+  <item component="ComponentInfo{info.flowersoft.theotown.theotown/com.min.n.MainActivity}" drawable="theotown" name="TheoTown" />
   <item component="ComponentInfo{com.tmvno.thepay/com.tmvno.thepay.MainActivity}" drawable="thepay" name="thePAY" />
   <item component="ComponentInfo{com.google.android.apps.pixel.health/com.google.android.apps.pixel.health.thermometer.ThermometerHomeActivity}" drawable="thermometer" name="Thermometer" />
   <item component="ComponentInfo{javalc6.thesaurus/javalc6.thesaurus.ThesaurusView}" drawable="thesaurus" name="Thesaurus" />
@@ -17897,6 +18073,7 @@
   <item component="ComponentInfo{com.rezvorck.tiktokplugin/com.rezvorck.tiktokplugin.MainActivity}" drawable="tiktok_plugin" name="TikTok Plugin" />
   <item component="ComponentInfo{com.tiktok.plugin/com.tiktok.plugin.MainActivity}" drawable="tiktok_plugin" name="TikTok Plugin" />
   <item component="ComponentInfo{com.tiktokshop.seller/com.tiktokshop.seller.AppLauncher}" drawable="tiktok_shop" name="TikTok Shop" />
+  <item component="ComponentInfo{com.tiktokshop.seller/com.tiktokshop.seller.AppLauncher.Default}" drawable="tiktok_shop" name="TikTok Shop" />
   <item component="ComponentInfo{com.ss.android.tt.creator/com.ss.android.ugc.aweme.splash.SplashActivity}" drawable="tiktok" name="TikTok Studio" />
   <item component="ComponentInfo{com.video.downloader.no.watermark.tiktok/com.video.downloader.no.watermark.tiktok.ui.activity.SplashActivity}" drawable="tiktokdownloader" name="TikTokDownloader" />
   <item component="ComponentInfo{com.thetileapp.tile/com.thetileapp.tile.activities.DispatchingActivity}" drawable="tile" name="Tile" />
@@ -17987,6 +18164,7 @@
   <item component="ComponentInfo{com.tocaboca.tocalifeworld/com.google.android.archive.ReactivateActivity}" drawable="toca_boca_world" name="Toca Boca World" />
   <item component="ComponentInfo{com.tocaboca.tocalifeworld/com.tocaboca.activity.TocaBocaActivity}" drawable="toca_boca_world" name="Toca Boca World" />
   <item component="ComponentInfo{com.tocaboca.tocalifeworld/com.tocaboca.activity.TocaBocaMainActivity}" drawable="toca_boca_world" name="Toca Boca World" />
+  <item component="ComponentInfo{com.tocaboca.tocalifeworld/com.me.game.game_mod.MainActivity}" drawable="toca_boca_world" name="Toca Boca World" />
   <item component="ComponentInfo{mobi.eup.jpnews/mobi.eup.jpnews.activity.MainActivity}" drawable="todaii" name="Todaii" />
   <item component="ComponentInfo{mobi.eup.jpnews/mobi.eup.jpnews.activity.SplashScreenActivity}" drawable="todaii" name="Todaii" />
   <item component="ComponentInfo{mobi.lockdown.weather/mobi.lockdown.weather.activity.MainActivity}" drawable="today_weather" name="Today Weather" />
@@ -18168,6 +18346,7 @@
   <item component="ComponentInfo{cu.etecsa.cubacel.tr.tm/cu.etecsa.cubacel.tr.tm.WVeb1Va07v}" drawable="transfermovil" name="Transfermovil" />
   <item component="ComponentInfo{cu.etecsa.cubacel.tr.tm/cu.etecsa.cubacel.tr.tm.mTIUNNHZ2X}" drawable="transfermovil" name="Transfermovil" />
   <item component="ComponentInfo{cu.etecsa.cubacel.tr.tm/cu.etecsa.cubacel.tr.tm.dQIGCe2zqB}" drawable="transfermovil" name="Transfermóvil" />
+  <item component="ComponentInfo{cu.etecsa.cubacel.tr.tm/cu.etecsa.cubacel.tr.tm.prPzLeyxKk}" drawable="transfermovil" name="Transfermóvil" />
   <item component="ComponentInfo{org.y20k.transistor/org.y20k.transistor.MainActivity}" drawable="transistor_radio" name="Transistor Radio" />
   <item component="ComponentInfo{com.thetransitapp.droid/com.thetransitapp.droid.shared.activity.SplashActivitydcmetroblue}" drawable="transit" name="Transit" />
   <item component="ComponentInfo{com.thetransitapp.droid/com.thetransitapp.droid.shared.activity.SplashActivitytransportforlondonblack}" drawable="transit" name="Transit" />
@@ -18216,6 +18395,7 @@
   <item component="ComponentInfo{eu.baroncelli.oraritrenitalia/eu.baroncelli.oraritrenitalia.mainactivity.MainActivity}" drawable="trenit" name="Trenit" />
   <item component="ComponentInfo{com.lynxspa.prontotreno/com.ibm.android.states.startup.StartUpActivity}" drawable="trenitalia" name="Trenitalia" />
   <item component="ComponentInfo{com.lynxspa.prontotreno/com.ibm.android.states.main.MainActivity}" drawable="trenitalia" name="Trenitalia" />
+  <item component="ComponentInfo{com.lynxspa.prontotreno/com.ibm.android._redesign.HostActivity}" drawable="trenitalia" name="Trenitalia" />
   <item component="ComponentInfo{it.nordcom.app/it.nordcom.app.ui.activity.SplashActivity}" drawable="trenord" name="Trenord" />
   <item component="ComponentInfo{com.tresorit.mobile/com.tresorit.android.activity.RootTresoritActivity}" drawable="tresorit" name="Tresorit" />
   <item component="ComponentInfo{io.trezor.suite/io.trezor.suite.MainActivity}" drawable="trezor" name="Trezor" />
@@ -18275,6 +18455,7 @@
   <item component="ComponentInfo{com.wallet.crypto.trustapp/com.wallet.crypto.trustapp.ui.start.activity.RootHostActivity}" drawable="trust_wallet" name="Trust Wallet" />
   <item component="ComponentInfo{com.wallet.crypto.trustapp/com.wallet.crypto.trustapp.ui.start.activity.StartActivity}" drawable="trust_wallet" name="Trust Wallet" />
   <item component="ComponentInfo{com.wallet.crypto.trustapp/com.wallet.crypto.trustapp.ui.app.AppActivity.default}" drawable="trust_wallet" name="Trust Wallet" />
+  <item component="ComponentInfo{com.wallet.crypto.trustapp/com.wallet.crypto.trustapp.ui.app.AppActivity.trust_gray}" drawable="trust_wallet" name="Trust Wallet" />
   <item component="ComponentInfo{com.trustdevice.android/cn.tongdun.android.activitys.SplashActivity}" drawable="trustdevice" name="TrustDevice" />
   <item component="ComponentInfo{com.truthsocial.android.app/com.truthsocial.app.features.startup.TruthActivity}" drawable="truth_social" name="Truth Social" />
   <item component="ComponentInfo{com.truthsocial.android.app/com.truthsocial.app.features.onboarding.SplashActivity}" drawable="truth_social" name="Truth Social" />
@@ -18299,6 +18480,7 @@
   <item component="ComponentInfo{org.polymorphicshade.tubular/org.schabi.newpipe.MainActivity}" drawable="tubular" name="Tubular" />
   <item component="ComponentInfo{com.tuentiargentina/com.tuentiargentina.MainActivity}" drawable="tuenti" name="Tuenti" />
   <item component="ComponentInfo{ec.otecel.tuenti/ec.otecel.tuenti.SplashActivity}" drawable="tuenti" name="Tuenti" />
+  <item component="ComponentInfo{ec.otecel.tuenti/ec.otecel.tuenti.MainActivity}" drawable="tuenti" name="Tuenti" />
   <item component="ComponentInfo{com.thomson.mythomson/com.tui.tda.launcher.ui.screen.LauncherActivity}" drawable="tui" name="TUI" />
   <item component="ComponentInfo{de.tui.meinetui/com.tui.tda.activities.LauncherActivity}" drawable="tui" name="TUI" />
   <item component="ComponentInfo{com.tui.tda.fi/com.tui.tda.activities.LauncherActivity}" drawable="tui" name="TUI" />
@@ -18337,6 +18519,7 @@
   <item component="ComponentInfo{com.tunnelbear.android/com.tunnelbear.android.TbearSplashActivity}" drawable="tunnelbear" name="TunnelBear" />
   <item component="ComponentInfo{com.tunnelbear.android/com.tunnelbear.android.NavGraphActivity}" drawable="tunnelbear" name="TunnelBear" />
   <item component="ComponentInfo{com.tunnelbear.android/com.tunnelbear.android.MainActivity}" drawable="tunnelbear" name="TunnelBear" />
+  <item component="ComponentInfo{com.tunnelbear.android/com.tunnelbear.android.MainActivityDefault}" drawable="tunnelbear" name="TunnelBear" />
   <item component="ComponentInfo{com.botpa.turbophotos/com.botpa.turbophotos.screens.home.HomeActivity}" drawable="turbo_photos" name="Turbo Photos" />
   <item component="ComponentInfo{free.vpn.unblock.proxy.turbovpn/free.vpn.unblock.proxy.turbovpn.activity.VpnMainActivity}" drawable="turbo_vpn" name="Turbo VPN" />
   <item component="ComponentInfo{free.vpn.unblock.proxy.turbovpn/free.vpn.unblock.proxy.turbovpn.activity.StartupActivity}" drawable="turbo_vpn" name="Turbo VPN" />
@@ -18447,6 +18630,7 @@
   <item component="ComponentInfo{com.ubs.Paymit.android/com.ubs.Paymit.android.P2PMobileBankingAppAndroidActivity}" drawable="ubs_twint" name="UBS TWINT" />
   <item component="ComponentInfo{com.ubs.Paymit.android/ch.twint.payment.ui.activities.start.StartActivity}" drawable="ubs_twint" name="UBS TWINT" />
   <item component="ComponentInfo{com.ubuy/com.app.mazade.ubuy.SplashActivity}" drawable="ubuy" name="Ubuy" />
+  <item component="ComponentInfo{com.ubuy/com.ubuy.SplashActivity}" drawable="ubuy" name="Ubuy" />
   <item component="ComponentInfo{com.UCMobile/com.UCMobile.main.UCMobile}" drawable="uc_browser" name="UC Browser" />
   <item component="ComponentInfo{com.UCMobile.intl/com.UCMobile.main.UCMobile}" drawable="uc_browser" name="UC Browser" />
   <item component="ComponentInfo{uz.ucell.ucellmobile/uz.ucell.app_ui.ui.splash.SplashScreenActivity}" drawable="ucell" name="Ucell" />
@@ -18557,6 +18741,8 @@
   <item component="ComponentInfo{com.uniqlo.in.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
   <item component="ComponentInfo{com.uniqlo.usa.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
   <item component="ComponentInfo{com.uniqlo.kr.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
+  <item component="ComponentInfo{com.uniqlo.my.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
+  <item component="ComponentInfo{com.uniqlo.vn.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
   <item component="ComponentInfo{com.veewalabs.unitconverter/com.veewalabs.unitconverter.MainActivity}" drawable="unit_converter" name="Unit Converter" />
   <item component="ComponentInfo{com.dronzer.unitconverter/com.dronzer.unitconverter.start.StartActivity}" drawable="unit_converter_by_dronzer" name="Unit Converter by Dronzer" />
   <item component="ComponentInfo{com.samruston.converter/com.samruston.converter.ui.MainActivity}" drawable="unit_converter_lab" name="Unit Converter Lab" />
@@ -18649,6 +18835,7 @@
   <item component="ComponentInfo{com.trianguloy.urlchecker/com.trianguloy.urlchecker.activities.MainActivity}" drawable="urlcheck" name="URLCheck" />
   <item component="ComponentInfo{com.bringyour.network/com.bringyour.network.LoginActivity}" drawable="urnetwork" name="URNetwork" />
   <item component="ComponentInfo{app.universal.revanced.manager/app.revanced.manager.MainActivity}" drawable="urv_manager" name="URV Manager" />
+  <item component="ComponentInfo{app.universal.revanced.manager/app.urv.manager.MainActivity}" drawable="urv_manager" name="URV Manager" />
   <item component="ComponentInfo{com.free.vpn.usa.proxy.planet/com.vpnapp.MainActivity}" drawable="planet_vpn" name="USA VPN" />
   <item component="ComponentInfo{com.usaa.mobile.android.usaa/com.usaa.mobile.android.app.entry.view.MainEntryActivity}" drawable="usaa" name="USAA" />
   <item component="ComponentInfo{com.usaa.mobile.android.usaa/com.usaa.mobile.android.app.SplashScreenActivity}" drawable="usaa" name="USAA" />
@@ -18713,6 +18900,7 @@
   <item component="ComponentInfo{com.cris.utsmobile/com.cris.utsmobile.mainmenuitems.SplashActivity}" drawable="uts" name="UTS" />
   <item component="ComponentInfo{com.cris.utsmobile/com.cris.ima.utsonmobile.mainmenuitems.SplashActivity}" drawable="uts" name="UTS" />
   <item component="ComponentInfo{com.netease.uu/com.netease.uu.activity.LaunchActivity}" drawable="uu_game_booster" name="UU Game Booster" />
+  <item component="ComponentInfo{com.netease.uu/com.netease.uu.activity.LaunchActivity.VIP}" drawable="uu_game_booster" name="UU Game Booster" />
   <item component="ComponentInfo{com.emacberry.uuid0xfd6fscan/com.emacberry.uuid0xfd6fscan.ScannerActivity}" drawable="uuid_0xfd6f_scanner" name="UUID 0xFD6F Scanner" />
   <item component="ComponentInfo{com.valuesccg.uvoice/com.valuesccg.uvoice.MainActivity}" drawable="uvoice" name="Uvoice" />
   <item component="ComponentInfo{nl.mediapp.pharmeon/nl.mediapp.pharmeon.MainActivity}" drawable="uw_zorg" name="Uw Zorg" />
@@ -18843,6 +19031,7 @@
   <item component="ComponentInfo{com.phonegap.Hello/com.phonegap.Hello.MainActivity}" drawable="generic_bible" name="VerseVIEWBible" />
   <item component="ComponentInfo{cn.super12138.todo/cn.super12138.todo.ui.activities.MainActivity}" drawable="vervedo" name="VerveDo" />
   <item component="ComponentInfo{it.very.mobile/it.windtre.dea.view.MainActivity}" drawable="very_mobile" name="Very Mobile" />
+  <item component="ComponentInfo{it.very.mobile/it.windtre.dea.MainActivity}" drawable="very_mobile" name="Very Mobile" />
   <item component="ComponentInfo{com.watch.life/com.ido.life.module.splash.SplashDefaultActivity}" drawable="veryfit" name="VeryFit" />
   <item component="ComponentInfo{com.vincentengelsoftware.vesandroidimagecompare/com.vincentengelsoftware.androidimagecompare.Activities.MainActivity}" drawable="photo_compare" name="VES" />
   <item component="ComponentInfo{com.vincentengelsoftware.vesandroidimagecompare/com.vincentengelsoftware.androidimagecompare.MainActivity}" drawable="photo_compare" name="VES" />
@@ -18900,6 +19089,7 @@
   <item component="ComponentInfo{com.instadownloader.instasave.igsave.ins/com.instadownloader.instasave.igsave.ins.MainActivity}" drawable="all_video_downloader" name="Video Downloader" />
   <item component="ComponentInfo{com.downloadlab.facebook.video.downloader/com.videodownloader.common.SplashActivity}" drawable="download_progress_plus_plus" name="Video Downloader" />
   <item component="ComponentInfo{video.downloader.save.video.social.media/video.downloader.save.video.social.media.view.activities.MainActivity}" drawable="download_progress_plus_plus" name="Video Downloader" />
+  <item component="ComponentInfo{com.instadownloader.instasave.igsave.ins/com.instadownloader.instasave.igsave.ins.StartupActivity}" drawable="all_video_downloader" name="Video Downloader" />
   <item component="ComponentInfo{photo.video.instasaveapp/photo.video.instasaveapp.WelcomeActivity}" drawable="generic_download_circle" name="Video Downloader &amp; Editor" />
   <item component="ComponentInfo{com.story.downloader.reels.videodownloader.repost.fast.save.video.photos/com.story.downloader.reels.videodownloader.repost.fast.save.video.photos.Views.SplashActivity}" drawable="download_progress_plus_plus" name="Video Downloader &amp; Editor" />
   <item component="ComponentInfo{twittervideosaver.twittervideodownloader.twimate.savetwittergif/twitter.downloader.twitterdownloader.activity.SplashActivity}" drawable="tiktokdownloader" name="Video Downloader &amp; GIF Saver" />
@@ -18959,6 +19149,7 @@
   <item component="ComponentInfo{com.vcb/com.vcb.activities.home.SplashActivity}" drawable="vietcombank_vcb" name="Vietcombank (VCB)" />
   <item component="ComponentInfo{com.vietinbank.ipay/com.vietinbank.ipay.activity.SplashActivity}" drawable="vietinbank_ipay" name="VietinBank iPay" />
   <item component="ComponentInfo{com.vietinbank.ipay/com.vnpaystart.SplashActivity}" drawable="vietinbank_ipay" name="VietinBank iPay" />
+  <item component="ComponentInfo{com.vietinbank.ipay/com.vietinbank.ipay.presenter.activity.splash.IPAYSplashActivity}" drawable="vietinbank_ipay" name="VietinBank iPay" />
   <item component="ComponentInfo{com.vietnammm.android/com.takeaway.android.activity.Splash}" drawable="just_eat" name="Vietnammm" />
   <item component="ComponentInfo{com.vietnammm.android/com.takeaway.android.Startup}" drawable="just_eat" name="Vietnammm" />
   <item component="ComponentInfo{com.bplus.vtpay/com.google.android.archive.ReactivateActivity}" drawable="viettel_money" name="Viettel Money" />
@@ -19019,6 +19210,7 @@
   <item component="ComponentInfo{ch.viseca.visecaone/com.netcetera.visecaone.android.feature.branding.alias_activities.StGallerKantonalbankAliasActivity}" drawable="viseca_one" name="Viseca One" />
   <item component="ComponentInfo{ch.viseca.visecaone/com.netcetera.visecaone.android.feature.branding.alias_activities.BanqueCantonaleVaudoiseAliasActivity}" drawable="viseca_one" name="Viseca One" />
   <item component="ComponentInfo{ch.viseca.visecaone/com.netcetera.visecaone.android.feature.branding.alias_activities.VisecaBrandAliasActivity}" drawable="viseca_one" name="Viseca One" />
+  <item component="ComponentInfo{ch.viseca.visecaone/com.netcetera.visecaone.android.feature.branding.alias_activities.RaiffeisenBankAliasActivity}" drawable="viseca_one" name="Viseca One" />
   <item component="ComponentInfo{com.transsion.magicshow/com.transsion.magicmovie.activity.TRSplashActivity}" drawable="visha_video_player" name="Visha Video Player" />
   <item component="ComponentInfo{com.vmm.android/com.vmm.android.view.SplashActivity}" drawable="vishal_mega_mart" name="Vishal Mega Mart" />
   <item component="ComponentInfo{com.visiblemobile.flagship/com.visiblemobile.flagship.splash.ui.SplashActivity}" drawable="visible" name="Visible" />
@@ -19036,13 +19228,16 @@
   <item component="ComponentInfo{com.vuclip.viu/com.viu.phone.ui.activity.WelcomeActivity}" drawable="viu" name="Viu" />
   <item component="ComponentInfo{com.vuclip.viu/com.vuclip.viu.ui.screens.MainActivity}" drawable="viu" name="Viu" />
   <item component="ComponentInfo{com.viu.phone/com.viu.phone.v2.presentation.RouterActivity}" drawable="viu" name="Viu" />
+  <item component="ComponentInfo{com.vuclip.viu/com.viu.phone.v2.presentation.RouterActivity}" drawable="viu" name="Viu" />
   <item component="ComponentInfo{com.yammer.v1/com.yammer.droid.ui.LauncherActivity}" drawable="viva_engage" name="Viva Engage" />
   <item component="ComponentInfo{com.videoeditorpro.android/com.quvideo.vivacut.app.splash.SplashActivity}" drawable="vivacut" name="VivaCut" />
   <item component="ComponentInfo{com.vivaldi.browser/com.google.android.apps.chrome.Main}" drawable="vivaldi" name="Vivaldi" />
+  <item component="ComponentInfo{com.vivaldi.browser/com.vivaldi.browser.IconAlt0}" drawable="vivaldi" name="Vivaldi" />
   <item component="ComponentInfo{com.vivaldi.browser.snapshot/com.google.android.apps.chrome.Main}" drawable="vivaldi" name="Vivaldi Snapshot" />
   <item component="ComponentInfo{com.quvideo.xiaoying/com.quvideo.xiaoying.app.splash.SplashActivity}" drawable="vivavideo" name="VivaVideo" />
   <item component="ComponentInfo{com.vivi.vivimusic/com.music.vivi.MainActivityAlias}" drawable="vivi_music" name="VIVI Music" />
   <item component="ComponentInfo{com.vivi.vivimusic/com.music.vivi.MainActivity}" drawable="vivi_music" name="VIVI Music" />
+  <item component="ComponentInfo{com.vivi.vivimusic/com.music.vivi.WelcomeActivity}" drawable="vivi_music" name="VIVI Music" />
   <item component="ComponentInfo{vivid.money/vivid.money.feature_main_screen.MainActivity}" drawable="vivid" name="Vivid" />
   <item component="ComponentInfo{com.ivianuu.oneplusgestures/com.ivianuu.vivid.app.MainActivity}" drawable="vivid_navigation_gestures" name="Vivid Navigation Gestures" />
   <item component="ComponentInfo{com.ivianuu.oneplusgestures/com.ivianuu.oneplusgestures.ui.MainActivity}" drawable="vivid_navigation_gestures" name="Vivid Navigation Gestures" />
@@ -19219,6 +19414,7 @@
   <item component="ComponentInfo{com.appntox.vpnpro/app.appntox.vpn.presentation.splash.SplashActivity}" drawable="vpn_pro" name="VPN Pro" />
   <item component="ComponentInfo{free.vpn.unblock.proxy.vpn.master.pro/free.vpn.unblock.proxy.vpn.master.pro.activity.GodActivity}" drawable="vpn_proxy_master" name="VPN Proxy Master" />
   <item component="ComponentInfo{free.vpn.unblock.proxy.vpnmaster/com.quickdy.vpn.app.StartUpActivity}" drawable="vpn_proxy_master" name="VPN Proxy Master" />
+  <item component="ComponentInfo{com.free.vpn.super.hotspot.open/com.superunlimited.app.presentation.applauncher.AppLauncherActivity}" drawable="vpn_super_unlimited_proxy" name="VPN Super Unlimited Proxy" />
   <item component="ComponentInfo{com.vpn.lat/com.abc.opvpnfree.WelcomeActivity}" drawable="vpn_lat" name="VPN.lat" />
   <item component="ComponentInfo{com.vpn.lat/com.vpn.lat.MainActivity}" drawable="vpn_lat" name="VPN.lat" />
   <item component="ComponentInfo{com.vpnhood.client.android/crc64641a944156581feb.MainActivity}" drawable="vpnhood" name="VpnHood!" />
@@ -19260,6 +19456,7 @@
   <item component="ComponentInfo{com.vsmart.soundrecorder/com.bq.soundrecorder.activities.MainActivity}" drawable="vsmart_sound_recorder" name="Vsmart Sound Recorder" />
   <item component="ComponentInfo{com.vinsmart.themestore/com.vinsmart.vthemestore.module.main.MainActivity}" drawable="vsmart_themes" name="Vsmart Themes" />
   <item component="ComponentInfo{com.bhxhapp/com.bhxhapp.MainActivity}" drawable="vssid" name="VssID" />
+  <item component="ComponentInfo{com.bhxhapp/com.vnid.MainActivity}" drawable="vssid" name="VssID" />
   <item component="ComponentInfo{com.denchi.vtubestudio/com.unity3d.player.UnityPlayerActivity}" drawable="vtube_studio" name="VTube Studio" />
   <item component="ComponentInfo{com.Frontesque.vuetube/com.Frontesque.vuetube.MainActivity}" drawable="vuetube" name="VueTube" />
   <item component="ComponentInfo{com.Frontesque.youtube/com.Frontesque.vuetube.MainActivity}" drawable="vuetube" name="VueTube" />
@@ -19350,6 +19547,7 @@
   <item component="ComponentInfo{com.walmart.android/com.walmart.glass.integration.splash.SplashActivity}" drawable="walmart" name="Walmart" />
   <item component="ComponentInfo{com.walmart.cam.walmart/com.example.cam_walmart_mobile.MainActivity}" drawable="walmart" name="Walmart" />
   <item component="ComponentInfo{com.stresscodes.wallp/com.stresscodes.wallp.MainActivity}" drawable="walp" name="WalP" />
+  <item component="ComponentInfo{com.stresscodes.wallp/com.stresscodes.wallp.pro.CustomSplashScreen}" drawable="walp" name="WalP" />
   <item component="ComponentInfo{com.stresscodes.wallp.pro/com.stresscodes.wallp.pro.CustomSplashScreen}" drawable="walp_pro" name="WalP Pro" />
   <item component="ComponentInfo{com.feresr.walpy/com.feresr.wallpapers.SplashActivity}" drawable="walpy" name="Walpy" />
   <item component="ComponentInfo{com.feresr.walpy/com.feresr.walpy.ui.MainActivity}" drawable="walpy" name="Walpy" />
@@ -19384,6 +19582,7 @@
   <item component="ComponentInfo{de.markusfisch.android.wavelines/de.markusfisch.android.wavelines.activity.SplashActivity}" drawable="wave_lines_live_wallpaper" name="Wave Lines Live Wallpaper" />
   <item component="ComponentInfo{com.pittvandewitt.wavelet/com.pittvandewitt.wavelet.MainActivity}" drawable="wavelet" name="Wavelet" />
   <item component="ComponentInfo{wavy.walls.droidbeauty.pack/wavy.walls.droidbeauty.pack.MainActivity}" drawable="wavy_wallpapers" name="Wavy Wallpapers" />
+  <item component="ComponentInfo{wavy.walls.droidbeauty.pack/dev.jahir.frames.app.MainActivity}" drawable="wavy_wallpapers" name="Wavy Wallpapers" />
   <item component="ComponentInfo{me.way_in.proffer/me.way_in.proffer.MainActivity}" drawable="way_in" name="Way-in" />
   <item component="ComponentInfo{sun.way2sms.hyd.com/sun.way2sms.hyd.com.way2news.activities.SplashActivity}" drawable="way2news" name="Way2News" />
   <item component="ComponentInfo{com.internetarchive.waybackmachine/com.internetarchive.waybackmachine.activity.MainActivity}" drawable="wayback_machine" name="Wayback Machine" />
@@ -19482,8 +19681,10 @@
   <item component="ComponentInfo{at.westbahn.app/at.westbahn.app.MainActivity}" drawable="westbahn" name="Westbahn" />
   <item component="ComponentInfo{org.westpac.bank/au.com.westpac.banking.universal.android.ui.activity.MainActivity}" drawable="westpac" name="Westpac" />
   <item component="ComponentInfo{nz.co.westpac/nz.co.westpac.one.ui.MasterActivity}" drawable="westpac" name="Westpac" />
+  <item component="ComponentInfo{org.westpac.bank/au.com.westpac.banking.universal.android.ui.activity.MainActivityAliasMidnight}" drawable="westpac" name="Westpac" />
   <item component="ComponentInfo{com.wetalkapp/com.wetalkapp.ui.activity.LaunchActivity}" drawable="generic_dialer" name="WeTalk" />
   <item component="ComponentInfo{de.appsoluts.wetell/de.appsoluts.wetell.ui.main.ActivityMain}" drawable="wetell" name="WEtell" />
+  <item component="ComponentInfo{de.appsoluts.wetell/de.appsoluts.wetell.MainActivity}" drawable="wetell" name="WEtell" />
   <item component="ComponentInfo{com.wetherspoon.orderandpay/com.wetherspoon.orderandpay.MainActivity}" drawable="wetherspoon" name="Wetherspoon" />
   <item component="ComponentInfo{com.wetherspoon.orderandpay/com.wetherspoon.orderandpay.base.StartupActivity}" drawable="wetherspoon" name="Wetherspoon" />
   <item component="ComponentInfo{com.wetherspoon.orderandpay/com.xibis.txdvenues.StartActivity}" drawable="wetherspoon" name="Wetherspoon" />
@@ -19641,6 +19842,7 @@
   <item component="ComponentInfo{com.whatsapp/com.whatsapp.mod.Mulbhut-05}" drawable="whatsapp" name="WhatsApp" />
   <item component="ComponentInfo{com.sathwbg.easymessager/com.sathwbg.easymessager.Icon0}" drawable="whatsapp" name="WhatsApp" />
   <item component="ComponentInfo{com.somessenger.site/com.whatsapp.Main}" drawable="whatsapp" name="WhatsApp" />
+  <item component="ComponentInfo{com.whatsapp/com.whatsapp.AppIcon10}" drawable="whatsapp" name="WhatsApp" />
   <item component="ComponentInfo{com.whatsapp.w4b/com.whatsapp.Main}" drawable="whatsapp_business" name="WhatsApp Business" />
   <item component="ComponentInfo{io.kuenzler.whatsappwebtogo/io.kuenzler.whatsappwebtogo.MainActivity}" drawable="whatsapp_web_to_go" name="WhatsApp Web To Go" />
   <item component="ComponentInfo{io.kuenzler.whatsappwebtogo/io.kuenzler.whatsappwebtogo.WebviewActivity}" drawable="whatsapp_web_to_go" name="WhatsApp Web To Go" />
@@ -19674,6 +19876,7 @@
   <item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.ui.MainActivity}" drawable="wi_fi_info" name="Wi-Fi Info" />
   <item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.SplashActivity}" drawable="wi_fi_info" name="Wi-Fi Info" />
   <item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.MainActivity}" drawable="wi_fi_info" name="Wi-Fi Info" />
+  <item component="ComponentInfo{com.truemlgpro.wifiinfo/com.truemlgpro.wifiinfo.ui.activities.MainActivity}" drawable="wi_fi_info" name="Wi-Fi Info" />
   <item component="ComponentInfo{com.borconi.emil.wifilauncherforhur/com.borconi.emil.wifilauncherforhur.activities.MainActivity}" drawable="wi_fi_launcher" name="Wi-Fi Launcher" />
   <item component="ComponentInfo{ru.andr7e.wifimonitor/ru.andr7e.deviceinfohw.DeviceInfoActivity}" drawable="wifi_analyzer_open_source" name="Wi-Fi Monitor" />
   <item component="ComponentInfo{com.tplink.networktoolsbox/com.tplink.networktoolsbox.ui.init.SplashActivity}" drawable="wi_fi_toolkit" name="Wi-Fi Toolkit" />
@@ -19710,6 +19913,7 @@
   <item component="ComponentInfo{com.wmos.main/com.wmos.guide.Welcome}" drawable="wifi_pingce_dashi" name="WiFi测评大师 ~~ WiFi Pingce Dashi" />
   <item component="ComponentInfo{com.hicorenational.wikipedia/org.wikipedia.DefaultIcon}" drawable="wiki_fronted" name="Wiki Fronted" />
   <item component="ComponentInfo{com.wikiloc.wikilocandroid/com.wikiloc.wikilocandroid.view.activities.MainActivity}" drawable="wikiloc" name="Wikiloc" />
+  <item component="ComponentInfo{com.wikiloc.wikilocandroid/com.wikiloc.wikilocandroid.view.activities.LauncherActivity}" drawable="wikiloc" name="Wikiloc" />
   <item component="ComponentInfo{org.wikipedia/org.wikipedia.MainActivity}" drawable="wikipedia" name="Wikipedia" />
   <item component="ComponentInfo{org.wikipedia/org.wikipedia.main.MainActivity}" drawable="wikipedia" name="Wikipedia" />
   <item component="ComponentInfo{org.wikipedia/org.wikipedia.PageActivity}" drawable="wikipedia" name="Wikipedia" />
@@ -19826,6 +20030,7 @@
   <item component="ComponentInfo{com.mcsnowflake.worktimer/com.mcsnowflake.worktimer.MainActivity}" drawable="worktimer" name="WorkTimer" />
   <item component="ComponentInfo{ru.wz.android/ru.wz.android.home.HomeActivity}" drawable="workzilla" name="Workzilla" />
   <item component="ComponentInfo{de.ericz.worldclockv2/com.example.world_clock_v2.MainActivity}" drawable="generic_earth" name="World Clock v2" />
+  <item component="ComponentInfo{de.ericz.worldclockv2/de.ericz.worldclockv2.MainActivity}" drawable="generic_earth" name="World Clock v2" />
   <item component="ComponentInfo{com.qbis.guessthecountry/dev.axmol.app.AppActivity}" drawable="generic_earth" name="World Map Quiz" />
   <item component="ComponentInfo{com.qbis.guessthecountry/org.cocos2dx.cpp.AppActivity}" drawable="generic_earth" name="World Map Quiz" />
   <item component="ComponentInfo{net.wargaming.wot.blitz/com.dava.engine.DavaActivity}" drawable="world_of_tanks_blitz" name="World of Tanks Blitz" />
@@ -19836,6 +20041,7 @@
   <item component="ComponentInfo{com.sigseg.android.worldmap/com.sigseg.android.map.ImageViewerActivity}" drawable="generic_earth" name="WorldMap" />
   <item component="ComponentInfo{com.funbase.xradio/com.funbase.xradio.activity.SplashActivity}" drawable="wow_fm" name="WOW FM" />
   <item component="ComponentInfo{com.funbase.xradio/com.funbase.xradio.home.activity.MainActivity}" drawable="wow_fm" name="WOW FM" />
+  <item component="ComponentInfo{com.funbase.xradio/com.transsion.fm.main.MainActivity}" drawable="wow_fm" name="WOW FM" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice.documentmanager.ab.proxy.a}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice.documentmanager.ab.proxy.main}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.shell.MainActivity}" drawable="wps_office" name="WPS Office" />
@@ -19955,6 +20161,8 @@
   <item component="ComponentInfo{com.xiaomi.glgm/com.xiaomi.glgm.home.ui.category}" drawable="xiaomi_game_center" name="Xiaomi Game Center" />
   <item component="ComponentInfo{com.xiaomi.glgm/com.xiaomi.glgm.home.ui.SplashActivity}" drawable="xiaomi_game_center" name="Xiaomi Game Center" />
   <item component="ComponentInfo{com.xiaomi.glgm/com.mig.play.Icon1}" drawable="xiaomi_game_center" name="Xiaomi Game Center" />
+  <item component="ComponentInfo{com.xiaomi.glgm/com.mig.play.Icon4}" drawable="xiaomi_game_center" name="Xiaomi Game Center" />
+  <item component="ComponentInfo{com.xiaomi.glgm/com.mig.play.Icon5}" drawable="xiaomi_game_center" name="Xiaomi Game Center" />
   <item component="ComponentInfo{com.xiaomi.superhexa/com.superhexa.supervision.NavHostActivity}" drawable="xiaomi_glasses" name="Xiaomi Glasses" />
   <item component="ComponentInfo{com.tvremote.xiaomitvsmart/com.thomson9atvremote.MainActivity}" drawable="android_tv_remote_service" name="Xiaomi Mi Tv Remote" />
   <item component="ComponentInfo{xiaomi.mi.tv.remote.xiaomismarttvremote/xiaomi.mi.tv.remote.xiaomismarttvremote.control.activities.SplashActivity}" drawable="mi_remote" name="Xiaomi Mi TV Remote" />
@@ -20137,6 +20345,7 @@
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_original_2}" drawable="youtube" name="YouTube Morphe" />
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_light_2}" drawable="morphe" name="YouTube Morphe" />
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_black_5}" drawable="morphe" name="YouTube Morphe" />
+  <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_black_4}" drawable="morphe" name="Youtube Morphe" />
   <item component="ComponentInfo{com.google.android.apps.youtube.music/com.google.android.archive.ReactivateActivity}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.google.android.music/com.google.android.music.tombstone.LauncherActivity}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.google.android.music/com.android.music.activitymanagement.TopLevelActivity}" drawable="generic_player" name="YouTube Music" />
@@ -20154,6 +20363,7 @@
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_original_2}" drawable="generic_player" name="YouTube Music Morphe" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_2}" drawable="morphe" name="YouTube Music Morphe" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_3}" drawable="morphe" name="YouTube Music Morphe" />
+  <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_original_3}" drawable="generic_player" name="YouTube Music Morphe" />
   <item component="ComponentInfo{anddea.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
   <item component="ComponentInfo{app.rvx.android.apps.youtube.music/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="youtube_music_revanced" name="YouTube Music ReVanced" />
@@ -20258,6 +20468,7 @@
   <item component="ComponentInfo{com.dewmobile.kuaiya.play/com.dewmobile.kuaiya.activity.DmStartupActivity}" drawable="zapya" name="Zapya" />
   <item component="ComponentInfo{com.dewmobile.kuaiya.play/com.dewmobile.kuaiya.activity.MainActivity}" drawable="zapya" name="Zapya" />
   <item component="ComponentInfo{com.dewmobile.kuaiya.play/com.dewmobile.kuaiya.act.DmStartupActivity}" drawable="zapya" name="Zapya" />
+  <item component="ComponentInfo{com.dewmobile.kuaiya.play/com.qshare.app.activity.FirstActivity}" drawable="zapya" name="Zapya" />
   <item component="ComponentInfo{com.inditex.zara/com.inditex.zara.MainActivityDefaultIcon}" drawable="zara" name="Zara" />
   <item component="ComponentInfo{com.inditex.zara/com.inditex.zara.MainActivity2}" drawable="zara" name="Zara" />
   <item component="ComponentInfo{com.inditex.zara/com.inditex.zara.MainActivity}" drawable="zara" name="Zara" />
@@ -20393,12 +20604,14 @@
   <item component="ComponentInfo{com.zoho.zohooneuser/com.zoho.zohooneuser.AppLockActivity}" drawable="zoho_one" name="Zoho One" />
   <item component="ComponentInfo{com.zoho.accounts.oneauth/com.zoho.accounts.oneauth.v2.ui.login.WalkthroughActivity}" drawable="zoho_oneauth" name="Zoho OneAuth" />
   <item component="ComponentInfo{com.zoho.accounts.oneauth/com.zoho.accounts.oneauth.v2.ui.applock.AppLockActivity}" drawable="zoho_oneauth" name="Zoho OneAuth" />
+  <item component="ComponentInfo{com.zoho.accounts.oneauth/com.zoho.accounts.oneauth.IconDefault}" drawable="zoho_oneauth" name="Zoho OneAuth" />
   <item component="ComponentInfo{com.zoho.projects/com.zoho.projects.android.activity.ZohoProjectsLogin}" drawable="zoho_projects" name="Zoho Projects" />
   <item component="ComponentInfo{com.zoho.salesiq/com.zoho.salesiq.MainActivity}" drawable="zoho_salesiq" name="Zoho SalesIQ" />
   <item component="ComponentInfo{com.zoho.sheet.android/com.zoho.sheet.android.doclisting.DocListingActivity}" drawable="zoho_sheet" name="Zoho Sheet" />
   <item component="ComponentInfo{com.zoho.zohosocial/com.zoho.zohosocial.login.view.RedirectingActivity}" drawable="zoho_social" name="Zoho Social" />
   <item component="ComponentInfo{com.zoho.survey/com.zoho.survey.activity.ui.SplashActivity}" drawable="zoho_survey" name="Zoho Survey" />
   <item component="ComponentInfo{com.zoho.mail.task/com.zoho.mail.task.ui.activity.OnBoardingActivity}" drawable="zoho_todo" name="Zoho ToDo" />
+  <item component="ComponentInfo{com.zoho.mail.task/com.zoho.mail.task.MainActivity}" drawable="zoho_todo" name="Zoho ToDo" />
   <item component="ComponentInfo{com.zoho.primeum.stable/com.google.android.apps.chrome.Main}" drawable="zoho_ulaa" name="Zoho Ulaa" />
   <item component="ComponentInfo{com.zoho.writer/com.zoho.writer.activity.LauncherActivity}" drawable="zoho_writer" name="Zoho Writer" />
   <item component="ComponentInfo{com.zoiper.android.app/com.zoiper.android.ui.MainActivity}" drawable="zoiper" name="Zoiper" />
@@ -20469,6 +20682,7 @@
   <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.apb2c.ui.ZappkaActivityDefault}" drawable="zappka" name="żappka" />
   <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.app.ui.ZappkaActivityDefault}" drawable="zappka" name="żappka" />
   <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.app.ui.ZappkaActivityWinterSeason}" drawable="zappka" name="żappka" />
+  <item component="ComponentInfo{pl.zabka.apb2c/pl.zabka.app.ui.ZappkaActivityTriki}" drawable="zappka" name="żappka" />
   <item component="ComponentInfo{com.kvt.ziogas/com.ziogas.MainActivity}" drawable="ziogas" name="Žiogas" />
   <item component="ComponentInfo{ru.aviasales/ru.aviasales.ui.activity.MainActivity}" drawable="aviasales" name="Авиасейлс ~~ Aviasales" />
   <item component="ComponentInfo{com.avito.android/com.avito.android.Launcher}" drawable="avito" name="Авито ~~ Avito" />
@@ -20609,6 +20823,7 @@
   <item component="ComponentInfo{ru.letu/ru.letu.ui.base.MainActivity}" drawable="letoile" name="ЛЭТУАЛЬ ~~ L'Etoile" />
   <item component="ComponentInfo{com.sashucity.literali/com.example.literally.MainActivity}" drawable="literaly" name="літералі ~~ literaly" />
   <item component="ComponentInfo{ru.filit.mvideo.b2c/ru.filit.mvideo.b2c.splash.view.SplashScreenActivity}" drawable="m_video" name="М.Видео ~~ M.Video" />
+  <item component="ComponentInfo{ru.filit.mvideo.b2c/com.app.mvideo.base.activities.SplashScreenActivity}" drawable="m_video" name="М.Видео ~~ M.Video" />
   <item component="ComponentInfo{ru.tander.magnit/pyaterochka.app.main.base.presentation.MainActivity}" drawable="magnit" name="Магнит ~~ Magnit" />
   <item component="ComponentInfo{ru.tander.magnit/ru.tander.magnit.presentation.MainActivity}" drawable="magnit" name="Магнит ~~ Magnit" />
   <item component="ComponentInfo{com.kazanexpress.ke_app/ru.kazanexpress.feature.splash.presentation.SplashScreenActivity}" drawable="magnet_market" name="Магнит Маркет ~~ Magnet Market" />
@@ -20633,6 +20848,7 @@
   <item component="ComponentInfo{by.mts.client/ru.stream.mymts.MainActivity}" drawable="my_mts" name="Мой МТС ~~ My MTS" />
   <item component="ComponentInfo{by.mts.client/by.mts.client.MainActivity}" drawable="my_mts" name="Мой МТС ~~ My MTS" />
   <item component="ComponentInfo{kg.o.nurtelecom/kg.o.nurtelecom.ui.splash.SplashScreenActivity}" drawable="my_o_plus_bank" name="Мой О! + Банк ~~ My O! + Bank" />
+  <item component="ComponentInfo{kg.o.nurtelecom/kg.o.nurtelecom.Default}" drawable="my_o_plus_bank" name="Мой О! + Банк ~~ My O! + Bank" />
   <item component="ComponentInfo{ru.mos.app/ru.mos.uivm.AppActivity}" drawable="my_moscow" name="Моя Москва ~~ My Moscow" />
   <item component="ComponentInfo{ru.mts.fogplay/ru.mts.fogplay_tv.phone.PhoneActivity}" drawable="mts" name="МТС Fog Play ~~ MTS Fog Play" />
   <item component="ComponentInfo{ru.mts.mymts/ru.mts.splash.ActivitySplash}" drawable="mts" name="МТС ~~ MTS" />
@@ -20901,6 +21117,7 @@
   <item component="ComponentInfo{jp.hamitv.hamiand1/jp.hamitv.hamiand1.tver.ui.activities.MainActivity}" drawable="tver" name="ティーバー ~~ TVer" />
   <item component="ComponentInfo{jp.go.digital.auth_and_sign/jp.go.digital.auth_and_sign.ui.main.MainActivity}" drawable="digital_authentication" name="デジタル認証 ~~ Digital Authentication" />
   <item component="ComponentInfo{jp.showa_shell_dmp.shellpass/jp.co.dropsystem.shell_android.MainActivity}" drawable="drive_on" name="ドライブオン ~~ Drive On" />
+  <item component="ComponentInfo{jp.showa_shell_dmp.shellpass/com.driveon.MainActivity}" drawable="drive_on" name="ドライブオン ~~ Drive On" />
   <item component="ComponentInfo{numberplace.ohte/com.withprize.numpl.MainActivity}" drawable="generic_sudoku" name="ナンプレde懸賞 ~~ Sudoku de Sweepstakes" />
   <item component="ComponentInfo{jp.co.dwango.nicocas/jp.co.dwango.nicocas.ui.RootActivity}" drawable="niconico" name="ニコニコ ~~ Niconico" />
   <item component="ComponentInfo{jp.nicovideo.android/jp.nicovideo.android.StartupActivity}" drawable="niconico_video" name="ニコニコ動画 ~~ Niconico Video" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
A Dance of Fire and Ice (`com.fizzd.connectedworlds` → `a_dance_of_fire_and_ice.svg`)
Activity Launcher (`de.szalkowski.activitylauncher.oss` → `activity_launcher.svg`)
Activity Launcher (`de.szalkowski.activitylauncher` → `activity_launcher.svg`)
Agencia Tributaria (`es.aeat.dgc.mobile` → `agencia_tributaria.svg`)
AI Dungeon (`com.aidungeon` → `ai_dungeon.svg`)
Aloha Browser (`com.aloha.browser` → `aloha_browser.svg`)
Anixart (`com.swiftsoft.anixartd` → `anixart.svg`)
Aptoide (`cm.aptoide.pt` → `aptoide.svg`)
2 × ArchiveTune (`moe.rukamori.archivetune` → `archivetune.svg`)
ArgoVPN (`com.filtershekanha.argovpn` → `argovpn.svg`)
ASOS (`com.asos.app` → `asos.svg`)
Audio Editor (`audioeditor.musiceditor.soundeditor.songeditor` → `generic_audio_editor.svg`)
Autoškola (`cz.jamesdeer.free.autotest` → `autoskola.svg`)
Banco do Brasil (BB) (`br.com.bb.android` → `banco_do_brasil_bb.svg`)
Beer With Me (`se.dagsappar.beer` → `beer_with_me.svg`)
Bikroy (`com.bikroy` → `bikroy.svg`)
BitTorrent (`com.bittorrent.client` → `bittorrent.svg`)
BlockSite (`co.blocksite` → `blocksite.svg`)
botim (`im.thebot.messenger` → `botim.svg`)
Brain Test 2 (`com.unicostudio.braintest2new` → `brain_test_2.svg`)
Bus is Coming (`br.com.projectnetwork.onibus` → `bus_is_coming.svg`)
by.U (`com.byu.id` → `by_u.svg`)
CAIXA (`br.com.gabba.Caixa` → `caixa.svg`)
ChargePoint (`com.coulombtech` → `chargepoint.svg`)
CIMB OCTO MY (`com.cimb.cimbocto` → `cimb.svg`)
Cineplex (`com.fivemobile.cineplex` → `cineplex.svg`)
2 × Cinépolis Go (`com.cinepolis.go` → `cinepolis.svg`)
2 × Coppel (`com.coppel.coppelapp` → `bancoppel.svg`)
Couchsurfing (`com.couchsurfing.mobile.android` → `couchsurfing.svg`)
CRED (`com.dreamplug.androidapp` → `cred.svg`)
Customuse (`com.customuse.customuse` → `customuse.svg`)
DaiRescue (`com.magneticchen.daijishou` → `daijisho.svg`)
Dayforce (`com.dayforce.mobile` → `dayforce.svg`)
Decolar (`com.gm.decolar` → `decolar.svg`)
Deezer (`deezer.android.app` → `deezer.svg`)
DevBytes (`com.candelalabs.devbytes` → `devbytes.svg`)
DKB (`com.dkbcodefactory.banking` → `dkb.svg`)
Docx Reader (`com.alldocumentreader.office.viewer.filesreader` → `docx_reader.svg`)
Domino's Pizza (`zena.dominos` → `dominos_pizza.svg`)
DRIVE2 (`com.drive2` → `drive2.svg`)
Drops (`org.yoki.android.drops` → `buienalarm.svg`)
dubizzle (`com.olxmena.horizontal` → `dubizzle.svg`)
7 × Duolingo (`com.duolingo` → `duolingo.svg`)
Earn (`us.current.android` → `earn.svg`)
ELSA Speak (`us.nobarriers.elsa` → `elsa_speak.svg`)
Emochi (`com.flow.mobile` → `emochi.svg`)
Entri (`me.entri.entrime` → `entri.svg`)
ExpressVPN (`com.expressvpn.vpn` → `expressvpn.svg`)
Farmacias del Ahorro (`mx.com.fahorro2` → `farmacias_del_ahorro.svg`)
Fineasy (`com.fintech.life` → `fineasy.svg`)
Firefox (`org.mozilla.firefox` → `firefox.svg`)
Flat Equalizer (`com.jazibkhan.equalizer` → `flat_equalizer.svg`)
Flickr (`com.flickr.android` → `flickr.svg`)
2 × Flipkart (`com.flipkart.android` → `flipkart.svg`)
Flitsmeister (`nl.flitsmeister` → `flitsmeister.svg`)
Flow (`io.github.aedev.flow` → `flow.svg`)
FotMob (`com.mobilefootie.wc2010` → `fotmob.svg`)
Free (`fr.free.moncomptefree` → `free.svg`)
Freezer (`nep.timeline.freezer` → `airfrozen.svg`)
GameHub (`com.xiaoji.egggame` → `gamehub.svg`)
George (`ro.bcr.georgego` → `george.svg`)
George (`at.erstebank.george` → `george.svg`)
Geto (`com.android.geto` → `geto.svg`)
Global66 (`com.global66.cards` → `global66.svg`)
Google (`com.google.android.apps.searchlite` → `google.svg`)
Grab (`com.grabtaxi.passenger` → `grab.svg`)
Grab Driver (`com.grabtaxi.driver2` → `grab.svg`)
Grindr (`com.grindrapp.android` → `grindr.svg`)
Groupon (`com.groupon` → `groupon.svg`)
Guide du tri (`fr.ecoemballage.guidedutri` → `guide_du_tri.svg`)
HappyMod (`com.happymod.apk` → `happymod.svg`)
Hola Browser (`com.talpa.hibrowser` → `hola_browser.svg`)
HP PAY (`com.drivetrackplusrefuel` → `hp_pay.svg`)
HSBC (`sg.com.hsbc.hsbcsingapore` → `hsbc.svg`)
Iconify (`com.drdisagree.iconify` → `iconify.svg`)
Image to PDF Converter (`com.readpdf.pdfreader.pdfviewer` → `generic_pdf_file.svg`)
Imou Life (`com.mm.android.smartlifeiot` → `imou_life.svg`)
Infinite Minesweeper (`com.grykuby.minesweeper` → `generic_minesweeper.svg`)
Instagram (`com.instagram.android` → `instagram.svg`)
Joytify (`music.ytstream.youtify` → `joytify.svg`)
Juno Icons (`studio14.application.juno` → `juno_icons.svg`)
Keep Screen On (`eu.davidweis.keepscreenon` → `keep_screen_on.svg`)
Key Driver (`com.kunzisoft.hardware.key` → `key_driver.svg`)
KFC (`com.kfc.nl.mobileapp` → `kfc.svg`)
Killer Sudoku (`com.easybrain.killer.sudoku.free` → `generic_sudoku.svg`)
KOHO (`ca.koho` → `koho.svg`)
Komoot (`de.komoot.android` → `komoot.svg`)
Kotak811 (`com.kotak811mobilebankingapp.instantsavingsupiscanandpayrecharge` → `kotak811.svg`)
2 × Lenskart (`com.lenskart.app` → `lenskart.svg`)
Letterboxd (`com.letterboxd.letterboxd` → `letterboxd.svg`)
LSPosed (`org.lsposed.manager` → `lspatch_lsposed.svg`)
MAE (`com.maybank2u.life` → `mae.svg`)
MahsaNG (`com.MahsaNet.MahsaNG` → `mahsang.svg`)
maxim (`com.taxsee.taxsee` → `maxim.svg`)
McDonald's (`il.co.inmanage.mcdonalds` → `mcdonalds.svg`)
Medal (`tv.medal.recorder` → `medal.svg`)
4 × Mercado Libre (`com.mercadolibre` → `mercado_libre.svg`)
Meshtastic (`com.geeksville.mesh` → `meshtastic.svg`)
Mi Vídeo (`com.miui.videoplayer` → `mi_video.svg`)
Microsoft Copilot (`com.microsoft.copilot` → `microsoft_copilot.svg`)
Minecraft (`com.mojang.minecraftpe` → `minecraft.svg`)
minimalist phone (`com.qqlabs.minimalistlauncher` → `minimalist_phone.svg`)
MioDottore (`it.docplanner` → `doctoralia.svg`)
MJ PDF (`com.gitlab.mudlej.MjPdfReader` → `mj_pdf.svg`)
Movistar (`com.otecel.mimovistar` → `movistar.svg`)
My VNPT (`com.vnp.myvinaphone` → `my_vnpt.svg`)
My Vodafone (`com.VodafoneIreland.MyVodafone` → `my_vodafone.svg`)
My7E (`my.com.sevenelevenmy.app` → `_7_eleven.svg`)
MyCamu (`com.octoze.mycamu_web_lite` → `mycamu.svg`)
Myntra (`com.myntra.android` → `myntra.svg`)
MyTherapy (`eu.smartpatient.mytherapy` → `mytherapy.svg`)
2 × N26 (`de.number26.android` → `n26.svg`)
Nagram X (`nu.gpu.nagram` → `nagram_niello_icon.svg`)
Namida (`com.msob7y.namida` → `namida.svg`)
NBA Live (`com.ea.gp.nbamobile` → `nba_live.svg`)
NG.CASH (`com.neaglebank` → `ng_cash.svg`)
Nova Icons (`cs14.pixelperfect.iconpack.nova` → `nova_icons.svg`)
NS (`nl.ns.android.activity` → `ns.svg`)
Odysee (`com.odysee.floss` → `odysee.svg`)
OmeTV (`omegle.tv` → `ometv.svg`)
Opera (`com.opera.browser` → `opera.svg`)
Opera Beta (`com.opera.browser.beta` → `opera_beta.svg`)
Opera Mini Beta (`com.opera.mini.native.beta` → `opera_mini_beta.svg`)
Orbot (`org.torproject.android` → `orbot.svg`)
PC Simulator (`com.Yiming.PC` → `pc_simulator.svg`)
2 × Pichincha (`com.yellowpepper.pichincha` → `pichincha.svg`)
Pix Material Icons (`com.pashapuma.pix.material.iconpack` → `pix_material_icons.svg`)
Pixel Clock Widgets (`twelve.clock.mibrahim` → `pixel_clock_widgets.svg`)
Plants Vs Zombies 2 (`com.ea.game.pvz2_row` → `plants_vs_zombies_2.svg`)
Proximus+ (`be.belgacom.hello` → `proximus_plus.svg`)
Pure Web Browser (`pure.lite.browser` → `pure_web_browser.svg`)
QR Code Scanner (`qrcodescanner.barcodescanner.qrscanner.qrcodereader` → `generic_qr_reader.svg`)
Radio France (`com.radiofrance.radio.radiofrance.android` → `radio_france.svg`)
Ready (`im.argent.contractwalletclient` → `ready.svg`)
Reddit (`com.reddit.frontpage` → `reddit.svg`)
ReFra (`com.dot.gallery` → `refra.svg`)
Rezona (`ai.rezona.app` → `rezona.svg`)
Right Contacts (`com.goodwy.contacts` → `right_contacts.svg`)
Ringtone Maker (`com.herman.ringtone` → `ringtone_maker.svg`)
Robinhood (`com.robinhood.money` → `robinhood.svg`)
Rostic's (`ru.kfc.kfc_delivery` → `rostics.svg`)
Safe Space (`org.privacymatters.safespace` → `safe_space.svg`)
Samsung Camera (`com.samsung.android.scan3d` → `generic_camera.svg`)
Samsung Shop (`com.samsung.ecomm` → `samsung_shop.svg`)
Scalable Capital (`capital.scalable.droid` → `scalable_capital.svg`)
ScooterHacking Utility (`sh.cfw.utility` → `scooterhacking_utility.svg`)
SeaBank (`id.co.bankbkemobile.digitalbank` → `seabank.svg`)
Ski Tracks (`com.corecoders.skitracks` → `ski_tracks.svg`)
Slack (`com.Slack` → `slack.svg`)
SNCB/NMBS (`be.sncbnmbs.b2cmobapp` → `sncb_nmbs.svg`)
SoundCloud (`com.soundcloud.android` → `soundcloud.svg`)
SRAM AXS (`com.sram.armyknife` → `sram_axs.svg`)
STADTRADELN (`org.klimabuendnis.Stadtradeln` → `stadtradeln.svg`)
Stickman Hook (`com.mindy.grap1` → `stickman_hook.svg`)
Stripe (`com.stripe.android.dashboard` → `stripe.svg`)
talabat (`com.talabat` → `talabat.svg`)
Tata Play Binge (`com.tatasky.binge` → `tata_play_binge.svg`)
TELUS Health MyCare (`com.babylon.telushealth` → `telus_health_mycare.svg`)
TextNow (`com.enflick.android.TextNow` → `textnow.svg`)
TheoTown (`info.flowersoft.theotown.theotown` → `theotown.svg`)
TikTok Shop (`com.tiktokshop.seller` → `tiktok_shop.svg`)
Toca Boca World (`com.tocaboca.tocalifeworld` → `toca_boca_world.svg`)
Transfermóvil (`cu.etecsa.cubacel.tr.tm` → `transfermovil.svg`)
Trenitalia (`com.lynxspa.prontotreno` → `trenitalia.svg`)
Trust Wallet (`com.wallet.crypto.trustapp` → `trust_wallet.svg`)
Tuenti (`ec.otecel.tuenti` → `tuenti.svg`)
TunnelBear (`com.tunnelbear.android` → `tunnelbear.svg`)
Ubuy (`com.ubuy` → `ubuy.svg`)
UNIQLO (`com.uniqlo.my.catalogue` → `uniqlo.svg`)
UNIQLO (`com.uniqlo.vn.catalogue` → `uniqlo.svg`)
URV Manager (`app.universal.revanced.manager` → `urv_manager.svg`)
UU Game Booster (`com.netease.uu` → `uu_game_booster.svg`)
Very Mobile (`it.very.mobile` → `very_mobile.svg`)
Video Downloader (`com.instadownloader.instasave.igsave.ins` → `all_video_downloader.svg`)
VietinBank iPay (`com.vietinbank.ipay` → `vietinbank_ipay.svg`)
Viseca One (`ch.viseca.visecaone` → `viseca_one.svg`)
Viu (`com.vuclip.viu` → `viu.svg`)
Vivaldi (`com.vivaldi.browser` → `vivaldi.svg`)
VIVI Music (`com.vivi.vivimusic` → `vivi_music.svg`)
VPN Super Unlimited Proxy (`com.free.vpn.super.hotspot.open` → `vpn_super_unlimited_proxy.svg`)
VssID (`com.bhxhapp` → `vssid.svg`)
WalP (`com.stresscodes.wallp` → `walp.svg`)
Wavy Wallpapers (`wavy.walls.droidbeauty.pack` → `wavy_wallpapers.svg`)
Westpac (`org.westpac.bank` → `westpac.svg`)
WEtell (`de.appsoluts.wetell` → `wetell.svg`)
WhatsApp (`com.whatsapp` → `whatsapp.svg`)
Wi-Fi Info (`com.truemlgpro.wifiinfo` → `wi_fi_info.svg`)
Wikiloc (`com.wikiloc.wikilocandroid` → `wikiloc.svg`)
World Clock v2 (`de.ericz.worldclockv2` → `generic_earth.svg`)
WOW FM (`com.funbase.xradio` → `wow_fm.svg`)
2 × Xiaomi Game Center (`com.xiaomi.glgm` → `xiaomi_game_center.svg`)
Youtube Morphe (`app.morphe.android.youtube` → `morphe.svg`)
YouTube Music Morphe (`app.morphe.android.apps.youtube.music` → `generic_player.svg`)
żappka (`pl.zabka.apb2c` → `zappka.svg`)
Zapya (`com.dewmobile.kuaiya.play` → `zapya.svg`)
Zoho OneAuth (`com.zoho.accounts.oneauth` → `zoho_oneauth.svg`)
Zoho ToDo (`com.zoho.mail.task` → `zoho_todo.svg`)
М.Видео ~~ M.Video (`ru.filit.mvideo.b2c` → `m_video.svg`)
Мой О! + Банк ~~ My O! + Bank (`kg.o.nurtelecom` → `my_o_plus_bank.svg`)
ドライブオン ~~ Drive On (`jp.showa_shell_dmp.shellpass` → `drive_on.svg`)