### PR TITLE
Fix clock icons not showing on Moto Launcher

### DIFF
--- a/svg-processor/src/main/kotlin/app/lawnchair/lawnicons/helper/SvgFilesProcessor.kt
+++ b/svg-processor/src/main/kotlin/app/lawnchair/lawnicons/helper/SvgFilesProcessor.kt
@@ -117,13 +117,15 @@ object SvgFilesProcessor {
             .addAttribute("xmlns:android", "http://schemas.android.com/apk/res/android")
         root.addElement("background")
             .addAttribute("android:drawable", bgColor)
-        root.addElement("foreground").addElement("inset")
+        root.addElement("foreground").addElement("layer-list").addElement("item")
+            .addElement("inset")
             .addAttribute("android:inset", "32%")
             .addAttribute(
                 "android:drawable",
                 "@drawable/" + FilenameUtils.getBaseName(foregroundXml),
             )
-        root.addElement("monochrome").addElement("inset")
+        root.addElement("monochrome").addElement("layer-list").addElement("item")
+            .addElement("inset")
             .addAttribute("android:inset", "28%")
             .addAttribute(
                 "android:drawable",


### PR DESCRIPTION
## Problem

On Motorola devices, the stock launcher (`com.motorola.launcher3`) treats clock apps specially: it wraps their icon in a ClockDrawableWrapper that casts the adaptive icon's foreground to a LayerDrawable.

Lawnicons generated clock icons with a plain <inset> foreground, which inflates to an InsetDrawable. The cast failed with a ClassCastException, which made the launcher fall back to the stock system icon — so Lawnicons clock icons were never displayed.

## Fix

In SvgFilesProcessor.createAdaptive, wrap the `<inset>` foreground/monochrome in a `<layer-list><item>`. The foreground now inflates to a LayerDrawable, matching what the launcher expects.

```xml
<!-- before -->
<foreground><inset android:inset="32%" .../></foreground>

<!-- after -->
<foreground>
  <layer-list><item><inset android:inset="32%" .../></item></layer-list>
</foreground>
```

This applies to all icons uniformly, and the visuals are unchanged since the layer-list contains only one item with the same inset.

## Verification

The root-cause analysis was done with LLM assistance by inspecting decompiled launcher sources and logcat. The fix itself was built, installed on a Motorola device, and confirmed working there: the Lawnicons clock icon now displays and no ClassCastException appears in logcat.

<img width="1080" height="679" alt="photo_2026-08-02_18-00-12" src="https://github.com/user-attachments/assets/ce1a35bd-2186-4a9d-a023-3489bec2ebeb" />