### PR TITLE
+39 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -208,6 +208,7 @@
   <item component="ComponentInfo{jp.chikaharu11.instant_drumpad_tr808/jp.chikaharu11.instant_drumpad_tr808.MainActivity}" drawable="generic_grid_3x3" name="808 Drum Pad" />
   <item component="ComponentInfo{com.ilixa.ebp/com.ilixa.ebp.ui.MainActivity}" drawable="_8bit_photo_lab" name="8Bit Photo Lab" />
   <item component="ComponentInfo{com.abitdo.advance/com.abitdo.advance.activity.SearchActivity}" drawable="_8bitdo" name="8BitDo" />
+  <item component="ComponentInfo{com.bbitdo.advanceandroidv2/com.bbitdo.advanceandroidv2.activity.MainActivity}" drawable="_8bitdo" name="8BitDo Ultimate Software V2" />
   <item component="ComponentInfo{nl.browney.nintydayschallenge/nintydayschallenge.MainActivity}" drawable="_90_day_challenge" name="90 Day Challenge" />
   <item component="ComponentInfo{tq.tech.Fps/tq.tech.Fps.splashscreen}" drawable="_90_fps_plus_120_fps" name="90 FPS + 120 FPS" />
   <item component="ComponentInfo{nl.negentwee/nl.negentwee.ui.MainActivity}" drawable="_9292" name="9292" />
@@ -1390,6 +1391,7 @@
   <item component="ComponentInfo{com.zenthek.autozen/app.ui.main.ActivitySplashScreen}" drawable="autozen" name="AutoZen" />
   <item component="ComponentInfo{cz.jamesdeer.free.autotest/cz.jamesdeer.test.activity.SplashScreenActivity}" drawable="autoskola" name="Autoškola" />
   <item component="ComponentInfo{cz.jamesdeer.free.autotest/cz.jamesdeer.test.activity.MainActivity}" drawable="autoskola" name="Autoškola" />
+  <item component="ComponentInfo{cz.jamesdeer.autotest/cz.jamesdeer.test.activity.SplashScreenActivity}" drawable="autoskola" name="Autoškola" />
   <item component="ComponentInfo{org.oxycblt.auxio/org.oxycblt.auxio.MainActivity}" drawable="auxio" name="Auxio" />
   <item component="ComponentInfo{com.kddi.auwellnesspartner/com.kddi.au_wellness.MainActivity}" drawable="au_wellness" name="auウェルネス ~~ au Wellness" />
   <item component="ComponentInfo{com.kddi.android.aumail/com.kddi.android.aumail.MainActivity}" drawable="au_mail" name="auメール ~~ au mail" />
@@ -1820,6 +1822,7 @@
   <item component="ComponentInfo{it.mirko.beta/it.mirko.beta.login.LoginActivity}" drawable="beta_maniac" name="Beta Maniac" />
   <item component="ComponentInfo{it.mirko.beta/it.mirko.beta.login.LoadingActivity}" drawable="beta_maniac" name="Beta Maniac" />
   <item component="ComponentInfo{nl.beterdichtbij/nl.beterdichtbij.views.startup.StartupActivity}" drawable="beterdichtbij" name="BeterDichtbij" />
+  <item component="ComponentInfo{nl.beterDichtbij/nl.beterDichtbij.views.startup.StartupActivity}" drawable="beterdichtbij" name="BeterDichtbij" />
   <item component="ComponentInfo{be.casperverswijvelt.unifiedinternetqs/be.casperverswijvelt.unifiedinternetqs.ui.MainActivity}" drawable="better_internet_tiles" name="Better Internet Tiles" />
   <item component="ComponentInfo{app.lawnchair.betterlawnicons/app.lawnchair.betterlawnicons.MainActivity}" drawable="lawnicons" name="Better Lawnicons" />
   <item component="ComponentInfo{com.aboutmycode.betteropenwith/com.aboutmycode.betteropenwith.HandlerListActivity}" drawable="better_open_with" name="Better Open With" />
@@ -1869,6 +1872,9 @@
   <item component="ComponentInfo{me.xizzhu.android.joshua/me.xizzhu.android.joshua.LauncherActivity}" drawable="generic_bible" name="Bible" />
   <item component="ComponentInfo{com.andromo.dev137436.app249505/com.ryanheise.audioservice.AudioServiceActivity}" drawable="generic_bible" name="Bible (Douay-Rheims Version)" />
   <item component="ComponentInfo{app.bible.lite.offline/youversion.bible.app.MainActivity}" drawable="generic_bible" name="Bible App Lite" />
+  <item component="ComponentInfo{com.azwstudios.theholybible.kjv/com.azwstudios.theholybible.MainActivity}" drawable="generic_bible" name="Bible KJV" />
+  <item component="ComponentInfo{com.hmobile.biblekjv/com.hmobile.biblekjv.MainActivity}" drawable="generic_bible" name="Bible KJV" />
+  <item component="ComponentInfo{com.azwstudios.theholybible.frls/com.azwstudios.theholybible.MainActivity}" drawable="generic_bible" name="Bible Louis Segond" />
   <item component="ComponentInfo{com.offline.bible/com.offline.bible.IconDefault}" drawable="generic_bible" name="Bible Offline" />
   <item component="ComponentInfo{com.bestweatherfor.bibleoffline_pt_ra/com.bestweatherfor.bibleoffline_pt_ra.bibleoffline.splash.Splash}" drawable="generic_bible" name="Bible Offline KJV with Audio" />
   <item component="ComponentInfo{org.bsfinternational.bsfapp/org.bsfinternational.bsfapp.MainActivity}" drawable="bible_study_fellowship" name="Bible Study Fellowship" />
