### PR TITLE
+4 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -2192,6 +2192,7 @@
   <item component="ComponentInfo{air.au.com.minimega.bonza/air.au.com.minimega.bonza.AIRAppEntry}" drawable="bonza_word_puzzle" name="Bonza Word Puzzle" />
   <item component="ComponentInfo{enterprises.dating.boo/dating.boo.MainActivity}" drawable="boo" name="Boo" />
   <item component="ComponentInfo{enterprises.dating.boo/enterprises.dating.boo.MainActivity}" drawable="boo" name="Boo" />
+  <item component="ComponentInfo{enterprises.dating.boo/enterprises.dating.boo.MainActivityDefault}" drawable="boo" name="Boo" />
   <item component="ComponentInfo{com.github.axet.bookreader/com.github.axet.bookreader.activities.MainActivity}" drawable="book_reader" name="Book Reader" />
   <item component="ComponentInfo{ua.acclorite.book_story/ua.acclorite.book_story.Activity}" drawable="books_story" name="Book's Story" />
   <item component="ComponentInfo{ua.acclorite.book_story/ua.acclorite.book_story.presentation.main.MainActivity}" drawable="books_story" name="Book's Story" />
@@ -3123,6 +3124,7 @@
   <item component="ComponentInfo{com.casadosaber.digital/com.casadosaber.digital.MainActivity}" drawable="casa_do_saber_plus" name="Casa do Saber +" />
   <item component="ComponentInfo{it.casa.app/it.casa.app.MainActivity}" drawable="casa_it" name="Casa.it" />
   <item component="ComponentInfo{com.novapontocom.casasbahia/br.concrete.base.ui.SplashActivity}" drawable="casas_bahia" name="Casas Bahia" />
+  <item component="ComponentInfo{com.novapontocom.casasbahia/com.novapontocom.casasbahia.LauncherDefault}" drawable="casas_bahia" name="Casas Bahia" />
   <item component="ComponentInfo{com.squareup.cash/com.squareup.cash.ui.MainActivity}" drawable="cash_app" name="Cash App" />
   <item component="ComponentInfo{com.cashbooknew/com.cashbooknew.MainActivity}" drawable="cashbook" name="CashBook" />
   <item component="ComponentInfo{com.cashbooknew/com.cashbooknew.SplashScreen}" drawable="cashbook" name="CashBook" />
@@ -14275,6 +14277,8 @@
   <item component="ComponentInfo{com.qobuz.music/com.qobuz.android.mobile.app.refont.screen.launch.LauncherActivity}" drawable="qobuz" name="Qobuz" />
   <item component="ComponentInfo{com.qobuz.music/com.qobuz.music.refont.screen.launch.LauncherActivity}" drawable="qobuz" name="Qobuz" />
   <item component="ComponentInfo{com.qobuz.music/com.qobuz.music.ui.LauncherActivity}" drawable="qobuz" name="Qobuz" />
+  <item component="ComponentInfo{com.qobuz.music/com.qobuz.android.mobile.app.IconGold}" drawable="qobuz" name="Qobuz" />
+  <item component="ComponentInfo{com.qobuz.music/com.qobuz.android.mobile.app.IconDark}" drawable="qobuz" name="Qobuz" />
   <item component="ComponentInfo{eu.qonto.qonto/com.qonto.qonto.ui.login.LoginActivity}" drawable="qonto" name="Qonto" />
   <item component="ComponentInfo{com.qooapp.qoohelper/com.qooapp.qoohelper.arch.welcome.WelcomeActivity}" drawable="qooapp" name="QooApp" />
   <item component="ComponentInfo{com.qooapp.qoohelper/com.qooapp.qoohelper.arch.welcome.BirthdayAlias}" drawable="qooapp" name="QooApp" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
Boo (`enterprises.dating.boo` → `boo.svg`)
Casas Bahia (`com.novapontocom.casasbahia` → `casas_bahia.svg`)
2 × Qobuz (`com.qobuz.music` → `qobuz.svg`)