### PR TITLE
+72 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -164,6 +164,7 @@
   <item component="ComponentInfo{com.cheburnet.mobile/com.cheburnet.MainActivity}" drawable="_4eburnet_vpn" name="4ebur.net VPN" />
   <item component="ComponentInfo{com.cheburnet.mobile/com.cheburnet.mobile.MainActivity}" drawable="_4eburnet_vpn" name="4ebur.net VPN" />
   <item component="ComponentInfo{com.four4glte.only.networkmode/com.androidevs.lteonlyapp.ui.fragments.activities.NewMainActivity}" drawable="forcelte" name="4G LTE" />
+  <item component="ComponentInfo{com.fourg.lteModeOnly.speedTest.dataUsage.network/com.fourg.lteModeOnly.speedTest.dataUsage.network.activities.SplashActivity}" drawable="forcelte" name="4G LTE" />
   <item component="ComponentInfo{com.alpha.lte4g/com.alpha.lte4g.ui.main.MainActivity}" drawable="forcelte" name="4G LTE Only Mode" />
   <item component="ComponentInfo{com.alpha.lte4g/com.alpha.lte4g.ui.MainActivity}" drawable="forcelte" name="4G LTE Only Mode" />
   <item component="ComponentInfo{com.kliksob.forgswitch2/com.kliksob.forgswitch2.SplashActivity}" drawable="forcelte" name="4G LTE Switcher" />
@@ -561,6 +562,7 @@
   <item component="ComponentInfo{com.alightcreative.motion/com.alightcreative.app.motion.activities.ProjectListActivity}" drawable="alight_motion" name="Alight Motion" />
   <item component="ComponentInfo{com.alightcreative.motion/com.alightcreative.app.motion.activities.main.MainActivity}" drawable="alight_motion" name="Alight Motion" />
   <item component="ComponentInfo{com.alightcreative.motioo/com.alightcreative.app.motion.activities.main.MainActivity}" drawable="alight_motion" name="Alight Motion" />
+  <item component="ComponentInfo{dev.goodwy.phone/dev.goodwy.phone.activities.SplashActivity.Original}" drawable="generic_dialer" name="Alight Phone" />
   <item component="ComponentInfo{com.alinma.pay.consumer/com.alinma.pay.consumer.MainActivity}" drawable="alinmapay" name="AlinmaPay" />
   <item component="ComponentInfo{pl.aliorbank.aib/pl.alior.aib.main.splash.SplashActivity}" drawable="alior" name="Alior" />
   <item component="ComponentInfo{pl.aliorbank.aib/pl.alior.aib.legacy.main.splash.SplashActivity}" drawable="alior" name="Alior" />
@@ -612,6 +614,7 @@
   <item component="ComponentInfo{allinonepdftool.pdftoolprop/allinonepdftool.pdftoolprop.activity.SplashActivity}" drawable="all_in_one_pdf" name="All in one PDF" />
   <item component="ComponentInfo{com.pdfmerge.imagetopdf.pdfmaker/com.pdfmerge.imagetopdf.pdfmaker.screen.home.SplashScreen}" drawable="generic_pdf_square" name="All PDF Maker" />
   <item component="ComponentInfo{com.pdf.editor.viewer.pdfreader.pdfviewer/com.pdf.editor.viewer.pdfreader.pdfviewer.ui.splash.SplashActivity}" drawable="generic_pdf_file" name="All PDF Reader" />
+  <item component="ComponentInfo{pdfreader.pdfviewer.free.officetool/pdfreader.pdfviewer.free.officetool.ui.R3WelcomeActivity}" drawable="generic_pdf_file" name="All PDF Reader" />
   <item component="ComponentInfo{com.download.free.videodownloader/videodownloader.free.downloader.com.downloaderone.activity.LoadingActivity}" drawable="all_video_downloader" name="All Video Downloader" />
   <item component="ComponentInfo{com.videodownloader.instagram.video.downloader/com.universal.LauncherActivity}" drawable="all_video_downloader" name="All Video Downloader" />
   <item component="ComponentInfo{all.video.downloader.allvideodownloader/video.downloader.videodownloader.activity.MainActivity}" drawable="v_downloader" name="All Video Downloader" />
@@ -640,6 +643,7 @@
   <item component="ComponentInfo{com.allstate.view/com.allstate.accountmanagementlibrary.SplashActivity}" drawable="allstate" name="Allstate" />
   <item component="ComponentInfo{ca.allstate.blueocean/ca.allstate.blueocean.launcher.LauncherActivity}" drawable="allstate" name="Allstate" />
   <item component="ComponentInfo{com.alltrails.alltrails/com.alltrails.alltrails.StartActivity}" drawable="alltrails" name="AllTrails" />
+  <item component="ComponentInfo{com.hoodles.alltrails/com.alltrails.alltrails.StartActivity}" drawable="alltrails" name="AllTrails" />
   <item component="ComponentInfo{com.ally.MobileBanking/com.ally.MobileBanking.SplashScreen}" drawable="ally" name="Ally" />
   <item component="ComponentInfo{com.ally.MobileBanking/com.ally.MobileBanking.splash.SplashScreenActivity}" drawable="ally" name="Ally" />
   <item component="ComponentInfo{com.almanea.android/com.almanea.android.MainActivity}" drawable="almanea" name="Almanea" />
@@ -700,6 +704,7 @@
   <item component="ComponentInfo{com.amazon.mp3/com.amazon.mp3.library.activity.LaunchActivity}" drawable="headphones" name="Amazon Music" />
   <item component="ComponentInfo{com.amazon.mp3/leakcanary.internal.activity.LeakLauncherActivity}" drawable="headphones" name="Amazon Music" />
   <item component="ComponentInfo{com.amazon.clouddrive.photos/com.amazon.photos.activity.LauncherActivity}" drawable="amazon_photos" name="Amazon Photos" />
+  <item component="ComponentInfo{com.amazon.photos/com.amazon.photos.MainActivity}" drawable="amazon_photos" name="Amazon Photos" />
   <item component="ComponentInfo{com.amazon.avod.thirdpartyclient/com.amazon.avod.thirdpartyclient.LauncherActivity}" drawable="amazon_prime_video" name="Amazon Prime Video" />
   <item component="ComponentInfo{com.amazon.sellermobile.android/com.amazon.mShop.home.MainActivity}" drawable="amazon_seller" name="Amazon Seller" />
   <item component="ComponentInfo{in.amazon.mShop.android.shopping/com.amazon.mShop.amazonpay.AmazonPayHomeActivityAliasWoShortcuts}" drawable="amazon_shopping" name="Amazon Shopping" />
@@ -1189,6 +1194,7 @@
   <item component="ComponentInfo{com.ithersta.assistantforsv.android/com.ithersta.assistantforsv.android.MainActivity}" drawable="assistant_for_stardew_valley" name="Assistant for Stardew Valley" />
   <item component="ComponentInfo{com.appsgenz.assistivetouch.phone.ios/com.appsgenz.assistivetouch.phone.ios.views.SplashActivity}" drawable="assistive_touch" name="Assistive Touch" />
   <item component="ComponentInfo{com.easytouch.assistivetouch/com.easytouch.activity.FirstActivity}" drawable="assistive_touch" name="Assistive Touch" />
+  <item component="ComponentInfo{touch.assistivetouch.easytouch/touch.assistivetouch.easytouch.splash.SplashActivity}" drawable="assistive_touch" name="Assistive Touch" />
   <item component="ComponentInfo{com.infinityvector.assolutoracing/com.google.firebase.MessagingUnityPlayerActivity}" drawable="assoluto_racing" name="Assoluto Racing" />
   <item component="ComponentInfo{com.infinityvector.assolutoracing/com.unity3d.player.UnityPlayerActivity}" drawable="assoluto_racing" name="Assoluto Racing" />
   <item component="ComponentInfo{com.nevidimka655.astracrypt/com.nevidimka655.astracrypt.MainActivity}" drawable="astracrypt" name="AstraCrypt" />
@@ -1268,6 +1274,7 @@
   <item component="ComponentInfo{com.audials.paid/com.audials.main.SplashScreenActivity}" drawable="generic_fm_radio_pro" name="Audials Play Pro" />
   <item component="ComponentInfo{com.audible.application/com.audible.application.MainLauncher}" drawable="audible" name="Audible" />
   <item component="ComponentInfo{com.audible.application/com.audible.application.SplashScreen}" drawable="audible" name="Audible" />
+  <item component="ComponentInfo{com.audible.application.kindle/com.audible.application.MainLauncher}" drawable="audible" name="Audible" />
   <item component="ComponentInfo{com.musicplayer.playermusic/com.musicplayer.playermusic.activities.AudifyStartActivity}" drawable="just_player" name="Audify Player" />
   <item component="ComponentInfo{com.mrsep.musicrecognizer/com.mrsep.musicrecognizer.presentation.MainActivity}" drawable="audile" name="Audile" />
   <item component="ComponentInfo{com.bdroid.audiomediaconverter/com.bdroid.audiomediaconverter.activity.LauncherActivity}" drawable="audio_converter" name="Audio Converter" />
@@ -2223,6 +2230,7 @@
   <item component="ComponentInfo{com.dish.vvm/com.coremobility.app.vnotes.CM_VnoteInbox}" drawable="boost_visual_voicemail" name="Boost Visual Voicemail" />
   <item component="ComponentInfo{com.boostedproductivity.app/com.boostedproductivity.app.activities.LauncherActivity}" drawable="boosted" name="Boosted" />
   <item component="ComponentInfo{to.boosty.mobile/to.boosty.android.ui.root.MainActivity}" drawable="boosty" name="Boosty" />
+  <item component="ComponentInfo{to.boosty.android/to.boosty.android.ui.root.MainActivity}" drawable="boosty" name="Boosty" />
   <item component="ComponentInfo{com.elektropepi.bootboi/com.elektropepi.bootboi.MainActivity}" drawable="bootboi" name="BootBoi" />
   <item component="ComponentInfo{cz.jboudny.borderlight/cz.jboudny.borderlight.MainActivity}" drawable="borderlight" name="Borderlight" />
   <item component="ComponentInfo{com.unvoid.borealis/com.unvoid.borealis.activities.MainActivity}" drawable="borealis_icons" name="Borealis Icons" />
