### PR TITLE
+3 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4354,6 +4354,8 @@
   <item component="ComponentInfo{dk.digst.DigitalPost/com.digitaliseringsstyrelsen.digitalPostApp.MainActivity}" drawable="sony_email" name="Digital Post" />
   <item component="ComponentInfo{com.google.android.apps.wellbeing/com.google.android.apps.wellbeing.settings.MultiPaneLauncherActivity}" drawable="digital_wellbeing" name="Digital Wellbeing" />
   <item component="ComponentInfo{com.google.android.apps.wellbeing/com.google.android.apps.wellbeing.settings.LauncherActivity}" drawable="digital_wellbeing" name="Digital Wellbeing" />
+  <item component="ComponentInfo{com.actionlauncher.pixelshortcuts/pixelshortcuts.loaders.WellbeingLoader}" drawable="digital_wellbeing" name="Digital Wellbeing" />
+  <item component="ComponentInfo{com.actionlauncher.pixelshortcuts/pixelshortcuts.loaders.WellbeingDashboardLoader}" drawable="digital_wellbeing" name="Digital Wellbeing" />
   <item component="ComponentInfo{id.go.kominfo.digitalent/id.go.kominfo.digitalent.MainActivity}" drawable="digitalent" name="Digitalent" />
   <item component="ComponentInfo{at.gv.oe.app/at.gv.oe.app.MainActivity}" drawable="digitales_amt" name="Digitales Amt" />
   <item component="ComponentInfo{hu.gov.dap.app/hu.gov.dap.MainActivity}" drawable="digitalis_allampolgar" name="Digitális Állampolgár" />
@@ -16379,6 +16381,7 @@
   <item component="ComponentInfo{com.netease.sky/com.tgc.sky.netease.GameActivity_Netease}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.netease.sky/com.tgc.sky.TGCBootActivity}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.netease.sky/com.netease.ntunisdk.external.protocol.ProtocolLauncher}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
+  <item component="ComponentInfo{com.netease.sky.bilibili/com.netease.ntunisdk.external.protocol.ProtocolLauncher}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.netease.sky.vivo/com.netease.ntunisdk.external.protocol.ProtocolLauncher}" drawable="sky_children_of_the_light" name="Sky: Children of the Light" />
   <item component="ComponentInfo{com.flightradar24.skycards/com.flightradar24.skycards.MainActivity}" drawable="skycards" name="SkyCards" />
   <item component="ComponentInfo{com.skycash.beta/com.norbsoft.android.ease.activities.SplashScreenActivity}" drawable="skycash" name="SkyCash" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

## Icons
The Pixel Shortcuts app provides shortcuts to various Pixel (and non-Pixel) apps which otherwise might not have an icon.
Here I link 2 Digital Wellbeing shortcuts to the appropriate icon.
The Sky:CotL link is to the Bilibili variant of the app.

### Linked
2 × Digital Wellbeing (`com.actionlauncher.pixelshortcuts` → `digital_wellbeing.svg`)
Sky: Children of the Light (`com.netease.sky.bilibili` → `sky_children_of_the_light.svg`)

<!-- bot: icons -->
## Icons

### Linked
2 × Digital Wellbeing (`com.actionlauncher.pixelshortcuts` → `digital_wellbeing.svg`)
Sky: Children of the Light (`com.netease.sky.bilibili` → `sky_children_of_the_light.svg`)