@@ -3434,6 +3440,7 @@
   <item component="ComponentInfo{com.cinemark.mobile/crc64687967b3ed425736.MainActivity}" drawable="cinemark" name="Cinemark" />
   <item component="ComponentInfo{com.cinemarkca.cinemarkapp/com.cinepapaya.ckc_app_flutter.MainActivity}" drawable="cinemark" name="Cinemark" />
   <item component="ComponentInfo{com.cinemark/com.cinemark.MainActivity}" drawable="cinemark" name="Cinemark" />
+  <item component="ComponentInfo{com.cinepapaya.cinemarkBolivia/com.cinepapaya.ckc_app_flutter.MainActivity}" drawable="cinemark" name="Cinemark" />
   <item component="ComponentInfo{pt.nos.cinemas/pt.nos.cinemas.MainActivity}" drawable="cinemas_nos" name="Cinemas NOS" />
   <item component="ComponentInfo{com.cinemex/com.cinemex.cinemex.views.activities.SplashActivity}" drawable="cinemex" name="Cinemex" />
   <item component="ComponentInfo{com.fivemobile.cineplex/com.cineplex.MainActivity}" drawable="cineplex" name="Cineplex" />
@@ -3874,6 +3881,7 @@
   <item component="ComponentInfo{no.coop.members/no.coop.app2020.MainActivity}" drawable="coop" name="Coop" />
   <item component="ComponentInfo{se.nansen.coop/se.nansen.coop.feature.splash.SplashActivity}" drawable="coop" name="Coop" />
   <item component="ComponentInfo{dk.coop.coopplus/dk.coop.coopplus.splash.SplashActivity}" drawable="coop" name="Coop" />
+  <item component="ComponentInfo{ee.coop.shopping.app/ee.coop.shopping.app.MainActivity}" drawable="coop" name="Coop" />
   <item component="ComponentInfo{ca.qc.quebec.ville.copilote/ca.qc.quebec.ville.copilote.MainActivity}" drawable="copilote" name="Copilote" />
   <item component="ComponentInfo{com.coppel.coppelapp/com.coppel.coppelapp.splash.presentation.SplashActivity}" drawable="bancoppel" name="Coppel" />
   <item component="ComponentInfo{com.coppel.coppelapp/oGCSj5.mKCAZ2.bF7je1.afFQS0.utBYV9.or0VD5}" drawable="bancoppel" name="Coppel" />
@@ -3908,6 +3916,8 @@
   <item component="ComponentInfo{intl.costco.com.mobile.japan/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{intl.costco.com.mobile.australia/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{intl.costco.com.mobile.uk/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
+  <item component="ComponentInfo{intl.costco.com.mobile.newzealand/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
+  <item component="ComponentInfo{intl.costco.com.mobile.spain/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{com.couchsurfing.mobile.android/com.couchsurfing.mobile.ui.WelcomeActivity}" drawable="couchsurfing" name="Couchsurfing" />
   <item component="ComponentInfo{com.couchsurfing.mobile.android/com.couchsurfing.mobile.MainActivity}" drawable="couchsurfing" name="Couchsurfing" />
   <item component="ComponentInfo{com.jupli.countdowntoanything/com.jupli.countdowntoanything.MainActivity}" drawable="countdown_to_anything" name="Countdown To Anything" />
@@ -4171,6 +4181,7 @@
   <item component="ComponentInfo{dk.dba.android/com.schibsted.nmp.NmpActivity}" drawable="dba" name="DBA" />
   <item component="ComponentInfo{com.dbna.app/com.dbna.app.MainActivity}" drawable="dbna" name="DBNA" />
   <item component="ComponentInfo{com.sparkslab.dcardreader/com.sparkslab.dcardreader.screen.splash.SplashActivity}" drawable="dcard" name="Dcard" />
+  <item component="ComponentInfo{com.dcard.freedom/com.dcard.freedom.product_1}" drawable="dcard" name="Dcard X" />
   <item component="ComponentInfo{com.paprbit.dcoder/com.paprbit.dcoder.splash.Splash}" drawable="dcoder" name="Dcoder" />
   <item component="ComponentInfo{com.dctimer/com.dctimer.activity.MainActivity}" drawable="cube_solver" name="DCTimer" />
   <item component="ComponentInfo{com.projectfinance.android.dcu/com.projectfinance.app.modules.general.StartupActivity}" drawable="dcu" name="DCU" />
@@ -4587,6 +4598,7 @@
   <item component="ComponentInfo{com.dolby.dax2appUI/com.motorola.dlbafx.MotoMainActivity}" drawable="dolby_atmos_moto" name="Dolby Atmos Moto" />
   <item component="ComponentInfo{com.motorola.dolby.dolbyui.ui/com.motorola.dolby.dolbyui.ui.LauncherActivity}" drawable="dolby" name="Dolby Audio" />
   <item component="ComponentInfo{com.dolby.dolby234/com.dolby.sessions.Launcher}" drawable="dolby" name="Dolby On" />