@@ -2972,6 +2980,7 @@
   <item component="ComponentInfo{com.evenwell.camera2/com.android.camera.CameraLauncher}" drawable="generic_camera" name="Camera" />
   <item component="ComponentInfo{com.android.MGC_3_2_045/com.android.camera.CameraLauncher}" drawable="generic_camera" name="Camera" />
   <item component="ComponentInfo{com.simplemobiletools.alabama.camera.manager.sam5/com.simplemobiletools.camera.activities.SplashActivity.Orange}" drawable="generic_camera" name="Camera" />
+  <item component="ComponentInfo{com.google.android.GoogleCamerb3/com.android.camera.CameraLauncher}" drawable="generic_camera" name="Camera" />
   <item component="ComponentInfo{de.kromke.andreas.cameradatefolders/de.kromke.andreas.cameradatefolders.MainActivity}" drawable="camera_date_folders" name="Camera Date Folders" />
   <item component="ComponentInfo{com.flavionet.android.camera.pro/com.flavionet.android.camera.MainActivity}" drawable="camera_fv_5" name="Camera FV-5" />
   <item component="ComponentInfo{com.flavionet.android.camera.lite/com.flavionet.android.camera.MainActivity}" drawable="camera_fv_5_lite" name="Camera FV-5 Lite" />
@@ -3006,6 +3015,7 @@
   <item component="ComponentInfo{com.canarabank.mobility/com.canarabank.mobility.MainActivity}" drawable="canara_ai1" name="Canara Ai1" />
   <item component="ComponentInfo{com.elasticrock.candle/com.elasticrock.candle.MainActivity}" drawable="candle" name="Candle" />
   <item component="ComponentInfo{com.king.candycrushsaga/com.king.candycrushsaga.CandyCrushSagaActivity}" drawable="candy_crush_saga" name="Candy Crush Saga" />
+  <item component="ComponentInfo{com.king.candycrushsaga.flexion/com.king.candycrushsaga.FlexionActivity}" drawable="candy_crush_saga" name="Candy Crush Saga" />
   <item component="ComponentInfo{it.candy.simplyfi/it.candyhoover.core.activities.PreSplash}" drawable="candy_simply_fi" name="Candy simply-Fi" />
   <item component="ComponentInfo{com.joeware.android.gpulumera/com.joeware.android.gpulumera.activity.activitycameralaunch}" drawable="candycamera" name="CandyCamera" />
   <item component="ComponentInfo{com.joeware.android.gpulumera/com.joeware.android.gpulumera.activity.ActivityCamera}" drawable="candycamera" name="CandyCamera" />
@@ -3096,6 +3106,7 @@
   <item component="ComponentInfo{com.grailr.carrotweather/com.grailr.carrotweather.view.MainActivity}" drawable="carrot" name="CARROT" />
   <item component="ComponentInfo{com.grailr.carrotweather/com.grailr.carrotweather.navigation.ComposeMainActivity}" drawable="carrot" name="CARROT" />
   <item component="ComponentInfo{au.com.carsales/au.com.carsales.globalapp.SplashActivity}" drawable="carsales" name="carsales" />
+  <item component="ComponentInfo{maps.jaoloonda.android.aaad_a39e4f/com.thekirankumar.youtubeauto2.activity.MainPhoneActivity}" drawable="youtube" name="CarStream" />
   <item component="ComponentInfo{fr.sesamvitale.cartevitale.app/fr.sesamvitale.cartevitale.app.MainActivity}" drawable="carte_vitale" name="Carte Vitale" />
   <item component="ComponentInfo{br.gov.dataprev.carteiradigital/br.gov.dataprev.carteiradigital.MainActivity}" drawable="carteira_de_trabalho_digital" name="Carteira de Trabalho Digital" />
   <item component="ComponentInfo{br.gov.serpro.cnhe/br.gov.serpro.cnhe.MainActivity}" drawable="carteira_digital_de_transito" name="Carteira Digital de Transito" />
@@ -4190,6 +4201,7 @@
   <item component="ComponentInfo{website.leifs.delta/website.leifs.delta.activities.SplashActivity}" drawable="delta_icons" name="Delta Icons" />
   <item component="ComponentInfo{website.leifs.delta/website.leifs.delta.activities.StartActivity}" drawable="delta_icons" name="Delta Icons" />
   <item component="ComponentInfo{org.hndteam.deltarune/org.hndteam.deltarune.RunnerActivity}" drawable="deltarune" name="Deltarune" />
+  <item component="ComponentInfo{com.hadrian.deltarune/com.hadrian.deltarune.RunnerActivity}" drawable="deltarune" name="DELTARUNE" />
   <item component="ComponentInfo{com.denizbank.mobildeniz/com.denizbank.mobildeniz.mainactivity.MainActivity}" drawable="denizbank" name="DenizBank" />
   <item component="ComponentInfo{sk.dennikn.dennikn/com.dennikn.android.dennikn.MainActivity}" drawable="dennik_n" name="Denník N" />
   <item component="ComponentInfo{com.dmholdings.DenonAVRRemote/com.dmholdings.remoteapp.Startup}" drawable="denon_avr_remote" name="Denon AVR Remote" />
@@ -4582,6 +4594,7 @@
   <item component="ComponentInfo{cl.dominospizza.dominoschile/cl.dominospizza.dominoschile.SplashScreenActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{com.molo.dominos/com.dominos.loadingscreen.InitialLaunchActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{zena.dominos/com.dominos.loadingscreen.InitialLaunchActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
+  <item component="ComponentInfo{com.daufood.ppt/com.iproject.dominos.ui.splash.SplashActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{com.LoopGames.Domino/com.unity3d.player.UnityPlayerActivity}" drawable="dominoes" name="Dominoes" />
   <item component="ComponentInfo{com.LoopGames.Domino/com.google.firebase.MessagingUnityPlayerActivity}" drawable="dominoes" name="Dominoes" />
   <item component="ComponentInfo{pl.dominium/pl.dominium.feature.main.MainActivity}" drawable="dominos_pizza" name="Domino’s Pizza" />
@@ -5036,6 +5049,7 @@
   <item component="ComponentInfo{com.ss.edgegestures/com.ss.edgegestures.SettingsActivity}" drawable="edge_gestures" name="Edge Gestures" />
   <item component="ComponentInfo{com.edgeround.lightingcolors.rgb/com.edgeround.lightingcolors.rgb.ui.flash.FlashEdgeActivity}" drawable="edge_lighting" name="Edge Lighting" />
   <item component="ComponentInfo{com.edgeround.lightingcolors.rgb/com.edgeround.lightingcolors.rgb.ui.main.MainNewActivity}" drawable="edge_lighting" name="Edge Lighting" />
+  <item component="ComponentInfo{com.cutestudio.edge.lighting.colors/com.cutestudio.edgelightingalert.notificationalert.activities.SplashActivity}" drawable="edge_lighting" name="Edge Lighting" />
   <item component="ComponentInfo{kim.uno.s8/kim.uno.s8.activity.PermissionsActivity}" drawable="edge_mask" name="EDGE MASK" />
   <item component="ComponentInfo{com.imagineer.edgevolume.free/com.imagineer.edgevolume.ConfigureActivity}" drawable="volume_control" name="Edge Volume" />
   <item component="ComponentInfo{edge.moran.tgc.pack/edge.moran.tgc.pack.MainActivity}" drawable="edgeui" name="EdgeUI" />
@@ -5075,6 +5089,7 @@
   <item component="ComponentInfo{nl.rodekruis.android/nl.rodekruis.android.MainActivity}" drawable="generic_aid" name="EHBO - Rode Kruis" />
   <item component="ComponentInfo{moe.tarsin.ehviewer/com.hippo.ehviewer.ui.MainActivity}" drawable="ehviewer" name="EhViewer" />
   <item component="ComponentInfo{moe.tarsin.ehviewer.m/com.hippo.ehviewer.ui.MainActivity}" drawable="ehviewer" name="EhViewer" />
+  <item component="ComponentInfo{moe.tarsin.ehviewer.cc/com.hippo.ehviewer.ui.MainActivity}" drawable="ehviewer" name="EhViewer" />
   <item component="ComponentInfo{ca.bluink.eid_me_and/ca.bluink.eid_me_and.MainActivity}" drawable="eid_me" name="eID-Me" />
   <item component="ComponentInfo{io.github.hathibelagal.eidetic/io.github.hathibelagal.eidetic.MainActivity}" drawable="eidetic" name="Eidetic" />
   <item component="ComponentInfo{com.isoton.Eight/com.isoton.Eight.MainActivity}" drawable="eight" name="eight" />
@@ -5186,6 +5201,7 @@
   <item component="ComponentInfo{io.ente.auth.independent/io.ente.auth.independent.IconDark}" drawable="ente_auth" name="Ente Auth" />
   <item component="ComponentInfo{io.ente.ensu/io.ente.ensu.MainActivity}" drawable="ente_ensu" name="Ente Ensu" />
   <item component="ComponentInfo{io.ente.locker/io.ente.locker.MainActivity}" drawable="ente_locker" name="Ente Locker" />
+  <item component="ComponentInfo{io.ente.locker.fdroid/io.ente.locker.MainActivity}" drawable="ente_locker" name="Ente Locker" />
   <item component="ComponentInfo{io.ente.photos.independent/io.ente.photos.MainActivity}" drawable="ente_photos" name="Ente Photos" />
   <item component="ComponentInfo{io.ente.photos.fdroid/io.ente.photos.MainActivity}" drawable="ente_photos" name="Ente Photos" />
   <item component="ComponentInfo{io.ente.photos/io.ente.photos.MainActivity}" drawable="ente_photos" name="Ente Photos" />
@@ -5967,6 +5983,7 @@
   <item component="ComponentInfo{com.quicinc.fmradio/com.quicinc.fmradio.FMRadio}" drawable="generic_fm_radio" name="FM Radio" />
   <item component="ComponentInfo{com.ape.fmradio/com.ape.fmradio.FmMainActivity}" drawable="generic_fm_radio" name="FM Radio" />
   <item component="ComponentInfo{com.liveradio.fmradio.radiotuner.radiostation.amradio/com.liveradio.fmradio.radiotuner.radiostation.amradio.ui.activities.SplashActivity}" drawable="generic_fm_radio" name="FM Radio" />
