### PR TITLE
+4 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -13600,6 +13600,7 @@
   <item component="ComponentInfo{com.guozhigq.pilipala/com.guozhigq.pilipala.MainActivity}" drawable="pilipala" name="PiliPala" />
   <item component="ComponentInfo{com.guozhigq.pilipala/com.ryanheise.audioservice.AudioServiceActivity}" drawable="pilipala" name="PiliPala" />
   <item component="ComponentInfo{com.example.piliplus/com.example.piliplus.MainActivity}" drawable="piliplus" name="PiliPlus" />
+  <item component="ComponentInfo{tv.danmaku.bili/tv.danmaku.bili.MainActivity}" drawable="piliplus" name="PiliPlusX" />
   <item component="ComponentInfo{com.pillars.pillars/com.pillars.pillars.MainActivity}" drawable="pillars" name="Pillars" />
   <item component="ComponentInfo{com.cyb3rko.pincredible/com.cyb3rko.pincredible.MainActivityWeather}" drawable="pincredible" name="PINcredible" />
   <item component="ComponentInfo{com.cyb3rko.pincredible/com.cyb3rko.pincredible.MainActivityDefault}" drawable="pincredible" name="PINcredible" />
@@ -14429,6 +14430,7 @@
   <item component="ComponentInfo{com.teskann.quax/com.teskann.quax.MainActivity}" drawable="quax" name="QuaX" />
   <item component="ComponentInfo{com.hero.iot/com.hero.iot.ui.splash.LoadingActivity}" drawable="qubo" name="Qubo" />
   <item component="ComponentInfo{m.hero.iot/com.hero.iot.ui.splash.LoadingActivity}" drawable="qubo" name="Qubo" />
+  <item component="ComponentInfo{com.hero.iot/com.hero.iot.ui.splash.SplashActivity}" drawable="qubo" name="Qubo" />
   <item component="ComponentInfo{com.qubotracker.iot/app.qubotracker.iot.ui.splash.SplashActivity}" drawable="qubo" name="Qubo Go" />
   <item component="ComponentInfo{com.querodelivery/com.querodelivery.MainActivity}" drawable="quero_delivery" name="quero delivery" />
   <item component="ComponentInfo{com.querodelivery/com.querodelivery.SplashActivity}" drawable="quero_delivery" name="quero delivery" />
@@ -19400,6 +19402,7 @@
   <item component="ComponentInfo{com.snowcorp.vita/com.snow.stuckyi.presentation.splash.SplashActivity}" drawable="vita" name="VITA" />
   <item component="ComponentInfo{com.vitastudio.mahjong/com.meevii.vitastudio.VitaDelegateActivity}" drawable="generic_mahjong" name="Vita Mahjong" />
   <item component="ComponentInfo{org.vita3k.emulator/org.vita3k.emulator.Emulator}" drawable="vita3k" name="Vita3K" />
+  <item component="ComponentInfo{org.vita3k.emulator/org.vita3k.emulator.MainActivity}" drawable="vita3k" name="Vita3K" />
   <item component="ComponentInfo{org.vita3k.emulator.ikhoeyZX/org.vita3k.emulator.Emulator}" drawable="vita3k" name="Vita3K ZX" />
   <item component="ComponentInfo{app.vitune.android/app.vitune.android.MainActivity}" drawable="vitune" name="ViTune" />
   <item component="ComponentInfo{app.vitune.android.nightly/app.vitune.android.MainActivity}" drawable="vitune_nightly" name="ViTune Nightly" />
@@ -20280,6 +20283,7 @@
   <item component="ComponentInfo{com.twitter.android/com.twitter.subscriptions.appicon.implementation.seasonal_icon20}" drawable="x" name="X" />
   <item component="ComponentInfo{com.twitter.android/com.yrwl.admanager.bytedance.SplashActivity}" drawable="x" name="X" />
   <item component="ComponentInfo{com.twitter.androie/com.twitter.androie.StartActivity}" drawable="x" name="X" />
+  <item component="ComponentInfo{com.twitter.android/com.x.android.main.MainActivity}" drawable="x" name="X" />
   <item component="ComponentInfo{com.twitter.aeromod/com.twitter.aeromod.StartActivity}" drawable="x" name="X Aeromod" />
   <item component="ComponentInfo{video.downloader.tiktok.instagram.file.saver.vault/com.videodownloader.main.ui.activity.LandingActivity}" drawable="x_downloader" name="X Downloader" />
   <item component="ComponentInfo{io.hexman.xiconchanger/io.hexman.xiconchanger.activity.SplashActivity}" drawable="x_icon_changer" name="X Icon Changer" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
PiliPlusX (`tv.danmaku.bili` → `piliplus.svg`)
Qubo (`com.hero.iot` → `qubo.svg`)
Vita3K (`org.vita3k.emulator` → `vita3k.svg`)
X (`com.twitter.android` → `x.svg`)