+  <item component="ComponentInfo{com.dolby.exphub/com.dolby.exphub.namespace.MainActivity}" drawable="dolby" name="Dolby XP" />
   <item component="ComponentInfo{com.davexp.dollify/com.unity3d.player.UnityPlayerActivity}" drawable="dollify" name="Dollify" />
   <item component="ComponentInfo{mobi.mgeek.TunnyBrowser/mobi.mgeek.TunnyBrowser.SplashActivity}" drawable="dolphin_browser" name="Dolphin Browser" />
   <item component="ComponentInfo{org.dolphinemu.dolphinemu/org.dolphinemu.dolphinemu.DolphinEmulator}" drawable="dolphin_emulator" name="Dolphin Emulator" />
@@ -4991,6 +5003,7 @@
   <item component="ComponentInfo{com.Etisalat.ETIDA/com.etisalat.etida.composerevamp.splash.presentation.SplashActivity}" drawable="eand" name="e&amp;" />
   <item component="ComponentInfo{com.etisalat.ewallet/com.etisalat.ewallet.ui.splash.SplashActivity}" drawable="eand" name="e&amp;" />
   <item component="ComponentInfo{com.etisalat.flous/com.etisalat.flous.MainActivity}" drawable="eand" name="e&amp;" />
+  <item component="ComponentInfo{ae.etisalat.smb/ae.etisalat.smb.presentation.splash.SplashActivity}" drawable="eand" name="e&amp;amp; Business UAE" />
   <item component="ComponentInfo{jp.konami.eam.link/jp.konami.eam.link.MainActivity}" drawable="e_amusement" name="e-amusement" />
   <item component="ComponentInfo{com.eboks.activities/dk.eboks.app.presentation.ui.start.screens.StartActivity}" drawable="e_boks_dk" name="e-Boks.dk" />
   <item component="ComponentInfo{cn.gov.pbc.dcep/com.alipay.mobile.quinox.LauncherActivity}" drawable="e_cny" name="e-CNY" />
@@ -5102,11 +5115,13 @@
   <item component="ComponentInfo{de.edeka.genuss/edeka.digital.app.edeka2020.ui.SplashActivity}" drawable="edeka" name="EDEKA" />
   <item component="ComponentInfo{dev.eden.eden_emulator/org.yuzu.yuzu_emu.ui.main.MainActivity}" drawable="eden" name="Eden" />
   <item component="ComponentInfo{com.miHoYo.Yuanshen/org.yuzu.yuzu_emu.ui.main.MainActivity}" drawable="eden" name="Eden" />
+  <item component="ComponentInfo{dev.legacy.eden_emulator/org.yuzu.yuzu_emu.ui.main.MainActivity}" drawable="eden" name="Eden Legacy" />
   <item component="ComponentInfo{es.edenred/es.edenred.LauncherActivity}" drawable="edenred" name="Edenred" />
   <item component="ComponentInfo{com.edenred.mobiletr/com.edenred.mobiletr.activity.MainActivity}" drawable="edenred" name="Edenred" />
   <item component="ComponentInfo{com.edenred.mobiletr/com.edenred.login.ui.activity.LoginActivity}" drawable="edenred" name="Edenred" />
   <item component="ComponentInfo{edenred.uy.mobile.beneficiaries/edenred.uy.mobile.beneficiaries.ui.splash.SplashActivity}" drawable="edenred" name="Edenred" />
   <item component="ComponentInfo{com.edenred.TicketRestaurant/com.path.ticket.ui.splash.ForceSplashActivity}" drawable="edenred" name="Edenred" />
+  <item component="ComponentInfo{com.pgs.ticket.rikskortet/com.pgs.ticket.rikskortet.features.splash.SplashActivity}" drawable="edenred" name="Edenred" />
   <item component="ComponentInfo{edenred.mx.mobile.services/edenred.mx.mobile.services.MainActivity}" drawable="edenred_wallet" name="Edenred Wallet" />
   <item component="ComponentInfo{com.edesur.movil/com.edesur.movil.MainActivity}" drawable="enel" name="Edesur" />
   <item component="ComponentInfo{com.edf.mobile/com.edf.mobile.SplashActivity}" drawable="edf" name="EDF" />
@@ -5342,6 +5357,7 @@
   <item component="ComponentInfo{it.esselunga.mobile/it.esselunga.mobile.activity.EsselungaActivity}" drawable="esselunga" name="Esselunga" />
   <item component="ComponentInfo{com.sameerasw.essentials/com.sameerasw.essentials.MainActivity}" drawable="essentials" name="Essentials" />
   <item component="ComponentInfo{com.firstdata.mpl/com.comarch.clm_flutter.MainActivity}" drawable="esso" name="Esso" />
+  <item component="ComponentInfo{com.exxonmobil.esso.sg/com.esso.base.activity.SplashActivity}" drawable="esso" name="Esso" />
   <item component="ComponentInfo{lt.registrucentras.esveikata_app/lt.registrucentras.esveikata.MainActivity}" drawable="esveikata" name="esveikata" />
   <item component="ComponentInfo{id.mjs.etalaseapp/id.mjs.etalaseapp.ui.splashscreen.SplashScreenActivity}" drawable="etalaseapps" name="EtalaseApps" />
   <item component="ComponentInfo{eu.depau.etchdroid/eu.depau.etchdroid.ui.activities.StartActivity}" drawable="etchdroid" name="EtchDroid" />