+  <item component="ComponentInfo{com.eurekateam.fmradio/com.eurekateam.fmradio.MainActivity}" drawable="generic_fm_radio" name="FM Radio" />
   <item component="ComponentInfo{ba.gov.fmt.eopc/ba.gov.fmt.eopc.MainActivity}" drawable="fmt_fbih_oil_info" name="FMT FBiH Oil Info" />
   <item component="ComponentInfo{za.co.fnb.connect.itt/za.co.fnb.connect.itt.gui.ZoneWelcomeActivity}" drawable="fnb" name="FNB" />
   <item component="ComponentInfo{com.ebase.banking/com.ebase.app.banking.ebase_banking_app.MainActivity}" drawable="fnz_bank" name="FNZ Bank" />
@@ -6488,6 +6505,8 @@
   <item component="ComponentInfo{net.slions.fulguris.full.fdroid/fulguris.activity.SplashActivity}" drawable="fulguris" name="Fulguris" />
   <item component="ComponentInfo{net.slions.fulguris.full.fdroid/acr.browser.lightning.SplashActivity}" drawable="fulguris" name="Fulguris" />
   <item component="ComponentInfo{net.slions.fulguris.full.fdroid/fulguris.activity.IncognitoActivity}" drawable="fulguris" name="Fulguris" />
+  <item component="ComponentInfo{net.slions.fulguris.full.playstore/fulguris.activity.SplashActivity}" drawable="fulguris" name="Fulguris" />
+  <item component="ComponentInfo{net.slions.fulguris.full.playstore/fulguris.activity.IncognitoActivity}" drawable="fulguris" name="Fulguris" />
   <item component="ComponentInfo{apps.syrupy.fullbatterychargealarm/apps.syrupy.fullbatterychargealarm.MainActivity}" drawable="battery_calibration" name="Full Battery Charge Alarm" />
   <item component="ComponentInfo{com.agooday.fullscreengestures/com.agooday.fullscreengestures.MainActivity}" drawable="full_screen_gestures" name="Full Screen Gestures" />
   <item component="ComponentInfo{in.fulldive.shell/com.fulldive.ui.OnboardingActivity}" drawable="fulldive_vr" name="Fulldive VR" />
@@ -6643,6 +6662,7 @@
   <item component="ComponentInfo{com.google.android.inputmethod.latin/com.google.android.apps.inputmethod.libs.framework.core.LauncherActivity}" drawable="gboard" name="Gboard" />
   <item component="ComponentInfo{com.google.android.inputmethod.latin/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="Gboard" />
   <item component="ComponentInfo{com.google.android.inputmethod.latin.adobo/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="Gboard" />
+  <item component="ComponentInfo{dev.jason.com.google.android.inputmethod.latin/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="Gboard" />
   <item component="ComponentInfo{com.google.android.inputmethod.morphe/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="Gboard Morphe" />
   <item component="ComponentInfo{com.google.android.inputmethod.latis/com.google.android.libraries.inputmethod.launcher.LauncherActivity}" drawable="gboard" name="GboardMd" />
   <item component="ComponentInfo{com.gbox.android/com.gbox.android.SplashActivity}" drawable="gbox" name="GBox" />
@@ -6862,6 +6882,7 @@
   <item component="ComponentInfo{com.ilixa.glitch/com.ilixa.glitch.GlitchActivity}" drawable="glitch_lab" name="Glitch Lab" />
   <item component="ComponentInfo{org.linaro.glmark2/org.linaro.glmark2.MainActivity}" drawable="glmark2" name="glmark2" />
   <item component="ComponentInfo{com.moto.glo/com.moto.glo.MainActivity}" drawable="glo" name="GLO" />
+  <item component="ComponentInfo{com.lknninex.glo/com.lknninex.glo.MainActivity}" drawable="glo" name="GLO" />
   <item component="ComponentInfo{com.global.player/com.thisisglobal.guacamole.main.views.SplashActivity}" drawable="global_player" name="Global Player" />
   <item component="ComponentInfo{com.heytap.quicksearchbox/com.heytap.quicksearchbox.ui.activity.SearchHomeActivity}" drawable="global_search" name="Global Search" />
   <item component="ComponentInfo{com.global66.cards/com.tns.NativeScriptActivity}" drawable="global66" name="Global66" />
@@ -7381,6 +7402,9 @@
   <item component="ComponentInfo{com.netflix.NGP.GTAViceCityDefinitiveEdition/com.android.support.MainActivity}" drawable="grand_theft_auto_vice_city" name="Grand Theft Auto: Vice City" />
   <item component="ComponentInfo{com.dvloper.granny/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny" />
   <item component="ComponentInfo{com.dvloper.granny/com.dvloper.granny.UnityPlayerActivity}" drawable="granny" name="Granny" />
+  <item component="ComponentInfo{com.OmegaMegaGigalIntel.GrannyLegacy/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny: Legacy" />
+  <item component="ComponentInfo{com.OmegaMegaGigaIntel.Granny/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny: Legacy" />
+  <item component="ComponentInfo{com.OmegaMegaGigaIntel.Grannymenu/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny: Legacy" />
   <item component="ComponentInfo{com.eanema.graph89/com.graph89.emulationcore.EmulatorActivity}" drawable="graph_89" name="Graph 89" />
   <item component="ComponentInfo{ir.ilmili.telegraph/org.telegram.messenger.GraphIconBlack}" drawable="graph_messenger" name="Graph Messenger" />
   <item component="ComponentInfo{ir.ilmili.telegraph/org.telegram.messenger.TelegramIcon}" drawable="graph_messenger" name="Graph Messenger" />
@@ -7515,6 +7539,7 @@
   <item component="ComponentInfo{com.hm.goe/com.hm.goe.MainDefaultAlias}" drawable="h_and_m" name="H&amp;M" />
   <item component="ComponentInfo{com.blingame.haaktestb/com.blingame.haakg.MainActivity}" drawable="haak" name="Haak" />
   <item component="ComponentInfo{com.ofalvai.habittracker/com.ofalvai.habittracker.ui.MainActivity}" drawable="habit_builder" name="Habit Builder" />
+  <item component="ComponentInfo{com.reveny.habittracker/com.reveny.habittracker.MainActivity}" drawable="vervedo" name="Habit Tracker" />
   <item component="ComponentInfo{br.gov.caixa.habitacao/br.gov.caixa.habitacao.MainActivity}" drawable="habitacao_caixa" name="Habitação Caixa" />
   <item component="ComponentInfo{br.gov.caixa.habitacao/br.gov.caixa.habitacao.ui.app.splash.view.StartActivity}" drawable="habitacao_caixa" name="Habitação Caixa" />
   <item component="ComponentInfo{com.habitrpg.android.habitica/com.habitrpg.android.habitica.ui.activities.MainActivity}" drawable="habitica" name="Habitica" />
@@ -7549,6 +7574,7 @@
   <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.allfunction.LaunchActivity}" drawable="happymod" name="HappyMod" />
   <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.main.LaunchActivity}" drawable="happymod" name="HappyMod" />
   <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.main.SplashAdActivity}" drawable="happymod" name="HappyMod" />
+  <item component="ComponentInfo{com.happymod.app/com.happymod.app.hmmvp.main.LaunchActivity}" drawable="happymod" name="HappyMod" />
   <item component="ComponentInfo{io.github.dorumrr.happytaxes/io.github.dorumrr.happytaxes.MainActivity}" drawable="happytaxes" name="HappyTaxes" />
   <item component="ComponentInfo{net.alkafeel.mcb/net.alkafeel.mcb.Splashscreen}" drawable="haqibat_almumin" name="Haqibat Almumin" />
   <item component="ComponentInfo{com.simon.harmonichackernews/com.simon.harmonichackernews.MainActivity}" drawable="harmonic" name="Harmonic" />
@@ -8358,6 +8384,7 @@
   <item component="ComponentInfo{com.instagram.android/com.instagram.mainactivity.LauncherActivity}" drawable="instagram" name="Instagram" />
   <item component="ComponentInfo{com.instagram.android/com.OM7753.gold.icon1}" drawable="instagram" name="Instagram" />
   <item component="ComponentInfo{com.instagram.android/com.instagram.android.activity.MainTabActivity15}" drawable="instagram" name="Instagram" />
+  <item component="ComponentInfo{com.aeroinsta.android/com.instagram.android.activity.MainTabActivity}" drawable="instagram" name="Instagram" />
   <item component="ComponentInfo{com.instagram.lite/com.facebook.lite.MainActivity}" drawable="instagram" name="Instagram Lite" />
   <item component="ComponentInfo{com.instagram.lite/com.instagram.lite.IgLiteActivity}" drawable="instagram" name="Instagram Lite" />
   <item component="ComponentInfo{dev.zwander.installwithoptions/dev.zwander.installwithoptions.MainActivity}" drawable="install_with_options" name="Install with Options" />
@@ -8365,6 +8392,7 @@
   <item component="ComponentInfo{com.rosan.installer.x/com.rosan.installer.ui.activity.SettingsActivity}" drawable="installerx" name="InstallerX" />
   <item component="ComponentInfo{com.rosan.installer.x.revived/com.rosan.installer.ui.activity.LauncherAlias}" drawable="installerx" name="InstallerX Revived" />
   <item component="ComponentInfo{com.rosan.installer.x.revived/com.rosan.installer.ui.activity.SettingsActivity}" drawable="installerx" name="InstallerX Revived" />
+  <item component="ComponentInfo{com.android.packageinstaller/com.rosan.installer.ui.activity.LauncherAlias}" drawable="installerx" name="InstallerX Revived" />
   <item component="ComponentInfo{in.swiggy.android.instamart/in.swiggy.android.HomeIcon}" drawable="swiggy" name="Instamart" />
   <item component="ComponentInfo{com.instander.android/com.instagram.android.activity.MainTabActivity}" drawable="instander" name="Instander" />
   <item component="ComponentInfo{com.instander.android/com.instander.android.activity.MainTabActivity}" drawable="instander" name="Instander" />
@@ -8544,6 +8572,7 @@
   <item component="ComponentInfo{com.ivy.wallet/com.ivy.wallet.ui.RootActivity}" drawable="ivy_wallet" name="Ivy Wallet" />
   <item component="ComponentInfo{com.ivy.wallet/com.ivy.wallet.RootActivity}" drawable="ivy_wallet" name="Ivy Wallet" />
   <item component="ComponentInfo{com.ivy.wallet/com.ivy.wallet.ui.IvyActivity}" drawable="ivy_wallet" name="Ivy Wallet" />
+  <item component="ComponentInfo{com.ivy.wallet.debug/com.ivy.wallet.RootActivity}" drawable="ivy_wallet" name="Ivy Wallet" />
   <item component="ComponentInfo{cz.motion.ivysilani/cz.motion.ivysilani.MainActivity}" drawable="ivysilani" name="iVysílání" />
   <item component="ComponentInfo{com.jungleapps.wallpapers/com.jungleapps.wallpapers.Preload}" drawable="iwall" name="iWALL" />
   <item component="ComponentInfo{com.ixigo/com.ixigo.DefaultSplashScreenActivity}" drawable="ixigo" name="ixigo" />
@@ -8871,6 +8900,7 @@
   <item component="ComponentInfo{com.github.capntrips.kernelflasher/com.github.capntrips.kernelflasher.MainActivity}" drawable="kernel_flasher" name="Kernel Flasher" />
   <item component="ComponentInfo{me.weishu.kernelsu/me.weishu.kernelsu.ui.MainActivity}" drawable="kernelsu" name="KernelSU" />
   <item component="ComponentInfo{dilwda.oeqtnt.oumigs/dilwda.oeqtnt.oumigs.ui.MainActivity}" drawable="kernelsu" name="KernelSU" />
+  <item component="ComponentInfo{com.kowx712.supermanager/me.weishu.kernelsu.MainActivityOfficial}" drawable="kernelsu" name="KernelSU" />
   <item component="ComponentInfo{com.rifsxd.ksunext/com.rifsxd.ksunext.ui.MainActivity}" drawable="kernelsu_next" name="KernelSU Next" />
   <item component="ComponentInfo{com.mobile.sabacc/com.mobile.sabacc.MainActivity}" drawable="kessel_sabacc" name="Kessel Sabacc" />
   <item component="ComponentInfo{com.ketchapp.circle/com.unity3d.player.UnityPlayerActivity}" drawable="ketchapp_circle" name="Ketchapp Circle" />
@@ -8879,6 +8909,7 @@
   <item component="ComponentInfo{cocobo1.pupu.manager/dev.beefers.vendetta.manager.ui.activity.MainActivity}" drawable="kettu_manager" name="Kettu Manager" />
   <item component="ComponentInfo{org.kexp.android/org.kexp.radio.activity.MainActivity}" drawable="kexp" name="KEXP" />
   <item component="ComponentInfo{io.github.vvb2060.keyattestation/io.github.vvb2060.keyattestation.home.HomeActivity}" drawable="key_attestation" name="Key Attestation" />
+  <item component="ComponentInfo{io.github.qwq233.keyattestation/io.github.vvb2060.keyattestation.home.HomeActivity}" drawable="key_attestation" name="Key Attestation" />
   <item component="ComponentInfo{com.kunzisoft.hardware.key/com.kunzisoft.hardware.key.SettingActivity}" drawable="key_driver" name="Key Driver" />
   <item component="ComponentInfo{com.kunzisoft.hardware.key/com.kunzisoft.hardware.key.presentation.AppActivity}" drawable="key_driver" name="Key Driver" />
   <item component="ComponentInfo{io.github.sds100.keymapper/io.github.sds100.keymapper.SplashActivity}" drawable="key_mapper" name="Key Mapper" />
@@ -9256,6 +9287,7 @@
   <item component="ComponentInfo{ch.deletescape.lawnchair/ch.deletescape.lawnchair.Launcher}" drawable="lawnchair" name="Lawnchair" />
   <item component="ComponentInfo{ch.deletescape.lawnchair.ci/ch.deletescape.lawnchair.LawnchairLauncher}" drawable="lawnchair" name="Lawnchair" />
   <item component="ComponentInfo{ch.deletescape.lawnchair.ci/ch.deletescape.lawnchair.settings.ui.SettingsLauncherActivity}" drawable="lawnchair" name="Lawnchair" />
+  <item component="ComponentInfo{com.zte.mifavor.launcher/app.lawnchair.LawnchairLauncher}" drawable="lawnchair" name="Lawnchair" />
   <item component="ComponentInfo{ch.deletescape.lawnchair.plah.debug/app.lawnchair.LawnchairLauncher}" drawable="lawnchair_debug" name="Lawnchair Debug" />
   <item component="ComponentInfo{app.lawnchair.debug/leakcanary.internal.activity.LeakLauncherActivity}" drawable="lawnchair_debug" name="Lawnchair Debug" />
   <item component="ComponentInfo{app.lawnchair.debug/app.lawnchair.LawnchairLauncher}" drawable="lawnchair_debug" name="Lawnchair Debug" />
@@ -9678,6 +9710,8 @@
   <item component="ComponentInfo{com.pulsar.nyxis/com.pulsar.nyxis.module_home.HomeActivityNew}" drawable="loklok" name="Loklok" />
   <item component="ComponentInfo{com.darmiu.folasia/com.aesar.krios.module_home.HomeActivityNew}" drawable="loklok" name="Loklok" />
   <item component="ComponentInfo{com.garmr.zygos/com.loklok.flash.android.MainActivity}" drawable="loklok" name="Loklok" />
+  <item component="ComponentInfo{com.risa.umbra/com.risa.umbra.module_home.HomeActivityNew}" drawable="loklok" name="Loklok" />
+  <item component="ComponentInfo{com.woden.celestis/com.woden.celestis.module_home.HomeActivityNew}" drawable="loklok" name="Loklok" />
   <item component="ComponentInfo{com.noaisu.loliSnatcher/com.noaisu.loliSnatcher.MainActivity}" drawable="loli_snatcher" name="Loli Snatcher" />
   <item component="ComponentInfo{com.noaisu.loliSnatcher/com.noaisu.loliSnatcher.MainActivityAlias_LoliSnatcher}" drawable="loli_snatcher" name="Loli Snatcher" />
   <item component="ComponentInfo{com.noaisu.loliSnatcher/com.noaisu.loliSnatcher.MainActivityAlias_LoliSnatcherSpaced}" drawable="loli_snatcher" name="Loli Snatcher" />
@@ -9781,6 +9815,7 @@
   <item component="ComponentInfo{com.BenPaul.LiveWallShortcut/com.BenPaul.LiveWallShortcut.LiveWallshortcutActivity}" drawable="lwp_plus" name="LWP" />
   <item component="ComponentInfo{com.lb.lwp_plus/com.lb.lwp_plus.activities.main.MainActivity}" drawable="lwp_plus" name="LWP+" />
   <item component="ComponentInfo{cn.toside.music.mobile/cn.toside.music.mobile.MainActivity}" drawable="lx_music" name="LX Music" />
+  <item component="ComponentInfo{wj.bcngmr.ykztj.mldvhy/cn.toside.music.mobile.MainActivity}" drawable="lx_music" name="LX Music" />
   <item component="ComponentInfo{io.gitlab.coolreader_ng.lxreader.fdroid/io.gitlab.coolreader_ng.project_s.ReaderActivity}" drawable="lxreader" name="LxReader" />
   <item component="ComponentInfo{io.gitlab.coolreader_ng.lxreader.gplay/io.gitlab.coolreader_ng.project_s.ReaderActivity}" drawable="lxreader" name="LxReader" />
   <item component="ComponentInfo{fr.lyceeconnecte.mobile/com.ode.appe.SplashActivity}" drawable="lycee_connecte" name="Lycée Connecté" />
@@ -10434,6 +10469,7 @@
   <item component="ComponentInfo{com.claro.pe.miclaro/com.everis.miclaro.view.activity.SplashScreenActivity}" drawable="mi_claro" name="Mi Claro" />
   <item component="ComponentInfo{com.claro.miclaro/com.claro.miclaro.view.SplashKTVC}" drawable="mi_claro" name="Mi Claro" />
   <item component="ComponentInfo{com.claroecuador.miclaro/com.claroecuador.miclaro.view.SplashKTVC}" drawable="mi_claro" name="Mi Claro" />
+  <item component="ComponentInfo{com.clarord.miclaro/com.clarord.miclaro.controller.LoginActivity}" drawable="mi_claro" name="Mi Claro" />
   <item component="ComponentInfo{com.mi.global.bbs/com.mi.global.bbs.ui.SplashActivity}" drawable="mi_community" name="Mi Community" />
   <item component="ComponentInfo{com.mi.global.bbs/com.mi.global.bbslib.headlines.ui.SplashActivity}" drawable="mi_community" name="Mi Community" />
   <item component="ComponentInfo{com.treydev.micontrolcenter/com.treydev.shades.activities.MainActivity}" drawable="mi_control_center" name="Mi Control Center" />
@@ -10450,6 +10486,7 @@
   <item component="ComponentInfo{com.xiaomi.smarthome/com.xiaomi.smarthome.StartupActivity}" drawable="mi_home" name="Mi Home" />
   <item component="ComponentInfo{com.xiaomi.smarthome/com.xiaomi.smarthome.SmartHomeMainActivity}" drawable="mi_home" name="Mi Home" />
   <item component="ComponentInfo{com.xiaomi.smarthomv/com.xiaomi.smarthome.SmartHomeMainActivity}" drawable="mi_home" name="Mi Home" />
+  <item component="ComponentInfo{com.xiaomi.smarthome.tv.global4/com.xiaomi.smarthome.tv.ui.MainActivity}" drawable="mi_home" name="Mi Home" />
   <item component="ComponentInfo{ar.gob.afip.mobile.android.contribuyentes.monotributo/ar.gob.afip.mobile.android.contribuyentes.monotributo.activities.nonauth.SplashActivity}" drawable="mi_monotributo" name="Mi Monotributo" />
   <item component="ComponentInfo{com.miui.huanji/com.miui.huanji.MainActivity}" drawable="mi_mover" name="Mi Mover" />
   <item component="ComponentInfo{com.miui.player/com.miui.player.component.MusicBrowserActivity}" drawable="mi_music" name="Mi Music" />
@@ -10665,6 +10702,7 @@
   <item component="ComponentInfo{com.mojang.minecraftpx/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.hanver.wdsj/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftpe/com.me.game.pmupdatesdk.MainActivity}" drawable="minecraft" name="Minecraft" />
+  <item component="ComponentInfo{com.mojang.mine261301/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecrafttrialpe/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft Trial" />
   <item component="ComponentInfo{com.panu/com.panu.SplashScreenActivity}" drawable="generic_minesweeper" name="Minesweeper" />
   <item component="ComponentInfo{Draziw.Button.Mines/minesweeper.Button.Mines.BoardViewActivity}" drawable="generic_minesweeper" name="Minesweeper" />