@@ -7486,6 +7502,7 @@
   <item component="ComponentInfo{com.netflix.NGP.GTAViceCityDefinitiveEdition/com.android.support.MainActivity}" drawable="grand_theft_auto_vice_city" name="Grand Theft Auto: Vice City" />
   <item component="ComponentInfo{com.dvloper.granny/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny" />
   <item component="ComponentInfo{com.dvloper.granny/com.dvloper.granny.UnityPlayerActivity}" drawable="granny" name="Granny" />
+  <item component="ComponentInfo{com.dvloper.granny.gelin_hs.cheat/com.android.support.MainActivity}" drawable="granny" name="Granny" />
   <item component="ComponentInfo{com.OmegaMegaGigalIntel.GrannyLegacy/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny: Legacy" />
   <item component="ComponentInfo{com.OmegaMegaGigaIntel.Granny/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny: Legacy" />
   <item component="ComponentInfo{com.OmegaMegaGigaIntel.Grannymenu/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny: Legacy" />
@@ -7590,6 +7607,7 @@
   <item component="ComponentInfo{com.gspace.android/com.gspace.android.ui.activity.SplashActivity}" drawable="manage_apps_shortcut" name="GSpace" />
   <item component="ComponentInfo{com.osharemaker/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="gu" name="GU" />
   <item component="ComponentInfo{com.osharemaker/com.uniqlo.ja.catalogue.view.mobile.home.HomeActivity}" drawable="gu" name="GU" />
+  <item component="ComponentInfo{com.gu_global.customer.app.tw/com.uniqlo.ja.catalogue.presentation.LoadingActivity}" drawable="gu" name="GU" />
   <item component="ComponentInfo{com.app.phone.mobileez4view/com.elsw.ezviewer.controller.activity.WelcomeAct}" drawable="hd_camera" name="Guard Viewer" />
   <item component="ComponentInfo{com.crypto.multiwallet/com.crypto.multiwallet.MainActivity}" drawable="guarda" name="Guarda" />
   <item component="ComponentInfo{com.kakaogames.gdts/com.kakaogame.KGUnityPlayerActivity}" drawable="guardian_tales" name="Guardian Tales" />
@@ -8154,6 +8172,7 @@
   <item component="ComponentInfo{jp.ne.ibis.ibispaintx.app.hms/jp.ne.ibis.ibispaintx.app.InitializeCheckActivity}" drawable="ibis_paint" name="ibis Paint X" />
   <item component="ComponentInfo{atws.app/tws.activity.launcher.LauncherActivity}" drawable="ibkr" name="IBKR" />
   <item component="ComponentInfo{atws.app/atws.activity.launcher.LauncherActivity}" drawable="ibkr" name="IBKR" />
+  <item component="ComponentInfo{com.ibkr.gt.app/com.ibkr.gt.activity.launcher.LauncherActivity}" drawable="ibkr" name="IBKR GlobalTrader" />
   <item component="ComponentInfo{com.ibm.security.verifyapp/com.ibm.security.verifyapp.activities.LaunchActivity}" drawable="ibm_verify" name="IBM Verify" />
   <item component="ComponentInfo{se.ica.handla/se.ica.handla.launcher.LauncherActivity}" drawable="ica" name="ICA" />
   <item component="ComponentInfo{ph.com.toplogic.insularhealth/ph.com.toplogic.insularhealth.activity.initialactivity.LandingActivity}" drawable="icare" name="iCare" />
@@ -8689,6 +8708,7 @@
   <item component="ComponentInfo{in.sunilpaulmathew.izzyondroid/in.sunilpaulmathew.izzyondroid.MainActivity}" drawable="izzyondroid" name="IzzyOnDroid" />
   <item component="ComponentInfo{com.belbim.istanbulkart/com.belbim.istanbulkart.MainActivity}" drawable="istanbulkart" name="İstanbulkart" />
   <item component="ComponentInfo{com.pozitron.iscep/com.pozitron.iscep.features.prelogin.splash.SplashActivity}" drawable="iscep" name="İşCep" />
+  <item component="ComponentInfo{com.jtexpress.MyClient/com.jtexpress.MyClient.ui.SplashActivity}" drawable="j_and_t" name="J&amp;amp;T" />
   <item component="ComponentInfo{com.msd.JTClient/com.msd.JTClient.ui.SplashActivity}" drawable="j_and_t" name="J&amp;T" />
   <item component="ComponentInfo{com.jt.indonesiaexpress/com.jt.indonesiaexpress.ui.activity.SplashActivity}" drawable="j_and_t" name="J&amp;T CARGO" />
   <item component="ComponentInfo{com.jtexpress.PhClient/com.jtexpress.PhClient.ui.SplashActivity}" drawable="j_and_t" name="J&amp;T Express" />
@@ -9113,6 +9133,7 @@
   <item component="ComponentInfo{com.kia.connect.eu/hmns.global.mobile.pages.splash.SplashActivity}" drawable="kia_connect" name="Kia Connect" />
   <item component="ComponentInfo{com.kiacanada.uvo/io.jetbridge.kia_connect.MainActivity}" drawable="kia_connect" name="Kia Connect" />
   <item component="ComponentInfo{com.kick.mobile/com.kick.mobile.MainActivity}" drawable="kick" name="Kick" />