@@ -10685,6 +10723,7 @@
   <item component="ComponentInfo{nz.co.codepoint.minimetro/com.unity3d.player.UnityPlayerActivity}" drawable="mini_metro" name="Mini Metro" />
   <item component="ComponentInfo{com.east2west.minimetro.m4399/com.east2west.unitygame.MainActivity}" drawable="mini_metro" name="Mini Metro" />
   <item component="ComponentInfo{com.appsomniacs.da2/com.appsomniacs.da2.DA2Activity}" drawable="mini_militia" name="Mini Militia" />
+  <item component="ComponentInfo{com.minimilitia.undeectablemod.byneerajmods/com.appsomniacs.da2.DA2Activity}" drawable="mini_militia" name="Mini Militia" />
   <item component="ComponentInfo{com.appsomniacs.mmc/com.appsomniacs.mmc.MmcActivity}" drawable="mini_militia_classic" name="Mini Militia Classic" />
   <item component="ComponentInfo{jp.coffeebreakin.app.minifarm/jp.coffeebreakin.lib.SplashActivity}" drawable="mini_mini_farm" name="Mini Mini Farm" />
   <item component="ComponentInfo{com.chaoyue.neutral_obd/com.chaoyue.neutral_obd.app.SplashActivity}" drawable="mini_obdii" name="Mini OBDII" />
@@ -10906,6 +10945,7 @@
   <item component="ComponentInfo{com.ktwapps.walletmanager/com.ktwapps.walletmanager.MainActivity}" drawable="wallet" name="Money Manager" />
   <item component="ComponentInfo{com.realbyteapps.moneya/com.realbyte.money.ui.license.GPLicenseCheckActivity}" drawable="money_manager" name="Money Manager" />
   <item component="ComponentInfo{com.realbyteapps.moneymanagerfree/com.realbyte.money.ui.intro.Intro}" drawable="money_manager" name="Money Manager" />
+  <item component="ComponentInfo{ru.innim.my_finance/ru.innim.my_finance.MainActivityAlias2}" drawable="money_manager" name="Money Manager" />
   <item component="ComponentInfo{com.blogspot.e_kanivets.moneytracker/com.blogspot.e_kanivets.moneytracker.activity.record.MainActivity}" drawable="money_tracker" name="Money Tracker" />
   <item component="ComponentInfo{com.moneyboxapp/com.moneyboxapp.app.REGULAR}" drawable="moneybox" name="Moneybox" />
   <item component="ComponentInfo{com.divum.MoneyControl/com.moneycontrol.handheld.SplashActivity.PRO}" drawable="moneycontrol" name="Moneycontrol" />
@@ -11089,6 +11129,9 @@
   <item component="ComponentInfo{com.community.oneroom/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
   <item component="ComponentInfo{com.community.mbox.ng/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
   <item component="ComponentInfo{com.quint.turne/com.quint.turne.module_home.HomeActivityNew}" drawable="moviebox" name="MovieBox" />
+  <item component="ComponentInfo{com.yomobigroup.chat/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
+  <item component="ComponentInfo{com.community.mbox.afen/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
+  <item component="ComponentInfo{com.community.mbox.affr/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
   <item component="ComponentInfo{com.movielab.mobile/com.movielab.MainActivity}" drawable="movielab" name="Movielab" />
   <item component="ComponentInfo{com.moviesanywhere.goo/com.disney.brooklyn.mobile.ui.main.MainActivity}" drawable="movies_anywhere" name="Movies Anywhere" />
   <item component="ComponentInfo{com.parkit.selfcare/com.parkit.selfcare.MainActivity}" drawable="movil_tr" name="Movil-TR" />
@@ -11187,6 +11230,7 @@
   <item component="ComponentInfo{com.muzekart.app/com.muzekart.app.MainActivity}" drawable="museums_of_turkiye" name="Museums of Türkiye" />
   <item component="ComponentInfo{com.android.music/com.android.music.MusicBrowserActivity}" drawable="generic_player" name="Music" />
   <item component="ComponentInfo{com.android.bbkmusic/com.android.bbkmusic.WidgetToTrackActivity}" drawable="music_player" name="Music" />
+  <item component="ComponentInfo{com.vayunmathur.music/com.vayunmathur.music.MainActivity}" drawable="music_player" name="Music" />
   <item component="ComponentInfo{siva.app.music7pro/siva.app.music7pro.app.activities.M7Player}" drawable="apple_music" name="Music 7 Pro" />
   <item component="ComponentInfo{com.tianxingjian.supersound/com.tianxingjian.supersound.MainActivity}" drawable="music_audio_editor" name="Music Audio Editor" />
   <item component="ComponentInfo{com.musicmaker.mobile.android/com.musicmaker.mobile.android.AndroidLauncher}" drawable="ddmusic" name="Music Creator" />
@@ -11285,6 +11329,7 @@
   <item component="ComponentInfo{net.omobio.airtelsc/net.omobio.airtelsc.activities.HomeActivity}" drawable="my_airtel" name="My Airtel" />
   <item component="ComponentInfo{com.myairtelapp/com.myairtelapp.home.views.activities.SplashScreenActivityAlias}" drawable="my_airtel" name="My Airtel" />
   <item component="ComponentInfo{net.omobio.airtelsc/com.portonics.robi_airtel_super_app.ui.SplashActivity}" drawable="my_airtel" name="My Airtel" />
+  <item component="ComponentInfo{com.samsung.android.airtel.stubapp/com.samsung.android.airtel.stubapp.ui.StubActivity}" drawable="my_airtel" name="My Airtel" />
   <item component="ComponentInfo{cn.wq.myandroidtools/cn.wq.myandroidtools.MainActivity}" drawable="my_android_tools" name="My Android Tools" />
   <item component="ComponentInfo{cn.wq.myandroidtools/cn.wq.myandroidtoolspro.MainDarkActivity}" drawable="my_android_tools" name="My Android Tools" />
   <item component="ComponentInfo{cn.wq.myandroidtools/cn.wq.myandroidtoolspro.MainActivity}" drawable="my_android_tools" name="My Android Tools" />
@@ -11294,6 +11339,7 @@
   <item component="ComponentInfo{com.zako.mybac/com.zako.mybac.SplashScreen}" drawable="stundenplan_schedule" name="My Bac" />
   <item component="ComponentInfo{ca.virginmobile.mybenefits/ca.virginmobile.mybenefits.AboutActivity}" drawable="my_benefits" name="My Benefits" />
   <item component="ComponentInfo{de.bmw.connected.mobile20.row/com.mobileconnected.MainActivity}" drawable="my_bmw" name="My BMW" />
+  <item component="ComponentInfo{de.bmw.connected.mobile20.cn/com.mobileconnected.MainActivity}" drawable="my_bmw" name="My BMW" />
   <item component="ComponentInfo{com.fastemulator.gba/com.fastemulator.gba.MainActivity}" drawable="my_boy" name="My Boy!" />
   <item component="ComponentInfo{com.fastemulator.gba/com.fastemulator.gba.RomListActivity}" drawable="my_boy" name="My Boy!" />
   <item component="ComponentInfo{be.bpost.mybpost/be.bpost.mybpost.features.signup.splashview.view.SplashScreenActivity}" drawable="my_bpost" name="My bpost" />
@@ -11329,6 +11375,7 @@
   <item component="ComponentInfo{com.hihonor.phoneservice/com.hihonor.phoneservice.LaunchActivity}" drawable="my_honor" name="My HONOR" />
   <item component="ComponentInfo{com.huawei.phoneservice/com.huawei.phoneservice.LaunchActivity}" drawable="my_huawei" name="My Huawei" />
   <item component="ComponentInfo{com.huawei.phoneservice/com.huawei.myhuawei.ui.HwSplashActivity}" drawable="my_huawei" name="My Huawei" />
+  <item component="ComponentInfo{com.huawei.it.myhuawei/com.huawei.myhuawei.ui.HwSplashActivity}" drawable="my_huawei" name="My HUAWEI" />
   <item component="ComponentInfo{com.telkom.indihome.external/com.telkom.indihome.external.onboarding.SplashActivity}" drawable="my_indihome" name="My IndiHome" />
   <item component="ComponentInfo{com.telkom.indihome.external/com.telkom.indihome.external.presentation.onboarding.SplashActivity}" drawable="my_indihome" name="My IndiHome" />
   <item component="ComponentInfo{com.crossknowledge.learnguided/com.crossknowledge.learnguided.MainActivity}" drawable="my_learning" name="My Learning" />
@@ -11863,6 +11910,7 @@
   <item component="ComponentInfo{com.nisargjhaveri.netspeed/com.nisargjhaveri.netspeed.settings.SettingsActivity}" drawable="netspeed_indicator" name="NetSpeed Indicator" />
   <item component="ComponentInfo{com.valuephone.vpnetto/de.netto.b2c.activity.FragmentActivity}" drawable="netto" name="Netto" />
   <item component="ComponentInfo{com.valuephone.vpnetto/de.netto.b2c.FragmentActivity}" drawable="netto" name="Netto" />
+  <item component="ComponentInfo{com.mousquetaires.netto/com.mousquetaires.netto.netto_flutter.MainActivity}" drawable="netto" name="Netto" />
   <item component="ComponentInfo{pl.lebihan.network/pl.lebihan.network.RadioNetwork}" drawable="generic_dialer" name="Network" />
   <item component="ComponentInfo{net.techet.netanalyzerlite.an/net.techet.netanalyzerlite.an.activity.MainActivity}" drawable="network_analyzer" name="Network Analyzer" />
   <item component="ComponentInfo{net.techet.netanalyzer.an/net.techet.netanalyzer.an.activity.MainActivity}" drawable="network_analyzer_pro" name="Network Analyzer Pro" />
@@ -11928,6 +11976,7 @@
   <item component="ComponentInfo{com.nkming.nc_photos.paid/com.nkming.nc_photos.MainActivity}" drawable="nextcloud_photos" name="Nextcloud Photos" />
   <item component="ComponentInfo{com.nextcloud.talk2/com.nextcloud.talk.activities.MainActivity}" drawable="nextcloud_talk" name="Nextcloud Talk" />
   <item component="ComponentInfo{io.nextdns.NextDNS/io.nextdns.NextDNS.MainActivity}" drawable="nextdns" name="NextDNS" />