+  <item component="ComponentInfo{com.kick.streaming/com.kick.streaming.MainActivity}" drawable="kick" name="Kick" />
   <item component="ComponentInfo{com.netbiscuits.kicker/com.tickaroo.kicker.purabo.onboarding.KPurAboOnboardingActivity}" drawable="kicker" name="kicker" />
   <item component="ComponentInfo{com.netbiscuits.kicker/com.netbiscuits.kicker.Kicker}" drawable="kicker" name="kicker" />
   <item component="ComponentInfo{com.netbiscuits.kicker/com.netbiscuits.kicker.splash.SplashActivity}" drawable="kicker" name="kicker" />
@@ -9152,6 +9173,7 @@
   <item component="ComponentInfo{com.xxi.film.kitanonton/com.xxi.film.kitanonton.MainActivity}" drawable="just_player" name="KITA NONTON" />
   <item component="ComponentInfo{no.terki.kitchn/no.terki.kitchn.MainActivity}" drawable="kitch_n" name="Kitch´n" />
   <item component="ComponentInfo{com.yjllq.kito/cn.yujian.MainActivity}" drawable="kito" name="kito" />
+  <item component="ComponentInfo{com.yjllqint.kito/cn.yujian.MainActivity}" drawable="kito" name="Kito" />
   <item component="ComponentInfo{de.kitshn.android/de.kitshn.AppActivity}" drawable="kitshn" name="kitshn" />
   <item component="ComponentInfo{de.kitshn.android.nightly/de.kitshn.AppActivity}" drawable="kitshn_nightly" name="kitshn nightly" />
   <item component="ComponentInfo{com.kivra.Kivra/com.kivra.android.main.HomeActivity}" drawable="kivra" name="Kivra" />
@@ -9520,6 +9542,7 @@
   <item component="ComponentInfo{com.pamsys.lexisaudioeditor/crc641de11b621e6c00bd.MainActivity}" drawable="lexis_audio_editor" name="Lexis Audio Editor" />
   <item component="ComponentInfo{com.pamsys.lexisaudioeditor/crc6474e5e1fb856f6af6.MainActivity}" drawable="lexis_audio_editor" name="Lexis Audio Editor" />
   <item component="ComponentInfo{com.lexus.oneapp/com.toyota.oneapp.ui.splash.SplashActivity}" drawable="lexus" name="Lexus" />
+  <item component="ComponentInfo{com.lexus.oneapp.eu/com.toyota.oneapp.ui.splash.SplashActivity}" drawable="lexus" name="Lexus Link+" />
   <item component="ComponentInfo{nl.tijdschrift.newsstand/com.zinio.app.splash.presentation.activity.SplashActivity}" drawable="lezerij" name="Lezerij" />
   <item component="ComponentInfo{com.lgeil.serviceindia/com.lgeil.serviceindia.MainActivity}" drawable="lg_smartworld" name="LG" />
   <item component="ComponentInfo{com.lge.appcatalog.v2/com.lge.appcatalog.activity.SplashActivity}" drawable="tiktokdownloader" name="LG Aplicativos" />
@@ -9635,9 +9658,11 @@
   <item component="ComponentInfo{com.limbo.emu.main.arm/com.limbo.emu.main.arm.LimboEmuActivity}" drawable="limbo_x86" name="Limbo ARM" />
   <item component="ComponentInfo{com.limbo.emu.mavm/com.limbo.emu.mavm.LimboEmuActivity}" drawable="limbo_x86" name="Limbo VNC x86" />
   <item component="ComponentInfo{com.limbo.emu.mav6/com.limbo.emu.mav6.LimboEmuActivity}" drawable="limbo_x86" name="Limbo VNC x86" />
+  <item component="ComponentInfo{com.limbo.emu.mav7/com.limbo.emu.mav7.LimboEmuActivity}" drawable="limbo_x86" name="Limbo VNC x86" />
   <item component="ComponentInfo{com.limbo.emu.main/com.limbo.emu.main.LimboEmuActivity}" drawable="limbo_x86" name="Limbo x86" />
   <item component="ComponentInfo{com.ProjectMoon.LimbusCompany/com.unity3d.player.UnityPlayerActivity}" drawable="limbus_company" name="Limbus Company" />
   <item component="ComponentInfo{com.limebike/com.limebike.launcher.LauncherActivity}" drawable="lime" name="Lime" />
+  <item component="ComponentInfo{com.panotogomo.olylime/com.panotogomo.olylime.activities.MainActivity}" drawable="lime" name="Lime Icons" />
   <item component="ComponentInfo{app.pinya.lime/app.pinya.lime.ui.view.activity.MainActivity}" drawable="lime_launcher" name="Lime Launcher" />
   <item component="ComponentInfo{com.shopping.limeroad/com.shopping.limeroad.Launcher2Activity}" drawable="limeroad" name="LimeRoad" />
   <item component="ComponentInfo{jp.naver.line.android/jp.naver.line.android.activity.SplashActivity}" drawable="line" name="LINE" />
@@ -10096,6 +10121,7 @@
   <item component="ComponentInfo{pl.vipek.camera2_compatibility_test/pl.vipek.camera2_compatibility_test.MainActivity}" drawable="manual_camera_compatibility" name="Manual Camera Compatibility" />
   <item component="ComponentInfo{com.lensesdev.manual.camera.professional/com.antafunny.burstcamera.MainActivity}" drawable="manual_camera" name="Manual Camera Lite" />
   <item component="ComponentInfo{ca.manulife.MobileGBRS/com.manulife.mobile.gbrs.SplashActivity}" drawable="manulife" name="Manulife" />
+  <item component="ComponentInfo{com.manulife.mpf/io.ionic.starter.MainActivity}" drawable="manulife" name="Manulife" />
   <item component="ComponentInfo{md.point.map/md.point.map.activity.SplashScreenActivity}" drawable="map_md" name="Map.md" />
   <item component="ComponentInfo{io.mapgenie.eldenringmap/io.mapgenie.rdr2map.ui.SplashScreenActivity}" drawable="mapgenie_elden_ring" name="MapGenie: Elden Ring" />
   <item component="ComponentInfo{tech.chatmind/tech.chatmind.MainActivity}" drawable="mapify" name="Mapify" />
@@ -10825,6 +10851,8 @@
   <item component="ComponentInfo{com.hanver.wdsj/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.minecraftpe/com.me.game.pmupdatesdk.MainActivity}" drawable="minecraft" name="Minecraft" />
   <item component="ComponentInfo{com.mojang.mine261301/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
+  <item component="ComponentInfo{com.mojang.minecraftpe.hajsp/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft" />
+  <item component="ComponentInfo{com.mojang.minecraftpet/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft PE" />
   <item component="ComponentInfo{com.mojang.minecrafttrialpe/com.mojang.minecraftpe.MainActivity}" drawable="minecraft" name="Minecraft Trial" />
   <item component="ComponentInfo{com.panu/com.panu.SplashScreenActivity}" drawable="generic_minesweeper" name="Minesweeper" />
   <item component="ComponentInfo{Draziw.Button.Mines/minesweeper.Button.Mines.BoardViewActivity}" drawable="generic_minesweeper" name="Minesweeper" />
@@ -11265,6 +11293,7 @@
   <item component="ComponentInfo{com.yomobigroup.chat/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
   <item component="ComponentInfo{com.community.mbox.afen/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
   <item component="ComponentInfo{com.community.mbox.affr/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
+  <item component="ComponentInfo{com.gargan.abismo/com.gargan.abismo.module_home.HomeActivityNew}" drawable="moviebox" name="MovieBox HD" />
   <item component="ComponentInfo{com.movielab.mobile/com.movielab.MainActivity}" drawable="movielab" name="Movielab" />
   <item component="ComponentInfo{com.moviesanywhere.goo/com.disney.brooklyn.mobile.ui.main.MainActivity}" drawable="movies_anywhere" name="Movies Anywhere" />
   <item component="ComponentInfo{com.parkit.selfcare/com.parkit.selfcare.MainActivity}" drawable="movil_tr" name="Movil-TR" />
@@ -12241,6 +12270,7 @@
   <item component="ComponentInfo{com.picross.nonocross/com.picross.nonocross.MainActivity}" drawable="nonocross" name="Nonocross" />
   <item component="ComponentInfo{com.easybrain.nonogram/com.easybrain.template.SplashActivity}" drawable="nonogram" name="Nonogram" />
   <item component="ComponentInfo{com.easybrain.nonogram/com.easybrain.nonogram.SplashActivity}" drawable="nonogram" name="Nonogram" />
+  <item component="ComponentInfo{com.easybrain.nonogram.color/com.easybrain.template.SplashActivity}" drawable="nonogram" name="Nonogram Color" />
   <item component="ComponentInfo{com.ucdevs.jcross/com.ucdevs.jcross.MainActivity}" drawable="nonograms_katana" name="Nonograms Katana" />
   <item component="ComponentInfo{at.bitfire.nophonespam/at.bitfire.nophonespam.BlacklistActivity}" drawable="nophonespam" name="NoPhoneSpam" />
   <item component="ComponentInfo{jp.nonbili.nora/jp.nonbili.nora.MainActivity}" drawable="nora" name="Nora" />
@@ -14237,6 +14267,7 @@
   <item component="ComponentInfo{com.neuralprisma/com.prisma.starter.StarterActivity}" drawable="prisma" name="Prisma" />
   <item component="ComponentInfo{com.neuralprisma/com.google.android.archive.ReactivateActivity}" drawable="prisma" name="Prisma" />
   <item component="ComponentInfo{com.prisma3D.prisma3D/com.prisma.prismaplugin.UnityPlayerActivityStatusBar}" drawable="prisma3d" name="Prisma3D" />
+  <item component="ComponentInfo{com.prisma3D.prisma3DLegacy/com.prisma.prismaplugin.UnityPlayerActivityStatusBar}" drawable="prisma3d" name="Prisma3D Legacy" />
   <item component="ComponentInfo{com.codigames.idle.prison.empire.manager.tycoon/com.google.firebase.MessagingUnityPlayerActivity}" drawable="prison_empire_tycoon" name="Prison Empire Tycoon" />
   <item component="ComponentInfo{com.kaleedtc.privacium/com.kaleedtc.privacium.MainActivity}" drawable="privacium" name="Privacium" />
   <item component="ComponentInfo{com.stoutner.privacybrowser.standard/com.stoutner.privacybrowser.activities.MainWebViewActivity}" drawable="privacy_browser" name="Privacy Browser" />
@@ -14685,6 +14716,7 @@
   <item component="ComponentInfo{it.rainet/com.raiplayv2.MainActivity}" drawable="raiplay" name="RaiPlay" />
   <item component="ComponentInfo{it.rai.digital.yoyo/it.rai.digital.yoyo.ui.activity.splash.SplashActivity}" drawable="raiplay_yoyo" name="RaiPlay Yoyo" />
   <item component="ComponentInfo{com.ebates/com.ebates.activity.MainActivity}" drawable="rakuten" name="Rakuten" />