+  <item component="ComponentInfo{com.example.nextdns/com.example.nextdns.MainActivity}" drawable="nextdns" name="NextDNS" />
   <item component="ComponentInfo{com.doubleangels.nextdnsmanagement/com.doubleangels.nextdnsmanagement.MainActivity}" drawable="nextdns" name="NextDNS Manager" />
   <item component="ComponentInfo{com.nextdoor/com.nextdoor.registrationUi.nux.LoadAppConfigurationActivity}" drawable="nextdoor" name="Nextdoor" />
   <item component="ComponentInfo{com.nic.mparivahan/com.nic.mparivahan.activity.SplashActivity}" drawable="nextgen_mparivahan" name="NextGen mParivahan" />
@@ -12196,6 +12245,7 @@
   <item component="ComponentInfo{com.wn.app.np/player.normal.np.activity.GuideActivity}" drawable="np_manager" name="NP Manager" />
   <item component="ComponentInfo{org.lsposed.npatch/org.lsposed.lspatch.ui.activity.MainActivity}" drawable="lspatch_lsposed" name="NPatch" />
   <item component="ComponentInfo{org.lsposed.npatch/org.lsposed.npatch.ui.activity.MainActivity}" drawable="lspatch_lsposed" name="NPatch" />
+  <item component="ComponentInfo{top.nkbe.npatch/top.nkbe.npatch.ui.activity.MainActivity}" drawable="lspatch_lsposed" name="NPatch" />
   <item component="ComponentInfo{nl.uitzendinggemist/nl.uitzendinggemist.mobile.presentation.activities.StartupActivity}" drawable="npo_start" name="NPO Start" />
   <item component="ComponentInfo{nl.uitzendinggemist/nl.uitzendinggemist.mobile.presentation.activities.main.MainActivity}" drawable="npo_start" name="NPO Start" />
   <item component="ComponentInfo{nps.nps/nps.nps.SplashScreen}" drawable="nps" name="NPS" />
@@ -12658,6 +12708,7 @@
   <item component="ComponentInfo{com.darkempire78.opencalculator/com.darkempire78.opencalculator.MainActivity}" drawable="generic_calculator_plus_minus_multi_equal" name="OpenCalc" />
   <item component="ComponentInfo{com.darkempire78.opencalculator/com.darkempire78.opencalculator.activities.MainActivity}" drawable="generic_calculator_plus_minus_multi_equal" name="OpenCalc" />
   <item component="ComponentInfo{net.openconnect_vpn.android/net.openconnect_vpn.android.MainActivity}" drawable="openconnect" name="OpenConnect" />
+  <item component="ComponentInfo{com.github.digitalsoftwaresolutions.openconnect/app.openconnect.MainActivity}" drawable="openconnect" name="OpenConnect" />
   <item component="ComponentInfo{opencontacts.open.com.opencontacts/opencontacts.open.com.opencontacts.activities.MainActivity}" drawable="generic_dialer" name="OpenContacts" />
   <item component="ComponentInfo{io.github.rickymohk.opendefault/io.github.rickymohk.opendefault.MainActivity}" drawable="opendefault" name="OpenDefault" />
   <item component="ComponentInfo{at.tomtasche.reader/at.tomtasche.reader.ui.activity.MainActivity}" drawable="opendocument_reader" name="OpenDocument Reader" />
@@ -13006,6 +13057,8 @@
   <item component="ComponentInfo{dev.msfjarvis.aps/com.zeapo.pwdstore.LaunchActivity}" drawable="password_store" name="Password Store" />
   <item component="ComponentInfo{dev.msfjarvis.aps/com.zeapo.pwdstore.PasswordStore}" drawable="password_store" name="Password Store" />
   <item component="ComponentInfo{app.passwordstore/app.passwordstore.ui.main.LaunchActivity}" drawable="password_store" name="Password Store" />
+  <item component="ComponentInfo{app.passwordstore.pando85/app.passwordstore.ui.main.LaunchActivity}" drawable="password_store" name="Password Store" />
+  <item component="ComponentInfo{app.passwordstore.agrahn/app.passwordstore.ui.main.LaunchActivity}" drawable="password_store" name="Password Store" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.PasswordManagerActivity}" drawable="passwords_google_shortcuts_launcher" name="Passwords (Google Shortcuts Launcher)" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcut.PasswordManagerActivity}" drawable="passwords_google_shortcuts_launcher" name="Passwords (Google Shortcuts Launcher)" />
   <item component="ComponentInfo{com.wstxda.gsl/com.wstxda.gsl.shortcuts.PasswordManagerShortcut}" drawable="passwords_google_shortcuts_launcher" name="Passwords (Google Shortcuts Launcher)" />
@@ -13106,6 +13159,8 @@
   <item component="ComponentInfo{pdfreader.pdfviewer.officetool.pdfscanner/pdfreader.pdfviewer.officetool.pdfscanner.views.activities.splash.SplashLatestActivity}" drawable="generic_pdf_file" name="PDF Reader" />
   <item component="ComponentInfo{com.gamma.pdfreader/com.gammaplay.multidocreader.MainActivity}" drawable="generic_pdf_file" name="PDF Reader" />
   <item component="ComponentInfo{com.document.pdf.scanner.free.all/com.document.pdf.scanner.ui.ReaderSplashActivity}" drawable="generic_pdf_file" name="PDF Reader" />
+  <item component="ComponentInfo{com.pdfreaderapp.alldocumentreader.pdfviewer/com.adjut.sdkwallpaperx.SplashActivity}" drawable="generic_pdf_square" name="PDF Reader" />
+  <item component="ComponentInfo{com.pdfreader.editor.viewer.pdfviewer/com.pdfreader.editor.presentation.splash.SplashActivity}" drawable="generic_pdf_square" name="PDF Reader" />
   <item component="ComponentInfo{com.document.reader.pdfreader.pdf/com.document.reader.pdfreader.pdf.SplashScreenActivity}" drawable="generic_pdf_file" name="PDF Reader &amp; PDF Viewer" />
   <item component="ComponentInfo{com.camscanner.documentscanner.pdfscanner.textscanner.photos.scanner/com.hazel.cam.scanner.free.activity.splash.SplashActivity}" drawable="generic_scanner" name="PDF Scanner" />
   <item component="ComponentInfo{com.kaikaisoft.pdfscanner/com.kaikaisoft.pdfscanner.activity.MainActivity}" drawable="generic_camera" name="PDF Scanner" />
@@ -13453,7 +13508,9 @@
   <item component="ComponentInfo{com.sorincovor.pigments/com.sorincovor.pigments.MainActivity}" drawable="pigments" name="Pigments" />
   <item component="ComponentInfo{com.offshore.pikachu/com.offshore.pikachu.view.Splash}" drawable="pikashow" name="Pikashow" />
   <item component="ComponentInfo{com.offshore.pikachu/com.offshore.raichu.MainActivity}" drawable="pikashow" name="Pikashow" />
+  <item component="ComponentInfo{com.pikashow.mobile/com.pikashow.mobile.MainActivity}" drawable="pikashow" name="PikaShow" />
   <item component="ComponentInfo{com.nianticlabs.pikmin/com.nianticproject.ichigo.IchigoUnityPlayerActivity}" drawable="pikmin_bloom" name="Pikmin Bloom" />
+  <item component="ComponentInfo{com.instagram.android.piko/com.instagram.android.activity.MainTabActivity}" drawable="instagram" name="Piko Instagram" />
   <item component="ComponentInfo{com.pikcloud.pikpak/com.pikcloud.app.SplashActivity}" drawable="pikpak" name="PikPak" />
   <item component="ComponentInfo{com.diune.pictures/com.diune.pikture_ui.ui.Bridge}" drawable="piktures" name="Piktures" />
   <item component="ComponentInfo{com.diune.pictures/com.diune.pictures.ui.Bridge}" drawable="piktures" name="Piktures" />
@@ -14094,6 +14151,7 @@
   <item component="ComponentInfo{ch.protonvpn.android/ch.protonvpn.android.RoutingActivity}" drawable="proton_vpn" name="Proton VPN" />
   <item component="ComponentInfo{ch.protonvpn.android/com.protonvpn.android.ui.onboarding.SplashActivity}" drawable="proton_vpn" name="Proton VPN" />
   <item component="ComponentInfo{ch.protonvpn.android.revanced/ch.protonvpn.android.RoutingActivity}" drawable="proton_vpn" name="Proton VPN" />
+  <item component="ComponentInfo{ch.protonvpn.android.morphe/ch.protonvpn.android.RoutingActivity}" drawable="proton_vpn" name="Proton VPN" />
   <item component="ComponentInfo{me.proton.wallet.android/me.proton.wallet.android.activity.MainActivity}" drawable="proton_wallet" name="Proton Wallet" />
   <item component="ComponentInfo{ru.protonmod.next/ch.protonvpn.android.RoutingActivity}" drawable="proton_vpn" name="ProtonMOD-Next" />
   <item component="ComponentInfo{com.propel.ebenefits/com.propel.ebenefits.MainActivity}" drawable="providers" name="Providers" />
@@ -14231,6 +14289,7 @@
   <item component="ComponentInfo{com.gamma.scan/com.gamma.barcodeapp.ui.BarcodeCaptureActivity}" drawable="generic_qr_reader" name="QR &amp; Barcode Scanner" />
   <item component="ComponentInfo{com.cactus.qr.barcode.scanner/com.qrb.scanner.ui.splash.SplashActivity}" drawable="generic_qr_reader" name="QR &amp; Barcode Scanner" />
   <item component="ComponentInfo{com.gamma.scan2/com.gamma.barcodeapp.ui.BarcodeCaptureActivity}" drawable="generic_qr_reader_pro" name="QR &amp; Barcode Scanner PRO" />
+  <item component="ComponentInfo{com.vtool.qrcodereader.barcodescanner/com.ecomobile.qrcode.screens.splash.SplashActivity}" drawable="generic_qr_reader" name="QR &amp;amp; Barcode Scanner" />
   <item component="ComponentInfo{com.qrcode.barcode.scanner.reader.generator.free/com.qrcode.barcode.scanner.reader.generator.free.activity.MainActivity}" drawable="qrky" name="QR and Barcode Scanner" />
   <item component="ComponentInfo{com.noa.smartscanai/com.noa.smartscanai.ui.MainActivity}" drawable="generic_qr_reader" name="QR and Barcode Scanner" />
   <item component="ComponentInfo{com.qrcode.barcode.scanner.reader.generator.pro/com.qrcode.barcode.scanner.reader.generator.pro.activity.MainActivity}" drawable="generic_qr_reader_pro" name="QR and Barcode Scanner PRO" />