+  <item component="ComponentInfo{com.priceminister.buyerapp/com.priceminister.buyerapp.common.activity.SplashScreenActivity}" drawable="rakuten" name="Rakuten" />
   <item component="ComponentInfo{jp.co.rakuten.mobile.rcs/jp.co.rakuten.mobile.rcs.main.launcher.LauncherActivity}" drawable="rakuten_link" name="Rakuten Link" />
   <item component="ComponentInfo{io.floornfts/io.floornfts.MainActivity_Floor}" drawable="rally" name="Rally" />
   <item component="ComponentInfo{com.glgjing.captain/com.glgjing.captain.HomeActivity}" drawable="ram_memory_monitor" name="RAM Memory Monitor" />
@@ -17051,6 +17083,7 @@
   <item component="ComponentInfo{fm.anchor.android/com.spotify.app.s4p.main.applications.s4p.MainActivity}" drawable="spotify_for_creators" name="Spotify for Creators" />
   <item component="ComponentInfo{fm.anchor.android/anchor.MainActivity}" drawable="spotify_for_creators" name="Spotify for Creators" />
   <item component="ComponentInfo{com.spotify.premium/com.spotify.musid.MainActivity}" drawable="spotify" name="Spotify Premium" />
+  <item component="ComponentInfo{com.spotify.music.web/it.deviato.spotifuck.MainActivity}" drawable="spotify" name="Spotify Web" />
   <item component="ComponentInfo{com.spoti.plus/com.spotify.music.MainActivity}" drawable="spotify" name="Spotify X" />
   <item component="ComponentInfo{spoti.plus/com.spotify.music.MainActivity}" drawable="spotify" name="Spotify X" />
   <item component="ComponentInfo{com.spoti/com.spotify.music.MainActivity}" drawable="spotify" name="Spotify X" />
@@ -19224,6 +19257,7 @@
   <item component="ComponentInfo{com.vancity.mobileapp/com.central1.mobileapp.MainActivity}" drawable="vancity" name="Vancity" />
   <item component="ComponentInfo{com.vanguard/com.vanguard.shared.PromoActivity}" drawable="vanguard" name="Vanguard" />
   <item component="ComponentInfo{com.vanguard/com.vanguard.vanguard.activity.impl.MainActivity}" drawable="vanguard" name="Vanguard" />
+  <item component="ComponentInfo{com.vanguard.uk.pi.vanguarduk.playstore/com.vanguard.uk.pi.vanguarduk.ui.MainActivity}" drawable="vanguard" name="Vanguard" />
   <item component="ComponentInfo{com.mattkc.vanilla/com.mattkc.vanilla.VanillaActivity}" drawable="vanilla" name="Vanilla" />
   <item component="ComponentInfo{ch.blinkenlights.android.vanilla/ch.blinkenlights.android.vanilla.LibraryActivity}" drawable="vanilla_music" name="Vanilla Music" />
   <item component="ComponentInfo{com.kyant.vanilla/com.kyant.vanilla.MainActivity}" drawable="vanilla_music_player" name="Vanilla Music Player" />
@@ -20238,6 +20272,8 @@
   <item component="ComponentInfo{com.winlator/com.winlator.MainActivity}" drawable="winlator" name="Winlator" />
   <item component="ComponentInfo{com.winlator.vanilla/com.winlator.cmod.MainActivity}" drawable="winlator" name="Winlator" />
   <item component="ComponentInfo{com.winlatcn/com.winlator.MainActivity}" drawable="winlator" name="Winlator" />
+  <item component="ComponentInfo{com.ludashi.benchmark/com.winlator.cmod.MainActivity}" drawable="winlator" name="Winlator CMOD" />
+  <item component="ComponentInfo{com.winlator.cmod/com.winlator.cmod.MainActivity}" drawable="winlator" name="Winlator CMOD" />
   <item component="ComponentInfo{il.talent.winner/il.talent.winner.MainActivity}" drawable="winner" name="Winner" />
   <item component="ComponentInfo{com.LordHonor.Windows10Simulator/com.unity3d.player.UnityPlayerActivity}" drawable="wins_10_simulator" name="Wins 10 Simulator" />
   <item component="ComponentInfo{com.wire/com.waz.zclient.LaunchActivity}" drawable="wire" name="Wire" />
@@ -20575,6 +20611,7 @@
   <item component="ComponentInfo{com.kapp.youtube.final/com.marverenic.music.activity.HomeActivity}" drawable="ymusic" name="YMusic" />
   <item component="ComponentInfo{com.kapp.youtube.final/com.marverenic.music.ui.library.LibraryActivity}" drawable="ymusic" name="YMusic" />
   <item component="ComponentInfo{com.kapp.youtube.final/com.marverenic.music.ui.youtube.HomeActivity}" drawable="ymusic" name="YMusic" />
+  <item component="ComponentInfo{com.kapp.youtube.finam/com.kapp.youtube.ui.MainActivity}" drawable="ymusic" name="YMusic Clone" />
   <item component="ComponentInfo{com.youneedabudget.evergreen.app/ynab.app.start.StartActivity}" drawable="ynab" name="YNAB" />
   <item component="ComponentInfo{net.beginners.weight.loss.workout.women.yoga.go/com.yogaline.ui.splash.SplashActivity}" drawable="yoga_go" name="Yoga-Go" />
   <item component="ComponentInfo{com.yosmart.yolink/com.yosmart.yolink.MainActivity}" drawable="yolink" name="YoLink" />