@@ -14356,6 +14415,7 @@
   <item component="ComponentInfo{com.github.jameshnsears.quoteunquote/com.github.jameshnsears.quoteunquote.QuoteUnquoteInstructions}" drawable="quote_unquote" name="Quote Unquote" />
   <item component="ComponentInfo{com.ashwin.apps.android.quoteswidget/com.ashwin.apps.android.quoteswidget.ui.SettingsActivity}" drawable="quotes_widget" name="Quotes Widget" />
   <item component="ComponentInfo{io.quotex/io.quotex.webview.MainActivity}" drawable="quotex" name="Quotex" />
+  <item component="ComponentInfo{io.quotex.x/io.quotex.webview.MainActivity}" drawable="quotex" name="Quotex" />
   <item component="ComponentInfo{com.quran.labs.androidquran/com.quran.labs.androidquran.QuranDataActivity}" drawable="generic_quran" name="Quran" />
   <item component="ComponentInfo{com.quran.labs.androidquran.naskh/com.quran.labs.androidquran.QuranDataActivity}" drawable="generic_quran" name="Quran" />
   <item component="ComponentInfo{com.andi.alquran.en/com.andi.alquran.ActivityHome}" drawable="generic_quran" name="Quran English" />
@@ -14639,6 +14699,7 @@
   <item component="ComponentInfo{com.dot.gallery/com.dot.gallery.feature_node.presentation.main.MainActivity}" drawable="refra" name="ReFra" />
   <item component="ComponentInfo{com.dot.gallery/com.dot.gallery.Launcher_Gallery}" drawable="refra" name="ReFra" />
   <item component="ComponentInfo{com.dot.gallery/com.dot.gallery.Launcher_ReFra}" drawable="refra" name="ReFra" />
+  <item component="ComponentInfo{com.dot.gallery.gplay/com.dot.gallery.Launcher_ReFra}" drawable="refra" name="ReFra" />
   <item component="ComponentInfo{ai.regainapp/ai.blox100.HomePageActivity}" drawable="regain" name="Regain" />
   <item component="ComponentInfo{com.fandango.regal/com.fandango.regal.activity.LauncherActivity}" drawable="regal" name="Regal" />
   <item component="ComponentInfo{com.fandango.regal/com.regal.activity.LauncherActivity}" drawable="regal" name="Regal" />
@@ -15350,6 +15411,7 @@
   <item component="ComponentInfo{ua.napps.scorekeeper/ua.napps.scorekeeper.app.MainActivity}" drawable="score_counter_by_napps" name="Score Counter by napps" />
   <item component="ComponentInfo{net.aasuited.scrabbleassistant/net.aasuited.belotescore.ui.activity.gamemanagement.GameManagementActivity}" drawable="score_keeper_for_scrabble" name="Score Keeper for SCRABBLE" />
   <item component="ComponentInfo{com.firsttouchgames.story/com.firsttouchgames.story.MainActivity}" drawable="score_hero" name="Score! Hero" />
+  <item component="ComponentInfo{com.firsttouchgames.hero2/com.firsttouchgames.hero2.MainActivity}" drawable="score_hero" name="Score! Hero" />
   <item component="ComponentInfo{com.github.vatbub.scoreboard/com.github.vatbub.scoreboard.view.MainActivity}" drawable="generic_solitaire" name="Scoreboard" />
   <item component="ComponentInfo{com.scotiabank.banking/com.scotiabank.nova.startup.StartupAlias}" drawable="scotiabank" name="Scotiabank" />
   <item component="ComponentInfo{pe.com.scotiabank.blpm.android.client/pe.com.scotiabank.blpm.android.client.entrypoint.LaunchActivity}" drawable="scotiabank" name="Scotiabank" />
@@ -15623,6 +15685,7 @@
   <item component="ComponentInfo{net.mbc.shahid/net.mbc.splash.ui.SplashActivity}" drawable="shahid" name="Shahid" />
   <item component="ComponentInfo{net.mbc.shahid/net.mbc.shahid.activities.SplashActivity}" drawable="shahid" name="Shahid" />
   <item component="ComponentInfo{com.playdigious.shapez/com.google.firebase.MessagingUnityPlayerActivity}" drawable="shapez" name="Shapez" />
+  <item component="ComponentInfo{com.playdigious.shapez.epic/com.google.firebase.MessagingUnityPlayerActivity}" drawable="shapez" name="Shapez" />
   <item component="ComponentInfo{com.hengye.share/com.hengye.share.Launcher}" drawable="share" name="Share" />
   <item component="ComponentInfo{com.appshare.shrethis.appshare/com.appshare.activities.SplashActivity}" drawable="apk_share" name="Share Apps" />
   <item component="ComponentInfo{in.mohalla.sharechat/sharechat.ads.feature.eva.EvaActivity}" drawable="sharechat" name="ShareChat" />
@@ -16559,6 +16622,7 @@
   <item component="ComponentInfo{solitaire.patience.card.games.klondike.free/solitaire.patience.card.games.klondike.free.MainActivity}" drawable="generic_solitaire" name="Solitaire" />
   <item component="ComponentInfo{com.moonfrog.solitaire.club/com.unity3d.player.UnityPlayerActivity}" drawable="generic_solitaire" name="Solitaire" />
   <item component="ComponentInfo{com.peoplefun.wordsolitaire/com.unity3d.player.UnityPlayerActivity}" drawable="generic_solitaire" name="Solitaire" />
+  <item component="ComponentInfo{com.netflix.NGP.Solitaire/com.mobilityware.sflnativeandroidutils.SFLLaunchActivity}" drawable="generic_solitaire" name="Solitaire" />
   <item component="ComponentInfo{com.brainium.solitaire/com.brainium.solitaire.SolitaireLoader}" drawable="generic_solitaire" name="Solitaire+" />
   <item component="ComponentInfo{home.solo.launcher.free/home.solo.launcher.free.Launcher}" drawable="solo_launcher" name="Solo Launcher" />
   <item component="ComponentInfo{home.solo.launcher.free/home.solo.launcher.free.SplashActivity}" drawable="solo_launcher" name="Solo Launcher" />
@@ -16657,6 +16721,7 @@
   <item component="ComponentInfo{com.gamebasic.decibel/com.gamebasic.decibel.DecibelActi}" drawable="sound_meter" name="Sound Meter" />
   <item component="ComponentInfo{com.codeclickers.soundmeter/com.codeclickers.soundmeter.MainActivity}" drawable="generic_voice_recorder_waves" name="Sound Meter" />
   <item component="ComponentInfo{com.splendapps.decibel/com.splendapps.decibel.MainActivity}" drawable="sound_meter" name="Sound Meter" />
+  <item component="ComponentInfo{com.pony.decibelmeter.soundmeter/com.binghuo.soundmeter.launcher.LauncherActivity}" drawable="sound_meter" name="Sound Meter" />
   <item component="ComponentInfo{kr.sira.sound/kr.sira.sound.Intro}" drawable="sound_meter_by_smart_tools" name="Sound Meter by Smart Tools" />
   <item component="ComponentInfo{com.google.audio.hearing.visualization.accessibility.scribe/com.google.audio.hearing.visualization.accessibility.dolphin.DolphinLauncherActivity}" drawable="sound_notifications" name="Sound Notifications" />
   <item component="ComponentInfo{Orion.Soft/orion.soft.clsVentanaPrevia}" drawable="volume_control" name="Sound Profile" />
@@ -18202,6 +18267,7 @@
   <item component="ComponentInfo{com.mytolino.app/com.mytolino.app.tolino.android.SplashScreenActivity}" drawable="tolino" name="tolino" />
   <item component="ComponentInfo{org.nsh07.pomodoro/org.nsh07.pomodoro.MainActivity}" drawable="tomato" name="Tomato" />
   <item component="ComponentInfo{com.playgendary.tom/com.lllibset.LLActivity.LLActivity}" drawable="tomb_of_the_mask" name="Tomb of the Mask" />
+  <item component="ComponentInfo{com.netflix.NGP.tombofthemask/com.unity3d.player.UnityPlayerActivity}" drawable="tomb_of_the_mask" name="Tomb of the Mask" />
   <item component="ComponentInfo{com.playgendary.tombpaint/com.lllibset.LLActivity.LLActivity}" drawable="tomb_of_the_mask_color_maze" name="Tomb of the Mask: Color Maze" />
   <item component="ComponentInfo{com.tomtom.speedcams.android.map/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="tomtom" name="TomTom" />
   <item component="ComponentInfo{com.tomtom.speedcams.android.map/com.tomtom.amigo.MainActivity}" drawable="tomtom" name="TomTom" />
@@ -18699,6 +18765,7 @@
   <item component="ComponentInfo{kr.co.lylstudio.unicorn/kr.co.lylstudio.unicorn.MainActivity}" drawable="unicorn_blocker" name="Unicorn Blocker" />
   <item component="ComponentInfo{com.unicredit/com.unicredit.MainActivity}" drawable="unicredit" name="UniCredit" />
   <item component="ComponentInfo{hr.asseco.android.jimba.mUCI.ro/hr.asseco.android.muci.ae.prelogin.SplashScreenActivity}" drawable="unicredit" name="UniCredit" />
+  <item component="ComponentInfo{be.aion.android.app/be.aion.android.app.initialization.ui.InitializationActivity}" drawable="unicredit" name="UniCredit" />
   <item component="ComponentInfo{com.myunidays/com.myunidays.home.MainActivity}" drawable="unidays" name="UNiDAYS" />
   <item component="ComponentInfo{com.myunidays/com.myunidays.MainActivity}" drawable="unidays" name="UNiDAYS" />
   <item component="ComponentInfo{com.myunidays/com.myunidays.UNiDAYS}" drawable="unidays" name="UNiDAYS" />
@@ -18743,6 +18810,7 @@
   <item component="ComponentInfo{com.uniqlo.kr.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
   <item component="ComponentInfo{com.uniqlo.my.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
   <item component="ComponentInfo{com.uniqlo.vn.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" name="UNIQLO" />
+  <item component="ComponentInfo{com.yek.android.uniqlo/com.yek.android.uniqlo.activity.WelcomeActivity}" drawable="uniqlo" name="UNIQLO" />
   <item component="ComponentInfo{com.veewalabs.unitconverter/com.veewalabs.unitconverter.MainActivity}" drawable="unit_converter" name="Unit Converter" />
   <item component="ComponentInfo{com.dronzer.unitconverter/com.dronzer.unitconverter.start.StartActivity}" drawable="unit_converter_by_dronzer" name="Unit Converter by Dronzer" />
   <item component="ComponentInfo{com.samruston.converter/com.samruston.converter.ui.MainActivity}" drawable="unit_converter_lab" name="Unit Converter Lab" />
@@ -19952,6 +20020,7 @@
   <item component="ComponentInfo{com.meitu.wink/com.meitu.wink.startup.StartupActivity}" drawable="wink_video_enhancing" name="Wink — Video Enhancing" />
   <item component="ComponentInfo{com.winlator/com.winlator.MainActivity}" drawable="winlator" name="Winlator" />
   <item component="ComponentInfo{com.winlator.vanilla/com.winlator.cmod.MainActivity}" drawable="winlator" name="Winlator" />
+  <item component="ComponentInfo{com.winlatcn/com.winlator.MainActivity}" drawable="winlator" name="Winlator" />
   <item component="ComponentInfo{il.talent.winner/il.talent.winner.MainActivity}" drawable="winner" name="Winner" />
   <item component="ComponentInfo{com.LordHonor.Windows10Simulator/com.unity3d.player.UnityPlayerActivity}" drawable="wins_10_simulator" name="Wins 10 Simulator" />
   <item component="ComponentInfo{com.wire/com.waz.zclient.LaunchActivity}" drawable="wire" name="Wire" />
@@ -20317,6 +20386,7 @@
   <item component="ComponentInfo{com.yousician.yousician/com.yousician.yousiciannative.YousicianActivity}" drawable="yousician" name="Yousician" />
   <item component="ComponentInfo{com.yousician.yousician/com.yousician.YousicianPlayerActivity}" drawable="yousician" name="Yousician" />
   <item component="ComponentInfo{com.app.youthbank/com.app.youthbank.MainActivity}" drawable="youthbank" name="Youthbank" />
+  <item component="ComponentInfo{com.morphe.youtube.music/com.morphe.youtube.music.morphe_original_1}" drawable="generic_player" name="YouTtube Music" />
   <item component="ComponentInfo{com.google.android.youtube/com.google.android.youtube.app.honeycomb.Shell}" drawable="youtube" name="YouTube" />
   <item component="ComponentInfo{com.google.android.youtube/.app.honeycomb.Shell$HomeActivity}" drawable="youtube" name="YouTube" />
   <item component="ComponentInfo{com.google.android.youtube/com.google.android.youtube.app.froyo.phone.HomeActivity}" drawable="youtube" name="YouTube" />
@@ -20333,6 +20403,7 @@
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_original_1}" drawable="youtube" name="Youtube" />
   <item component="ComponentInfo{app.morphe.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube" name="YouTube" />
   <item component="ComponentInfo{com.rve.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube" name="YouTube" />
+  <item component="ComponentInfo{com.morphe.youtube/com.morphe.youtube.morphe_original_1}" drawable="youtube" name="YouTube" />
   <item component="ComponentInfo{ma.wanam.youtubeadaway/ma.wanam.youtubeadaway.SettingsActivity}" drawable="youtube_adaway" name="YouTube AdAway" />
   <item component="ComponentInfo{com.google.android.apps.youtube.producer/com.google.android.apps.youtube.producer.application.MainActivity}" drawable="youtube_create" name="YouTube Create" />
   <item component="ComponentInfo{com.google.android.youtube.tv/com.google.android.apps.youtube.tv.activity.ShellActivity}" drawable="youtube" name="YouTube for Android TV" />
@@ -20346,6 +20417,7 @@
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_light_2}" drawable="morphe" name="YouTube Morphe" />
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_black_5}" drawable="morphe" name="YouTube Morphe" />
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_black_4}" drawable="morphe" name="Youtube Morphe" />
+  <item component="ComponentInfo{yt.morphe.noname.exe/yt.morphe.noname.exe.morphe_black_2}" drawable="morphe" name="YouTube Morphe" />
   <item component="ComponentInfo{com.google.android.apps.youtube.music/com.google.android.archive.ReactivateActivity}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.google.android.music/com.google.android.music.tombstone.LauncherActivity}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.google.android.music/com.android.music.activitymanagement.TopLevelActivity}" drawable="generic_player" name="YouTube Music" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
4G LTE (`com.fourg.lteModeOnly.speedTest.dataUsage.network` → `forcelte.svg`)
Alight Phone (`dev.goodwy.phone` → `generic_dialer.svg`)
All PDF Reader (`pdfreader.pdfviewer.free.officetool` → `generic_pdf_file.svg`)
AllTrails (`com.hoodles.alltrails` → `alltrails.svg`)
Amazon Photos (`com.amazon.photos` → `amazon_photos.svg`)
Assistive Touch (`touch.assistivetouch.easytouch` → `assistive_touch.svg`)
Audible (`com.audible.application.kindle` → `audible.svg`)
Boosty (`to.boosty.android` → `boosty.svg`)
Camera (`com.google.android.GoogleCamerb3` → `generic_camera.svg`)
Candy Crush Saga (`com.king.candycrushsaga.flexion` → `candy_crush_saga.svg`)
CarStream (`maps.jaoloonda.android.aaad_a39e4f` → `youtube.svg`)
DELTARUNE (`com.hadrian.deltarune` → `deltarune.svg`)
Domino's Pizza (`com.daufood.ppt` → `dominos_pizza.svg`)
Edge Lighting (`com.cutestudio.edge.lighting.colors` → `edge_lighting.svg`)
EhViewer (`moe.tarsin.ehviewer.cc` → `ehviewer.svg`)
Ente Locker (`io.ente.locker.fdroid` → `ente_locker.svg`)
FM Radio (`com.eurekateam.fmradio` → `generic_fm_radio.svg`)
2 × Fulguris (`net.slions.fulguris.full.playstore` → `fulguris.svg`)
Gboard (`dev.jason.com.google.android.inputmethod.latin` → `gboard.svg`)
GLO (`com.lknninex.glo` → `glo.svg`)
Granny: Legacy (`com.OmegaMegaGigalIntel.GrannyLegacy` → `granny.svg`)
Granny: Legacy (`com.OmegaMegaGigaIntel.Granny` → `granny.svg`)
Granny: Legacy (`com.OmegaMegaGigaIntel.Grannymenu` → `granny.svg`)
Habit Tracker (`com.reveny.habittracker` → `vervedo.svg`)
HappyMod (`com.happymod.app` → `happymod.svg`)
Instagram (`com.aeroinsta.android` → `instagram.svg`)
InstallerX Revived (`com.android.packageinstaller` → `installerx.svg`)
Ivy Wallet (`com.ivy.wallet.debug` → `ivy_wallet.svg`)
KernelSU (`com.kowx712.supermanager` → `kernelsu.svg`)
Key Attestation (`io.github.qwq233.keyattestation` → `key_attestation.svg`)
Lawnchair (`com.zte.mifavor.launcher` → `lawnchair.svg`)
Loklok (`com.risa.umbra` → `loklok.svg`)
Loklok (`com.woden.celestis` → `loklok.svg`)
LX Music (`wj.bcngmr.ykztj.mldvhy` → `lx_music.svg`)
Mi Claro (`com.clarord.miclaro` → `mi_claro.svg`)
Mi Home (`com.xiaomi.smarthome.tv.global4` → `mi_home.svg`)
Minecraft (`com.mojang.mine261301` → `minecraft.svg`)
Mini Militia (`com.minimilitia.undeectablemod.byneerajmods` → `mini_militia.svg`)
Money Manager (`ru.innim.my_finance` → `money_manager.svg`)
MovieBox (`com.yomobigroup.chat` → `moviebox.svg`)
MovieBox (`com.community.mbox.afen` → `moviebox.svg`)
MovieBox (`com.community.mbox.affr` → `moviebox.svg`)
Music (`com.vayunmathur.music` → `music_player.svg`)
My Airtel (`com.samsung.android.airtel.stubapp` → `my_airtel.svg`)
My BMW (`de.bmw.connected.mobile20.cn` → `my_bmw.svg`)
My HUAWEI (`com.huawei.it.myhuawei` → `my_huawei.svg`)
Netto (`com.mousquetaires.netto` → `netto.svg`)
NextDNS (`com.example.nextdns` → `nextdns.svg`)
NPatch (`top.nkbe.npatch` → `lspatch_lsposed.svg`)
OpenConnect (`com.github.digitalsoftwaresolutions.openconnect` → `openconnect.svg`)
Password Store (`app.passwordstore.pando85` → `password_store.svg`)
Password Store (`app.passwordstore.agrahn` → `password_store.svg`)
PDF Reader (`com.pdfreaderapp.alldocumentreader.pdfviewer` → `generic_pdf_square.svg`)
PDF Reader (`com.pdfreader.editor.viewer.pdfviewer` → `generic_pdf_square.svg`)
PikaShow (`com.pikashow.mobile` → `pikashow.svg`)
Piko Instagram (`com.instagram.android.piko` → `instagram.svg`)
Proton VPN (`ch.protonvpn.android.morphe` → `proton_vpn.svg`)
QR &amp;amp; Barcode Scanner (`com.vtool.qrcodereader.barcodescanner` → `generic_qr_reader.svg`)
Quotex (`io.quotex.x` → `quotex.svg`)
ReFra (`com.dot.gallery.gplay` → `refra.svg`)
Score! Hero (`com.firsttouchgames.hero2` → `score_hero.svg`)
Shapez (`com.playdigious.shapez.epic` → `shapez.svg`)
Solitaire (`com.netflix.NGP.Solitaire` → `generic_solitaire.svg`)
Sound Meter (`com.pony.decibelmeter.soundmeter` → `sound_meter.svg`)
Tomb of the Mask (`com.netflix.NGP.tombofthemask` → `tomb_of_the_mask.svg`)
UniCredit (`be.aion.android.app` → `unicredit.svg`)
UNIQLO (`com.yek.android.uniqlo` → `uniqlo.svg`)
Winlator (`com.winlatcn` → `winlator.svg`)
YouTtube Music (`com.morphe.youtube.music` → `generic_player.svg`)
YouTube (`com.morphe.youtube` → `youtube.svg`)
YouTube Morphe (`yt.morphe.noname.exe` → `morphe.svg`)