@@ -20658,6 +20695,7 @@
   <item component="ComponentInfo{app.revanced.android.apps.youtube.music/app.revanced.android.apps.youtube.music.revanced_original_2}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.android.youtube.music.premium/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="generic_player_pro" name="YouTube Music" />
   <item component="ComponentInfo{com.android.youtube.music.premium/com.android.youtube.music.premium.morphe_original_1}" drawable="generic_player_pro" name="YouTube Music" />
+  <item component="ComponentInfo{ytm.morphe.noname.exe/ytm.morphe.noname.exe.morphe_original_1}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_original_2}" drawable="generic_player" name="YouTube Music Morphe" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_2}" drawable="morphe" name="YouTube Music Morphe" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_3}" drawable="morphe" name="YouTube Music Morphe" />
@@ -20715,6 +20753,7 @@
   <item component="ComponentInfo{com.sirma.mobile.bible.android/com.youversion.ui.MainActivity}" drawable="generic_bible" name="YouVersion Bible" />
   <item component="ComponentInfo{com.sirma.mobile.bible.android/com.youversion.ui.SplashActivity}" drawable="generic_bible" name="YouVersion Bible" />
   <item component="ComponentInfo{yo.app/yo.activity.MainActivity}" drawable="yowindow" name="YoWindow" />
+  <item component="ComponentInfo{yo.app.free/yo.activity.MainActivity}" drawable="yowindow" name="YoWindow" />
   <item component="ComponentInfo{ro.orange.yoxo/ro.orange.yoxo.onboarding.ui.activity.SplashScreenActivity}" drawable="yoxo" name="YOXO" />
   <item component="ComponentInfo{com.yellowpages.android.ypmobile/com.yellowpages.android.ypmobile.YPM}" drawable="yp" name="YP" />
   <item component="ComponentInfo{com.pallo.passiontimerscoped/com.pallo.passiontimerscoped.MainActivity}" drawable="ypt" name="YPT" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
8BitDo Ultimate Software V2 (`com.bbitdo.advanceandroidv2` → `_8bitdo.svg`)
Autoškola (`cz.jamesdeer.autotest` → `autoskola.svg`)
BeterDichtbij (`nl.beterDichtbij` → `beterdichtbij.svg`)
Bible KJV (`com.azwstudios.theholybible.kjv` → `generic_bible.svg`)
Bible KJV (`com.hmobile.biblekjv` → `generic_bible.svg`)
Bible Louis Segond (`com.azwstudios.theholybible.frls` → `generic_bible.svg`)
Cinemark (`com.cinepapaya.cinemarkBolivia` → `cinemark.svg`)
Coop (`ee.coop.shopping.app` → `coop.svg`)
Costco (`intl.costco.com.mobile.newzealand` → `costco.svg`)
Costco (`intl.costco.com.mobile.spain` → `costco.svg`)
Dcard X (`com.dcard.freedom` → `dcard.svg`)
Dolby XP (`com.dolby.exphub` → `dolby.svg`)
e&amp;amp; Business UAE (`ae.etisalat.smb` → `eand.svg`)
Eden Legacy (`dev.legacy.eden_emulator` → `eden.svg`)
Edenred (`com.pgs.ticket.rikskortet` → `edenred.svg`)
Esso (`com.exxonmobil.esso.sg` → `esso.svg`)
Granny (`com.dvloper.granny.gelin_hs.cheat` → `granny.svg`)
GU (`com.gu_global.customer.app.tw` → `gu.svg`)
IBKR GlobalTrader (`com.ibkr.gt.app` → `ibkr.svg`)
J&amp;amp;T (`com.jtexpress.MyClient` → `j_and_t.svg`)
Kick (`com.kick.streaming` → `kick.svg`)
Kito (`com.yjllqint.kito` → `kito.svg`)
Lexus Link+ (`com.lexus.oneapp.eu` → `lexus.svg`)
Limbo VNC x86 (`com.limbo.emu.mav7` → `limbo_x86.svg`)
Lime Icons (`com.panotogomo.olylime` → `lime.svg`)
Manulife (`com.manulife.mpf` → `manulife.svg`)
Minecraft (`com.mojang.minecraftpe.hajsp` → `minecraft.svg`)
Minecraft PE (`com.mojang.minecraftpet` → `minecraft.svg`)
MovieBox HD (`com.gargan.abismo` → `moviebox.svg`)
Nonogram Color (`com.easybrain.nonogram.color` → `nonogram.svg`)
Prisma3D Legacy (`com.prisma3D.prisma3DLegacy` → `prisma3d.svg`)
Rakuten (`com.priceminister.buyerapp` → `rakuten.svg`)
Spotify Web (`com.spotify.music.web` → `spotify.svg`)
Vanguard (`com.vanguard.uk.pi.vanguarduk.playstore` → `vanguard.svg`)
Winlator CMOD (`com.ludashi.benchmark` → `winlator.svg`)
Winlator CMOD (`com.winlator.cmod` → `winlator.svg`)
YMusic Clone (`com.kapp.youtube.finam` → `ymusic.svg`)
YouTube Music (`ytm.morphe.noname.exe` → `generic_player.svg`)
YoWindow (`yo.app.free` → `yowindow.svg`)