### PR TITLE
+162 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -223,6 +223,7 @@
   <item component="ComponentInfo{com.ninegag.android.app/com.ninegag.android.app.ui.HomeActivity}" drawable="_9gag" name="9GAG" />
   <item component="ComponentInfo{com.ninegag.android.app/com.ninegag.android.app.ui.home.HomeActivity}" drawable="_9gag" name="9GAG" />
   <item component="ComponentInfo{au.com.mi9.jumpin.app/com.ninenow.MainActivity}" drawable="_9now" name="9Now" />
+  <item component="ComponentInfo{au.com.mi9.jumpin.app/com.google.android.archive.ReactivateActivity}" drawable="_9now" name="9Now" />
   <item component="ComponentInfo{eu.chainfire.liveboot/eu.chainfire.liveboot.MainActivity}" drawable="liveboot" name="[root] LiveBoot" />
   <item component="ComponentInfo{com.iternio.abrpapp/com.iternio.abrpapp.MainActivity}" drawable="a_better_routeplanner_abrp" name="A Better Routeplanner (ABRP)" />
   <item component="ComponentInfo{com.fizzd.connectedworlds/com.unity3d.player.UnityPlayerActivity}" drawable="a_dance_of_fire_and_ice" name="A Dance of Fire and Ice" />
@@ -318,6 +319,7 @@
   <item component="ComponentInfo{app.adbotg.shell/app.adbotg.shell.views.MainActivity}" drawable="ladb" name="ADB OTG Shell" />
   <item component="ComponentInfo{com.github.standardadb/com.github.standardadb.SplashActivity}" drawable="ladb" name="ADB Shell" />
   <item component="ComponentInfo{crixec.adbtoolkitsinstall/crixec.adbtoolkitsinstall.MainActivity}" drawable="ladb" name="ADB Tool Kits Installer" />
+  <item component="ComponentInfo{com.rair.adbwifi/com.rair.adbwifi.activity.MainActivity}" drawable="ladb" name="ADB WiFi" />
   <item component="ComponentInfo{org.adblockplus.browser/org.adblockplus.browser.App}" drawable="adblock_browser" name="Adblock Browser" />
   <item component="ComponentInfo{org.adblockplus.browser/com.google.android.apps.chrome.Main}" drawable="adblock_browser" name="Adblock Browser" />
   <item component="ComponentInfo{com.betafish.adblocksbrowser/com.betafish.sbrowser.contentblocker.MainPreferences}" drawable="adblock" name="AdBlock for Samsung Internet" />
@@ -325,6 +327,7 @@
   <item component="ComponentInfo{com.close.hook.ads/com.close.hook.ads.MainActivityLauncher}" drawable="adclose" name="AdClose" />
   <item component="ComponentInfo{com.nand.addtext/com.nand.addtext.ui.home.HomeActivity}" drawable="add_text" name="Add Text" />
   <item component="ComponentInfo{com.adda247.app/com.adda247.modules.home.adda247default}" drawable="adda247" name="Adda247" />
+  <item component="ComponentInfo{com.adda247.app/com.adda247.app.adda247default}" drawable="adda247" name="Adda247" />
   <item component="ComponentInfo{co.pamobile.minecraft.addonsmaker/co.pamobile.minecraft.addonsmaker.MainActivity}" drawable="addons_maker_mcpe_creator_mods" name="AddOns Maker: MCPE Creator Mods" />
   <item component="ComponentInfo{host.stjin.anonaddy/host.stjin.anonaddy.ClassicIcon}" drawable="addy_io" name="addy.io" />
   <item component="ComponentInfo{host.stjin.anonaddy/host.stjin.anonaddy.GradientIcon}" drawable="addy_io" name="addy.io" />
@@ -732,8 +735,8 @@
   <item component="ComponentInfo{com.amc/com.amc.mobileapp.MainActivity}" drawable="amc_theatres" name="AMC Theatres" />
   <item component="ComponentInfo{media6.app.amenic/media6.app.amenic.Main}" drawable="amenic" name="Amenic" />
   <item component="ComponentInfo{com.aa.android/com.aa.android.view.SplashActivity}" drawable="american_airlines" name="American Airlines" />
-  <item component="ComponentInfo{com.americanexpress.android.acctsvcs.it/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express" />
-  <item component="ComponentInfo{com.americanexpress.android.acctsvcs.de/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express" />
+  <item component="ComponentInfo{com.americanexpress.android.acctsvcs.it/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
+  <item component="ComponentInfo{com.americanexpress.android.acctsvcs.de/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.us/com.americanexpress.activity.SplashActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.uk/com.americanexpress.android.intl.app.view.activity.SplashActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.us/com.americanexpress.android.acctsvcs.us.firstuse.StartupActivity}" drawable="american_express_amex" name="American Express (Amex)" />
@@ -742,6 +745,7 @@
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.ca/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.au/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.mx/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
+  <item component="ComponentInfo{com.americanexpress.android.acctsvcs.fr/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="American Express (Amex)" />
   <item component="ComponentInfo{com.b2w.americanas/com.b2w.main.activity.MainActivity}" drawable="americanas" name="Americanas" />
   <item component="ComponentInfo{com.vitorpamplona.amethyst/com.vitorpamplona.amethyst.ui.MainActivity}" drawable="amethyst" name="Amethyst" />
   <item component="ComponentInfo{com.americanexpress.android.acctsvcs.nl/com.americanexpress.android.intl.app.view.activity.SplashInitializationActivity}" drawable="american_express_amex" name="Amex" />
@@ -936,6 +940,7 @@
   <item component="ComponentInfo{com.gmail.heagoo.apkeditor.pro/com.gmail.heagoo.apkeditor.MainActivity}" drawable="apk_editor_pro" name="APK Editor Pro" />
   <item component="ComponentInfo{com.apkeditor.new.explorer3/com.apk.editor.activities.SplashActivity}" drawable="apk_editor_pro" name="APK Editor Pro" />
   <item component="ComponentInfo{com.gmail.heagoo.apkeditor.pro/com.gmail.heagoo.apkeditor.MainActivity-New1}" drawable="apk_editor_pro" name="APK Editor Pro" />
+  <item component="ComponentInfo{com.apkeditor.new.explorer3/com.apk.editor.SplashAds.SpashActivity}" drawable="apk_editor_pro" name="APK Editor Pro" />
   <item component="ComponentInfo{com.ramzidev.apkextractor/com.ramzidev.apkextractor.MainActivity}" drawable="apk_extractor" name="APK Extractor" />
   <item component="ComponentInfo{com.ext.ui/com.ext.ui.MainActivity}" drawable="app_apk_extractor" name="APK Extractor" />
   <item component="ComponentInfo{jbtech.com.apkgenerator/jbtech.com.apkgenerator.activity.SplashActivity}" drawable="app_apk_extractor" name="APK Extractor" />
@@ -1051,6 +1056,7 @@
   <item component="ComponentInfo{pe.solera.portales/pe.solera.portales.MainActivity}" drawable="apparka" name="Apparka" />
   <item component="ComponentInfo{rk.android.app.appbar/rk.android.app.appbar.activities.launch.LaunchActivity}" drawable="appbar" name="AppBar" />
   <item component="ComponentInfo{cz.mobilesoft.appblock/cz.mobilesoft.appblock.MainActivity}" drawable="appblock" name="AppBlock" />
+  <item component="ComponentInfo{cz.mobilesoft.appblock/cz.mobilesoft.appblock.MainActivityAlias1}" drawable="appblock" name="AppBlock" />
   <item component="ComponentInfo{com.kroegerama.appchecker/com.kroegerama.appchecker.ui.AcMain}" drawable="appchecker" name="AppChecker" />
   <item component="ComponentInfo{flar2.appdashboard/flar2.appdashboard.MainActivity}" drawable="appdash" name="AppDash" />
   <item component="ComponentInfo{com.bulk.uninstall/com.bulk.uninstall.main.LauncherActivity}" drawable="appdrop" name="AppDrop" />
@@ -1142,6 +1148,7 @@
   <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.DefaultIconAlias}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.IconAliasd8836aa281d013ca23229cfc}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.IconAlias544376e2699c4931e8414c1b}" drawable="archivetune" name="ArchiveTune" />
+  <item component="ComponentInfo{moe.rukamori.archivetune/moe.rukamori.archivetune.launcher.IconAliasbf8bd3c3adfb819408994c22}" drawable="archivetune" name="ArchiveTune" />
   <item component="ComponentInfo{com.kanedias.archforums/com.kanedias.archforums.MainActivity}" drawable="archlinux_forums" name="Archlinux Forums" />
   <item component="ComponentInfo{com.google.ar.unity.arcore_depth_lab/com.unity3d.player.UnityPlayerActivity}" drawable="arcore_depth_lab" name="ARCore Depth Lab" />
   <item component="ComponentInfo{com.donnnno.arcticons.light/com.donnnno.arcticons.activities.SplashActivity}" drawable="arcticons_line_icons" name="Arcticons Black Icons" />
@@ -1366,6 +1373,7 @@
   <item component="ComponentInfo{com.hnib.smslater/com.hnib.smslater.main.SplashActivity}" drawable="auto_text" name="Auto Text" />
   <item component="ComponentInfo{com.joaomgcd.autoappshub/com.joaomgcd.autoappshub.activity.ActivityMain}" drawable="autoapps" name="AutoApps" />
   <item component="ComponentInfo{com.kautra.android.autobusubilietai/com.kautra.android.MainActivity}" drawable="autobusu_bilietai" name="Autobusų bilietai" />
+  <item component="ComponentInfo{com.kautra.android.autobusubilietai/com.MainActivity}" drawable="autobusu_bilietai" name="Autobusų bilietai" />
   <item component="ComponentInfo{com.autodesk.autocadws/com.autodesk.autocadws.ui.RootActivity}" drawable="autocad" name="AutoCAD" />
   <item component="ComponentInfo{ro.lifeishard.autodeal/ro.lifeishard.autodeal.feature.splash.SplashActivity}" drawable="autodeal" name="Autodeal" />
   <item component="ComponentInfo{de.autodoc.gmbh/de.autodoc.gmbh.ui.activity.SplashActivity}" drawable="autodoc" name="AUTODOC" />
@@ -1418,6 +1426,7 @@
   <item component="ComponentInfo{com.antivirus/com.antivirus.ui.main.AntivirusMainScreen}" drawable="avg_antivirus" name="AVG AntiVirus" />
   <item component="ComponentInfo{com.antivirus/com.avast.android.mobilesecurity.app.main.MainActivity}" drawable="avg_antivirus" name="AVG AntiVirus" />
   <item component="ComponentInfo{com.antivirus/com.avast.android.one.base.ui.main.MainActivity}" drawable="avg_antivirus" name="AVG AntiVirus" />
+  <item component="ComponentInfo{com.antivirus/com.norton.n360.splash.SplashActivity}" drawable="avg_antivirus" name="AVG AntiVirus" />
   <item component="ComponentInfo{com.avg.cleaner/com.avast.android.cleaner.activity.StartActivity}" drawable="avg_cleaner" name="AVG Cleaner" />
   <item component="ComponentInfo{com.s.antivirus/com.avast.android.one.base.ui.main.MainActivity}" drawable="avg_antivirus" name="AVG Protection" />
   <item component="ComponentInfo{com.avira.vpn/com.avira.vpn.MainActivity}" drawable="avira_phantom_vpn" name="Avira Phantom VPN" />
@@ -1507,11 +1516,13 @@
   <item component="ComponentInfo{com.rovio.BadPiggiesHD/com.unity3d.player.UnityPlayerActivity}" drawable="bad_piggies" name="Bad Piggies" />
   <item component="ComponentInfo{com.rovio.BadPiggies/com.unity3d.player.UnityPlayerActivity}" drawable="bad_piggies" name="Bad Piggies" />
   <item component="ComponentInfo{com.rovio.BadPiggies/com.releasedata.ReleaseDataActivity.SplashActivityKing}" drawable="bad_piggies" name="Bad Piggies" />
+  <item component="ComponentInfo{com.rovio.BadPiggiesHD/com.mentalmoustache.immerse.ImmerseActivity}" drawable="bad_piggies" name="Bad Piggies" />
   <item component="ComponentInfo{badminton.king.sportsgame.smash/org.cocos2dx.cpp.AppActivity}" drawable="badminton_league" name="Badminton League" />
   <item component="ComponentInfo{com.badoo.mobile/com.badoo.mobile.android.BadooActivity}" drawable="badoo" name="Badoo" />
   <item component="ComponentInfo{com.deutschebahn.bahnbonus/com.deutschebahn.bahnbonus.ui.LauncherActivity}" drawable="bahnbonus" name="BahnBonus" />
   <item component="ComponentInfo{mg.itworks.bf/io.flutter.embedding.android.FlutterActivity}" drawable="baiboly_and_fihirana" name="Baiboly &amp;amp; Fihirana" />
   <item component="ComponentInfo{mg.itworks.bf/mg.itworks.bf.ActivitySplash}" drawable="baiboly_and_fihirana" name="Baiboly &amp;amp; Fihirana" />
+  <item component="ComponentInfo{org.altruist.BajajExperia/com.bfl.superapp.onboarding.revamp.activity.DefaultTheme}" drawable="bajaj_finserv" name="Bajaj Finance" />
   <item component="ComponentInfo{org.altruist.BajajExperia/com.bfl.superapp.onboarding.revamp.activity.SplashActivity}" drawable="bajaj_finserv" name="Bajaj Finserv" />
   <item component="ComponentInfo{org.altruist.BajajExperia/com.bfl.superapp.ui.activity.SplashActivity}" drawable="bajaj_finserv" name="Bajaj Finserv" />
   <item component="ComponentInfo{org.altruist.BajajExperia/com.bfl.superapp.onboarding.SplashActivity}" drawable="bajaj_finserv" name="Bajaj Finserv" />
@@ -1537,6 +1548,7 @@
   <item component="ComponentInfo{hemengetir.client.tr/com.sebbia.delivery.client.ui.splash.SplashActivityNewYear}" drawable="banabikurye" name="Banabikurye" />
   <item component="ComponentInfo{hemengetir.client.tr/com.sebbia.delivery.client.ui.splash.SplashActivityDefault}" drawable="banabikurye" name="Banabikurye" />
   <item component="ComponentInfo{com.fdgentertainment.bananakong/com.fdgentertainment.bananakong.CustomActivity}" drawable="banana_kong" name="Banana Kong" />
+  <item component="ComponentInfo{com.fdgentertainment.bananakong/com.dynamo.android.DefoldActivity}" drawable="banana_kong" name="Banana Kong" />
   <item component="ComponentInfo{it.bancadipiacenza.mobile/it.csebo.nmac.ui.splashscreen.SplashScreenActivity}" drawable="banca_di_piacenza" name="Banca di Piacenza" />
   <item component="ComponentInfo{it.bancaetica.bank/it.cedacri.hb3.achille.ui.login.LoginActivity}" drawable="banca_etica" name="Banca Etica" />
   <item component="ComponentInfo{net.bac.sbe.android/net.bac.sbe.bancamovil.activity.WalletMainActivity}" drawable="banca_movil" name="Banca Móvil" />
@@ -1560,6 +1572,7 @@
   <item component="ComponentInfo{com.mosync.app_Banco_Galicia/ar.com.galicia.core.ui.SplashActivity}" drawable="banco_galicia" name="Banco Galicia" />
   <item component="ComponentInfo{pt.cemg.BancoMontepio/pt.cemg.BancoMontepio.MainActivity}" drawable="banco_montepio" name="Banco Montepio" />
   <item component="ComponentInfo{br.com.bancopan.cartoes/br.com.bancopan.bancodigital.presentation.splash.SplashActivity}" drawable="banco_pan" name="Banco PAN" />
+  <item component="ComponentInfo{br.com.bancopan.cartoes/com.btg.pactual.banking.SplashScreenActivity}" drawable="banco_pan" name="Banco PAN" />
   <item component="ComponentInfo{net.inverline.bancosabadell.officelocator.android/net.inverline.bancosabadell.officelocator.android.sab.SplashActivity}" drawable="banco_sabadell" name="Banco Sabadell" />
   <item component="ComponentInfo{com.bancoagricola.bancamovil/com.bancoagricola.bancamovil.MainActivity}" drawable="bancolombia_personas" name="Bancoagrícola" />
   <item component="ComponentInfo{net.veritran.becl.prod/net.veritran.becl.prod.VTCommonActivity}" drawable="bancoestado" name="BancoEstado" />
@@ -1806,6 +1819,7 @@
   <item component="ComponentInfo{com.bennyco.app/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="benny_and_co" name="Benny &amp; Co." />
   <item component="ComponentInfo{com.bereal.ft/com.bereal.ft.MainActivity}" drawable="bereal" name="BeReal." />
   <item component="ComponentInfo{com.bereal.ft/bereal.app.MainActivity}" drawable="bereal" name="BeReal." />
+  <item component="ComponentInfo{com.bereal.ft/com.google.android.archive.ReactivateActivity}" drawable="bereal" name="BeReal." />
   <item component="ComponentInfo{com.bergfex.mobile.android/com.bergfex.mobile.activity.WelcomeActivityNew}" drawable="bergfex" name="Bergfex" />
   <item component="ComponentInfo{com.bergfex.mobile.weather/com.bergfex.mobile.weather.MainActivity}" drawable="kde_weather" name="bergfex" />
   <item component="ComponentInfo{nl.rijksoverheid.mbb.pub/crc64a62658a83f4e9f0e.MainActivity}" drawable="berichtenbox" name="Berichtenbox" />
@@ -1962,6 +1976,7 @@
   <item component="ComponentInfo{bipa.app.bipa/bipa.app.bipa.MainActivity}" drawable="bipa" name="Bipa" />
   <item component="ComponentInfo{az.kapitalbank.mbanking/kapitalbank.screen.splash.SplashScreen}" drawable="birbank" name="Birbank" />
   <item component="ComponentInfo{az.kapitalbank.mbanking/az.kapitalbank.feature_launcher_impl.presentation.activity.LauncherActivity}" drawable="birbank" name="Birbank" />
+  <item component="ComponentInfo{az.kapitalbank.mbanking/az.kapitalbank.mbanking.AliasLauncherDefault}" drawable="birbank" name="Birbank" />
   <item component="ComponentInfo{co.bird.android/co.bird.android.app.feature.main.MainActivity}" drawable="bird" name="Bird" />
   <item component="ComponentInfo{com.minar.birday/com.minar.birday.activities.MainActivity}" drawable="birday" name="Birday" />
   <item component="ComponentInfo{com.minar.birday/com.minar.birday.activities.SplashActivity}" drawable="birday" name="Birday" />
@@ -2100,6 +2115,7 @@
   <item component="ComponentInfo{com.blockblast.vn/org.cocos2dx.javascript.AppActivity}" drawable="block_blast" name="Block Blast!" />
   <item component="ComponentInfo{com.block.juggle/com.releasedata.ReleaseDataActivity.SplashActivityKing}" drawable="block_blast" name="Block Blast!" />
   <item component="ComponentInfo{com.block.juggle/org.cocos2dx.javascript.AppActivity}" drawable="block_blast" name="Block Blast!" />
+  <item component="ComponentInfo{com.block.juggle/org.cocos2dx.javascript.AppActivity.Default}" drawable="block_blast" name="Block Blast!" />
   <item component="ComponentInfo{com.fungames.blockcraft/com.fungames.blockcraft.AppActivity}" drawable="block_craft_3d" name="Block Craft 3D" />
   <item component="ComponentInfo{game.puzzle.blockpuzzle/org.cocos2dx.cpp.AppActivity}" drawable="block_puzzle" name="Block Puzzle" />
   <item component="ComponentInfo{linkdesks.block.puzzle.classic.puzzlegames/com.unity3d.player.UnityPlayerActivity}" drawable="block_puzzle" name="Block Puzzle" />
@@ -2322,6 +2338,7 @@
   <item component="ComponentInfo{com.boxter/com.boxter.MainActivity}" drawable="boxter" name="Boxter" />
   <item component="ComponentInfo{com.mobisoft.boyner/com.mobisoft.boyner.ui.splash.SplashActivitynew_boyner}" drawable="boyner" name="Boyner" />
   <item component="ComponentInfo{com.mobisoft.boyner/com.mobisoft.boyner.ui.splash.SplashActivity}" drawable="boyner" name="Boyner" />
+  <item component="ComponentInfo{com.mobisoft.boyner/com.mobisoft.boyner.DefaultIcon}" drawable="boyner" name="Boyner" />
   <item component="ComponentInfo{it.gruppobper.ams.android.bper/com.bper.app.ui.SplashScreenActivity}" drawable="bper_banca" name="BPER Banca" />
   <item component="ComponentInfo{com.bpi.ng.app/com.bpi.ng.app.presentation.views.MainActivity}" drawable="bpi" name="BPI" />
   <item component="ComponentInfo{de.br.sep.news.br24/de.br.sep.news.br24.activities.MainActivity}" drawable="br24" name="BR24" />
@@ -2389,6 +2406,7 @@
   <item component="ComponentInfo{com.moorlandgames.brickyboy/com.unity3d.player.UnityPlayerActivity}" drawable="bricky_boy" name="Bricky Boy" />
   <item component="ComponentInfo{me.bridgefy.main/me.bridgefy.main.ux.startup.StartupActivity}" drawable="bridgefy" name="Bridgefy" />
   <item component="ComponentInfo{me.bridgefy.main/me.bridgefy.ux.home.TabbedMainActivity}" drawable="bridgefy" name="Bridgefy" />
+  <item component="ComponentInfo{me.bridgefy.main/me.bridgefy.main.MainActivityDefault}" drawable="bridgefy" name="Bridgefy" />
   <item component="ComponentInfo{com.flashlight.bright.led.light/ch.android.launcher.LawnchairLauncher}" drawable="generic_flashlight" name="Brightest Flashlight Launcher" />
   <item component="ComponentInfo{com.d2l.brightspace.student.android/com.d2l.brightspace.android.ui.DispatchActivity}" drawable="brightspace_pulse" name="Brightspace Pulse" />
   <item component="ComponentInfo{com.d2l.brightspace.student.android/com.d2l.brightspace.student.android.MainActivity}" drawable="brightspace_pulse" name="Brightspace Pulse" />
@@ -2490,6 +2508,7 @@
   <item component="ComponentInfo{com.netease.buff163/com.netease.buff.entry.launcher.icon1380}" drawable="buff" name="BUFF" />
   <item component="ComponentInfo{com.netease.buff/com.netease.buff.entry.launcher.icon1500}" drawable="buff" name="BUFF" />
   <item component="ComponentInfo{com.netease.buff/com.netease.buff.entry.launcher.icon2900}" drawable="buff" name="BUFF" />
+  <item component="ComponentInfo{com.netease.market.buff/com.netease.buff.entry.launcher.icon2900}" drawable="buff" name="BUFF" />
   <item component="ComponentInfo{org.buffer.android/org.buffer.android.ui.splash.SplashScreenActivity}" drawable="buffer" name="Buffer" />
   <item component="ComponentInfo{com.shadowteam.buffywallsfree/com.shadowteam.buffywallsfree.MainActivity}" drawable="buffywalls" name="BuffyWalls" />
   <item component="ComponentInfo{com.shadowteam.buffywallspaid/com.shadowteam.buffywallsfree.MainActivity}" drawable="buffywalls_pro" name="BuffyWalls Pro" />
@@ -2661,6 +2680,7 @@
   <item component="ComponentInfo{com.byu.id/com.cxos.tsel.byu.MainActivity}" drawable="by_u" name="by.U" />
   <item component="ComponentInfo{com.byu.id/com.byu.id.MainActivityDefault}" drawable="by_u" name="by.U" />
   <item component="ComponentInfo{com.bybit.app/com.bybit.pro.MainActivity}" drawable="bybit" name="Bybit" />
+  <item component="ComponentInfo{com.bybit.eu/com.bybit.pro.MainActivity}" drawable="bybit" name="Bybit" />
   <item component="ComponentInfo{io.github.romanvht.byedpi/io.github.dovecoteescapee.byedpi.activities.MainActivity}" drawable="byebyedpi" name="ByeByeDPI" />
   <item component="ComponentInfo{io.github.romanvht.byedpi/io.github.romanvht.byedpi.activities.MainActivity}" drawable="byebyedpi" name="ByeByeDPI" />
   <item component="ComponentInfo{io.github.dovecoteescapee.byedpi/io.github.dovecoteescapee.byedpi.activities.MainActivity}" drawable="byedpi" name="ByeDPI" />
@@ -3026,6 +3046,7 @@
   <item component="ComponentInfo{com.android.MGC_3_2_045/com.android.camera.CameraLauncher}" drawable="generic_camera" name="Camera" />
   <item component="ComponentInfo{com.simplemobiletools.alabama.camera.manager.sam5/com.simplemobiletools.camera.activities.SplashActivity.Orange}" drawable="generic_camera" name="Camera" />
   <item component="ComponentInfo{com.google.android.GoogleCamerb3/com.android.camera.CameraLauncher}" drawable="generic_camera" name="Camera" />
+  <item component="ComponentInfo{com.vayunmathur.camera/com.vayunmathur.camera.MainActivity}" drawable="generic_camera" name="Camera" />
   <item component="ComponentInfo{de.kromke.andreas.cameradatefolders/de.kromke.andreas.cameradatefolders.MainActivity}" drawable="camera_date_folders" name="Camera Date Folders" />
   <item component="ComponentInfo{com.flavionet.android.camera.pro/com.flavionet.android.camera.MainActivity}" drawable="camera_fv_5" name="Camera FV-5" />
   <item component="ComponentInfo{com.flavionet.android.camera.lite/com.flavionet.android.camera.MainActivity}" drawable="camera_fv_5_lite" name="Camera FV-5 Lite" />
@@ -3189,6 +3210,7 @@
   <item component="ComponentInfo{app.fedilab.castlab/app.fedilab.castlab.MainActivity}" drawable="castlab" name="CastLab" />
   <item component="ComponentInfo{xyz.castle/xyz.castle.MainActivity}" drawable="castle" name="Castle" />
   <item component="ComponentInfo{pl.looksoft.castorama/com.kingfisher.castopl.MainActivity}" drawable="castorama" name="Castorama" />
+  <item component="ComponentInfo{com.kingfisher.cafr/com.kingfisher.castofr.MainActivity}" drawable="castorama" name="Castorama" />
   <item component="ComponentInfo{com.itemstudio.castro/com.itemstudio.castro.screens.main_activity.MainActivity}" drawable="castro" name="Castro" />
   <item component="ComponentInfo{com.itemstudio.castro/com.itemstudio.castro.containers.PrimaryContainerActivity}" drawable="castro" name="Castro" />
   <item component="ComponentInfo{com.itemstudio.castro/com.itemstudio.castro.activity.BaseActivity}" drawable="castro" name="Castro" />
@@ -3265,6 +3287,7 @@
   <item component="ComponentInfo{com.teb/com.teb.feature.noncustomer.ui.splash.SplashActivity}" drawable="cepteteb" name="CEPTETEB" />
   <item component="ComponentInfo{org.random.randomapp/org.random.randomapp.activity.RandomActivity}" drawable="certified_true_randomizers" name="Certified True Randomizers" />
   <item component="ComponentInfo{com.cetelem.HomeBanking/homebanking.cetelem.com.homebanking2.Launcher}" drawable="cetelem" name="Cetelem" />
+  <item component="ComponentInfo{pt.cetelem.homebanking/pt.cetelem.hb.MainActivity}" drawable="cetelem" name="Cetelem" />
   <item component="ComponentInfo{mx.com.cfe.cfecontigo/mx.com.cfe.cfecontigo.ui.login.LoginActivity}" drawable="cfe" name="CFE" />
   <item component="ComponentInfo{com.Infofer.ImtMobile/crc64aa5f5eaf048ac5a7.MainActivity}" drawable="cfr_calatori" name="CFR Calatori" />
   <item component="ComponentInfo{com.blitz.blitzandapp1/com.blitz.blitzandapp1.MainActivity}" drawable="cgv_cinemas" name="CGV Cinemas" />
@@ -3376,6 +3399,7 @@
   <item component="ComponentInfo{jwtc.android.chess/jwtc.android.chess.start}" drawable="generic_chess" name="Chess" />
   <item component="ComponentInfo{com.chess.strategy.boardgame/com.common.common.act.v2.BaseAgentAct}" drawable="really_bad_chess" name="Chess" />
   <item component="ComponentInfo{com.llx.chess/com.llx.chess.AndroidLauncher}" drawable="generic_chess" name="Chess" />
+  <item component="ComponentInfo{com.birds.chess/com.dynamo.android.DefoldActivity}" drawable="generic_chess" name="Chess" />
   <item component="ComponentInfo{com.shenmareparas.chess/com.pscottzero.en_passant.MainActivity}" drawable="really_bad_chess" name="Chess - Offline 2 Player" />
   <item component="ComponentInfo{com.chess.clock/com.chess.clock.activities.ClockTimersActivity}" drawable="chess_clock" name="Chess Clock" />
   <item component="ComponentInfo{com.themarto.chessclock/com.themarto.chessclock.MainActivity}" drawable="chess_clock" name="Chess Clock" />
@@ -3537,9 +3561,11 @@
   <item component="ComponentInfo{dev.msfjarvis.claw.android/dev.msfjarvis.claw.android.MainActivity}" drawable="claw" name="Claw" />
   <item component="ComponentInfo{email.clean.android/email.clean.android.MainActivity}" drawable="clean_email" name="Clean Email" />
   <item component="ComponentInfo{com.clearme.clearapp/com.clearme.clearapp.splashscreen.SplashScreenActivity}" drawable="clear" name="CLEAR" />
+  <item component="ComponentInfo{com.clearme.clearapp/com.clearme.clearapp.MainActivity}" drawable="clear" name="CLEAR" />
   <item component="ComponentInfo{com.panotogomo.circleclear/com.panotogomo.circleclear.activities.MainActivity}" drawable="clear_circle_icons" name="Clear Circle Icons" />
   <item component="ComponentInfo{com.panotogomo.squareclear/com.panotogomo.squareclear.activities.MainActivity}" drawable="clear_square_icons" name="Clear Square Icons" />
   <item component="ComponentInfo{com.afterpaymobile.uk/com.afterpaymobile.MainActivity}" drawable="clearpay" name="Clearpay" />
+  <item component="ComponentInfo{com.afterpaymobile.uk/com.afterpaymobile.uk.MainActivity}" drawable="clearpay" name="Clearpay" />
   <item component="ComponentInfo{com.indymobileapp.document.scanner/com.notebloc.app.activity.MainActivity}" drawable="clearscanner" name="ClearScanner" />
   <item component="ComponentInfo{com.indymobileapp.document.scanner/com.indymobile.app.activity.MainActivity}" drawable="clearscanner" name="ClearScanner" />
   <item component="ComponentInfo{com.indymobileapp.document.scanner/com.indymobile.app.activity.SplashScreenActivity}" drawable="clearscanner" name="ClearScanner" />
@@ -3649,6 +3675,7 @@
   <item component="ComponentInfo{com.bnyro.clock/com.bnyro.clock.ui.MainActivityAlternative}" drawable="generic_clock" name="Clock You" />
   <item component="ComponentInfo{me.clockify.android/me.clockify.android.presenter.screens.main.MainActivity}" drawable="clockify" name="Clockify" />
   <item component="ComponentInfo{com.pengyou.cloneapp/com.pengyou.cloneapp.SplashActivity}" drawable="clone_app" name="Clone App" />
+  <item component="ComponentInfo{com.pengyou.cloneapp/com.pengyou.cloneapp.hide.Splash}" drawable="generic_calculator_plus_minus_multi_equal" name="Clone App Calculator Icon" />
   <item component="ComponentInfo{com.srylain.CloneHero/com.unity3d.player.UnityPlayerActivity}" drawable="clone_hero" name="Clone Hero" />
   <item component="ComponentInfo{ovh.wolfie.apps.doesitbackup/ovh.wolfie.apps.doesitbackup.MainActivity}" drawable="cloud_backup_checker" name="Cloud Backup Checker" />
   <item component="ComponentInfo{com.cloudstorage.mycloud.storagespace.cloudapp/global.cloud.storage.ui.splash.SplashActivity}" drawable="custom_uploader" name="Cloud Storage" />
@@ -3670,6 +3697,7 @@
   <item component="ComponentInfo{com.clubhouse.app/com.clubhouse.android.ui.ClubhouseActivity}" drawable="clubhouse" name="Clubhouse" />
   <item component="ComponentInfo{br.com.clude.cludeapp/br.com.clude.cludeapp.MainActivity}" drawable="clude" name="Clude" />
   <item component="ComponentInfo{com.clue.android/com.helloclue.ui.MainActivity}" drawable="clue" name="Clue" />
+  <item component="ComponentInfo{com.clue.android/com.helloclue.AppIconDefault}" drawable="clue" name="Clue" />
   <item component="ComponentInfo{com.pikpok.wtd.play/com.pikpok.PikPokUnityActivity}" drawable="clusterduck" name="Clusterduck" />
   <item component="ComponentInfo{com.nothing.cmf.watch/com.watchmanager.MainActivity}" drawable="cmf_watch" name="CMF Watch" />
   <item component="ComponentInfo{com.rbi.cmisign.prod/com.kobil.MainActivity}" drawable="raiffeisen_bank" name="CMI Sign" />
@@ -3927,6 +3955,7 @@
   <item component="ComponentInfo{intl.costco.com.mobile.uk/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{intl.costco.com.mobile.newzealand/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{intl.costco.com.mobile.spain/intl.costco.com.mobile.MainActivity}" drawable="costco" name="Costco" />
+  <item component="ComponentInfo{com.costco.app.android/com.costco.app.android.MainActivity}" drawable="costco" name="Costco" />
   <item component="ComponentInfo{com.couchsurfing.mobile.android/com.couchsurfing.mobile.ui.WelcomeActivity}" drawable="couchsurfing" name="Couchsurfing" />
   <item component="ComponentInfo{com.couchsurfing.mobile.android/com.couchsurfing.mobile.MainActivity}" drawable="couchsurfing" name="Couchsurfing" />
   <item component="ComponentInfo{com.jupli.countdowntoanything/com.jupli.countdowntoanything.MainActivity}" drawable="countdown_to_anything" name="Countdown To Anything" />
@@ -3991,6 +4020,7 @@
   <item component="ComponentInfo{fnzstudios.com.videocrop/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="crop_and_trim_video" name="Crop &amp; Trim Video" />
   <item component="ComponentInfo{me.okitastudio.crosshairherofps/me.okitastudio.crosshairherofps.ui.activity.HomeActivity}" drawable="crosshair_hero" name="Crosshair Hero" />
   <item component="ComponentInfo{me.okitastudio.crosshairherofps/io.chaldeaprjkt.noscope.ui.HomeActivity}" drawable="crosshair_hero" name="Crosshair Hero" />
+  <item component="ComponentInfo{me.okitastudio.crosshairherofps/id.chaldea.crosshairhero.MainActivity}" drawable="crosshair_hero" name="Crosshair Hero" />
   <item component="ComponentInfo{org.eehouse.android.xw4/org.eehouse.android.xw4.MainActivity}" drawable="crosswords" name="CrossWords" />
   <item component="ComponentInfo{com.yodo1.crossyroad/com.yodo1.android.sdk.view.Yodo1SplashActivity}" drawable="crossy_road" name="Crossy Road" />
   <item component="ComponentInfo{com.yodo1.crossyroad/com.google.firebase.MessagingUnityPlayerActivity}" drawable="crossy_road" name="Crossy Road" />
@@ -4128,6 +4158,7 @@
   <item component="ComponentInfo{com.amanotes.pamadancingroad/com.amanotes.pamadancingroad.DRUnityPlayerActivity}" drawable="dancing_road_color_ball_run" name="Dancing Road: Color Ball Run!" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.danish/com.anysoftkeyboard.languagepack.danish.MainActivity}" drawable="anysoftkeyboard" name="Danish for AnySoftKeyboard" />
   <item component="ComponentInfo{com.flxrs.dankchat/com.flxrs.dankchat.main.MainActivity}" drawable="dankchat" name="DankChat" />
+  <item component="ComponentInfo{com.flxrs.dankchat/com.flxrs.dankchat.ui.main.MainActivity}" drawable="dankchat" name="DankChat" />
   <item component="ComponentInfo{dk.danlon.app/dk.danlon.app.MainActivity}" drawable="danlon" name="Danløn" />
   <item component="ComponentInfo{com.danskebank.danskeid/com.danskebank.danskeid.launcher_635a6dbbbe6fcf1bd8de12428c9ab34a55a73d42baa271373bbae646e38a3b45}" drawable="danske_id" name="Danske ID" />
   <item component="ComponentInfo{ani.dantotsu/ani.dantotsu.MainActivity}" drawable="dantotsu" name="Dantotsu" />
@@ -4174,6 +4205,7 @@
   <item component="ComponentInfo{com.bendingspoons.dawn.ai/com.bendingspoons.remini.MainActivity}" drawable="dawn_ai" name="Dawn AI" />
   <item component="ComponentInfo{me.thanel.dank/me.saket.dank.Launcher}" drawable="dawn_for_reddit" name="Dawn For Reddit" />
   <item component="ComponentInfo{com.dayoneapp.dayone/com.dayoneapp.dayone.main.SplashActivity}" drawable="day_one_journal" name="Day One Journal" />
+  <item component="ComponentInfo{com.dayoneapp.dayone/com.dayoneapp.dayone.appicon.DefaultIconAlias}" drawable="day_one_journal" name="Day One Journal" />
   <item component="ComponentInfo{com.daybridge.android/com.daybridge.android.ui.MainActivity}" drawable="daybridge" name="Daybridge" />
   <item component="ComponentInfo{com.dayforce.mobile/com.dayforce.mobile.ui_login.SSOLoginHandlerActivity}" drawable="dayforce" name="Dayforce" />
   <item component="ComponentInfo{com.dayforce.mobile/com.dayforce.mobile.ui_login.AppStartActivity}" drawable="dayforce" name="Dayforce" />
@@ -4357,6 +4389,7 @@
   <item component="ComponentInfo{com.donanimhaber.dhandroid/com.donanimhaber.dhandroid.dh_app_mvvm.ui.navigator.NavigatorActivity}" drawable="dh" name="DH" />
   <item component="ComponentInfo{com.dhan.live/com.raise.dhan.MainActivity}" drawable="dhan" name="Dhan" />
   <item component="ComponentInfo{com.alifewithallah.app/com.ryanheise.audioservice.AudioServiceActivity}" drawable="dhikr_and_dua" name="Dhikr &amp; Dua" />
+  <item component="ComponentInfo{com.alifewithallah.app/com.alifewithallah.app.MainActivity}" drawable="dhikr_and_dua" name="Dhikr &amp;amp; Dua" />
   <item component="ComponentInfo{mv.com.dhiraagu.app/mv.com.dhiraagu.dhiraagu.SplashActivity}" drawable="dhiraagu" name="Dhiraagu" />
   <item component="ComponentInfo{com.rosan.dhizuku/com.rosan.dhizuku.ui.activity.SettingsActivity}" drawable="dhizuku" name="Dhizuku" />
   <item component="ComponentInfo{com.dhlparcel.nl/com.dhlparcel.MainActivity}" drawable="dhl" name="DHL" />
@@ -4375,6 +4408,7 @@
   <item component="ComponentInfo{fm.dice/fm.dice.splash.presentation.views.SplashActivity}" drawable="dice_fm" name="DICE FM" />
   <item component="ComponentInfo{com.example.diceroller/com.example.diceroller.MainActivity}" drawable="random_dice_defense" name="Dice Roller" />
   <item component="ComponentInfo{com.harryfo.dice/com.harryfo.dice.MainActivity}" drawable="dice_roller" name="Dice Roller" />
+  <item component="ComponentInfo{com.funcraft.diceyatzy/com.google.firebase.MessagingUnityPlayerActivity}" drawable="random_dice_defense" name="Dice Yatzy" />
   <item component="ComponentInfo{com.setegraus.dicio/com.setegraus.dicio.MainActivity}" drawable="dicio" name="Dicio" />
   <item component="ComponentInfo{org.stypox.dicio/org.stypox.dicio.MainActivity}" drawable="dicio_assistant" name="Dicio assistant" />
   <item component="ComponentInfo{cc.dict.dictcc/cc.dict.dictcc.DictCcActivity}" drawable="dict_cc" name="dict.cc" />
@@ -4434,6 +4468,7 @@
   <item component="ComponentInfo{at.gv.oe.app/at.gv.oe.app.MainActivity}" drawable="digitales_amt" name="Digitales Amt" />
   <item component="ComponentInfo{hu.gov.dap.app/hu.gov.dap.MainActivity}" drawable="digitalis_allampolgar" name="Digitális Állampolgár" />
   <item component="ComponentInfo{in.gov.diksha.app/org.sunbird.app.MainActivity}" drawable="diksha" name="DIKSHA" />
+  <item component="ComponentInfo{in.gov.diksha.app/dev.diksha.app.MainActivity}" drawable="diksha" name="DIKSHA" />
   <item component="ComponentInfo{giraffine.dimmer/giraffine.dimmer.Dimmer}" drawable="dimmer" name="Dimmer" />
   <item component="ComponentInfo{com.motorola.dimo/com.motorola.engageapp.ui.MotopayActivity}" drawable="dimo_essential" name="Dimo Essential" />
   <item component="ComponentInfo{com.dineout.book/in.swiggy.android.activities.HomeActivity}" drawable="dineout" name="Dineout" />
@@ -4566,6 +4601,7 @@
   <item component="ComponentInfo{br.com.doctoralia/com.app.MainActivity}" drawable="doctoralia" name="Doctoralia" />
   <item component="ComponentInfo{mx.com.doctoralia/com.app.MainActivity}" drawable="doctoralia" name="Doctoralia" />
   <item component="ComponentInfo{mx.com.doctoralia/mx.com.doctoralia.MainActivity}" drawable="doctoralia" name="Doctoralia" />
+  <item component="ComponentInfo{co.doctoralia/co.doctoralia.MainActivity}" drawable="doctoralia" name="Doctoralia" />
   <item component="ComponentInfo{eu.doctorbox.mobile.android.doctorbox/eu.doctorbox.presentation.application.EntryPointActivity}" drawable="doctorbox" name="DoctorBox" />
   <item component="ComponentInfo{all.documentreader.filereader.office.viewer/all.documentreader.filereader.office.viewer.pages.BlankActivity}" drawable="document_reader" name="Document Reader" />
   <item component="ComponentInfo{com.cv.docscanner/com.cv.docscanner.activity.AppMainActivity}" drawable="document_scanner" name="Document Scanner" />
@@ -4679,6 +4715,7 @@
   <item component="ComponentInfo{com.molo.dominos/com.dominos.loadingscreen.InitialLaunchActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{zena.dominos/com.dominos.loadingscreen.InitialLaunchActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{com.daufood.ppt/com.iproject.dominos.ui.splash.SplashActivity}" drawable="dominos_pizza" name="Domino's Pizza" />
+  <item component="ComponentInfo{com.Dominos/com.Dominos.activity.alias.LauncherRepublicAlias}" drawable="dominos_pizza" name="Domino's Pizza" />
   <item component="ComponentInfo{com.LoopGames.Domino/com.unity3d.player.UnityPlayerActivity}" drawable="dominoes" name="Dominoes" />
   <item component="ComponentInfo{com.LoopGames.Domino/com.google.firebase.MessagingUnityPlayerActivity}" drawable="dominoes" name="Dominoes" />
   <item component="ComponentInfo{pl.dominium/pl.dominium.feature.main.MainActivity}" drawable="dominos_pizza" name="Domino’s Pizza" />
@@ -4830,6 +4867,7 @@
   <item component="ComponentInfo{com.dream11.fantasy.cricket.football.kabaddi/com.app.dream11.dream11.ReactHomeActivity}" drawable="dream11" name="Dream11" />
   <item component="ComponentInfo{com.app.dream11Pro/com.app.dream11.dream11.SplashActivity}" drawable="dream11" name="Dream11" />
   <item component="ComponentInfo{com.dream11.fantasy.cricket.football.kabaddi/com.dream11.fantasy.cricket.football.kabaddi.MainActivity}" drawable="dream11" name="Dream11" />
+  <item component="ComponentInfo{com.app.dream11Pro/com.app.dream11.dream11.ReactHomeActivity}" drawable="dream11" name="Dream11" />
   <item component="ComponentInfo{net.reichholf.dreamdroid/net.reichholf.dreamdroid.activities.TabbedNavigationActivity}" drawable="dreamdroid" name="dreamDroid" />
   <item component="ComponentInfo{com.dreame.smartlife/com.dreame.smartlife.ui.activity.SplashActivity}" drawable="dreamehome" name="Dreamehome" />
   <item component="ComponentInfo{au.com.vodafone.dreamlabapp/au.com.vodafone.dreamlabapp.presentation.launcher.LauncherScreenActivity}" drawable="dreamlab" name="DreamLab" />
@@ -4896,6 +4934,7 @@
   <item component="ComponentInfo{vegabobo.dsusideloader/vegabobo.dsusideloader.MainActivity}" drawable="dsu_sideloader" name="DSU Sideloader" />
   <item component="ComponentInfo{vegabobo.dsusideloader/vegabobo.dsusideloader.SplashActivity}" drawable="dsu_sideloader" name="DSU Sideloader" />
   <item component="ComponentInfo{duleaf.duapp.splash/duleaf.duapp.splash.views.launch.LaunchActivity}" drawable="du" name="du" />
+  <item component="ComponentInfo{duleaf.duapp.splash/ae.du.cxapp.ignite.views.SplashActivity}" drawable="du" name="du" />
   <item component="ComponentInfo{de.dlyt.yanndroid.dualwallpaper/de.dlyt.yanndroid.dualwallpaper.ui.activity.MainActivity}" drawable="dual_wallpaper" name="Dual Wallpaper" />
   <item component="ComponentInfo{com.Seabaa.Dual/com.Seabaa.Dual.Dual}" drawable="dual" name="DUAL!" />
   <item component="ComponentInfo{com.olxmena.horizontal/com.empg.olxeg.MainActivity}" drawable="dubizzle" name="dubizzle" />
@@ -4989,6 +5028,7 @@
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakFrozenLauncher2FrozenFace}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakSaverLauncher4Hourglass}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.duolingo/com.duolingo.app.BackgroundedLauncher}" drawable="duolingo" name="Duolingo" />
+  <item component="ComponentInfo{com.duolingo/com.duolingo.app.StreakFrozenLauncher3FrozenFace}" drawable="duolingo" name="Duolingo" />
   <item component="ComponentInfo{com.rstgames.durak/com.rstgames.durak.StartActivity}" drawable="durak_online" name="Durak Online" />
   <item component="ComponentInfo{com.rstgames.durak/com.rstgames.durak.jvsFjEBbonfbs}" drawable="durak_online" name="Durak Online" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.dutch_oss/com.anysoftkeyboard.languagepack.dutch_oss.MainActivity}" drawable="anysoftkeyboard" name="Dutch for AnySoftKeyboard" />
@@ -5267,6 +5307,7 @@
   <item component="ComponentInfo{it.enel/crc64d0549c3f31f5415a.SplashActivity}" drawable="enel" name="Enel" />
   <item component="ComponentInfo{br.com.trinitysolucoes.saemobile/br.com.trinitysolucoes.saemobile.MainActivity}" drawable="enel" name="Enel" />
   <item component="ComponentInfo{br.com.trinitysolucoes.saemobile/com.enel.brasil.MainActivity}" drawable="enel" name="Enel" />
+  <item component="ComponentInfo{br.com.deway.coelce/br.com.deway.coelce.MainActivity}" drawable="enel" name="Enel" />
   <item component="ComponentInfo{com.flasskamp.energize/com.flasskamp.energize.MainActivity}" drawable="energize" name="Energize" />
   <item component="ComponentInfo{com.infinitygames.loopenergy/com.google.firebase.MessagingUnityPlayerActivity}" drawable="energy" name="Energy" />
   <item component="ComponentInfo{com.infinitygames.loopenergy/com.unity3d.player.UnityPlayerActivity}" drawable="energy" name="Energy" />
@@ -5295,6 +5336,7 @@
   <item component="ComponentInfo{io.ente.ensu/io.ente.ensu.MainActivity}" drawable="ente_ensu" name="Ente Ensu" />
   <item component="ComponentInfo{io.ente.locker/io.ente.locker.MainActivity}" drawable="ente_locker" name="Ente Locker" />
   <item component="ComponentInfo{io.ente.locker.fdroid/io.ente.locker.MainActivity}" drawable="ente_locker" name="Ente Locker" />
+  <item component="ComponentInfo{io.ente.locker.independent/io.ente.locker.MainActivity}" drawable="ente_locker" name="Ente Locker" />
   <item component="ComponentInfo{io.ente.photos.independent/io.ente.photos.MainActivity}" drawable="ente_photos" name="Ente Photos" />
   <item component="ComponentInfo{io.ente.photos.fdroid/io.ente.photos.MainActivity}" drawable="ente_photos" name="Ente Photos" />
   <item component="ComponentInfo{io.ente.photos/io.ente.photos.MainActivity}" drawable="ente_photos" name="Ente Photos" />
@@ -5472,6 +5514,7 @@
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.splash.SplashActivity}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.vpn.splash.ClassicAlias}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.expressvpn.vpn/com.expressvpn.vpn.splash.NeonAlias}" drawable="expressvpn" name="ExpressVPN" />
+  <item component="ComponentInfo{com.unlimited.unblock.free.accelerator.top/com.unlimited.unblock.free.accelerator.top.splash.SplashActivity}" drawable="expressvpn" name="ExpressVPN" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.AmethystIcon}" drawable="exteragram" name="exteraGram" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.AuroraIcon}" drawable="exteragram" name="exteraGram" />
   <item component="ComponentInfo{com.exteragram.messenger/com.exteragram.messenger.CyberpunkIcon}" drawable="exteragram" name="exteraGram" />
@@ -5527,6 +5570,15 @@
   <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.activity.media.CameraLauncherActivity}" drawable="facebook" name="Facebook" />
   <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity}" drawable="facebook" name="Facebook" />
   <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.orca.ThreadListLauncherActivity}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.worldcup_ic}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.fab_ic}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.vaporwave_ic}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.fierce_ic}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.dreamy_ic}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.loved_ic}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.quiet_cool}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.katana}" drawable="facebook" name="Facebook" />
+  <item component="ComponentInfo{com.facebook.katana/com.facebook.katana.LoginActivity.blue_fb}" drawable="facebook" name="Facebook" />
   <item component="ComponentInfo{com.facebook.lite/com.dzebb.handler.a}" drawable="facebook" name="Facebook Lite" />
   <item component="ComponentInfo{com.facebook.lite/com.facebook.lite.MainActivity}" drawable="facebook" name="Facebook Lite" />
   <item component="ComponentInfo{com.facebook.lite/com.aincrad.application.MainActivity}" drawable="facebook_lite" name="Facebook Lite" />
@@ -5608,6 +5660,7 @@
   <item component="ComponentInfo{ru.yandex.uber/ru.yandex.taxi.activity.MainActivity}" drawable="fasten" name="Fasten" />
   <item component="ComponentInfo{ru.yandex.uber/ru.yandex.taxi.activity.StartActivity}" drawable="fasten" name="Fasten" />
   <item component="ComponentInfo{ru.yandex.uber/com.yandex.go.fasten.activity.alias.FastenTransitionAppIconStartActivityAlias}" drawable="fasten" name="Fasten" />
+  <item component="ComponentInfo{ru.yandex.uber/com.yandex.go.fasten.activity.alias.FastenTargetAppIconStartActivityAlias}" drawable="fasten" name="Fasten" />
   <item component="ComponentInfo{com.fastaccess.github.libre/com.fastaccess.ui.modules.main.MainActivity}" drawable="fasthub_libre" name="FastHub-Libre" />
   <item component="ComponentInfo{com.fastaccess.github.revival/com.fastaccess.ui.modules.main.MainActivity}" drawable="fasthub_re" name="FastHub-RE" />
   <item component="ComponentInfo{de.fastic.app/de.fastic.app.MainActivity}" drawable="fastic" name="Fastic" />
@@ -6015,6 +6068,7 @@
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.GrwmSaleIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.GoatSaleIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.SASALELEIconAlias}" drawable="flipkart" name="Flipkart" />
+  <item component="ComponentInfo{com.flipkart.android/com.flipkart.android.IdSaleIconAlias}" drawable="flipkart" name="Flipkart" />
   <item component="ComponentInfo{com.flipperdevices.app/com.flipperdevices.singleactivity.impl.SingleActivity}" drawable="flipper" name="Flipper" />
   <item component="ComponentInfo{nl.flitsmeister/nl.flitsmeister.FM_SIMPLE_BLUE}" drawable="flitsmeister" name="Flitsmeister" />
   <item component="ComponentInfo{nl.flitsmeister/nl.flitsmeister.SPEED_CAM_3D}" drawable="flitsmeister" name="Flitsmeister" />
@@ -6046,6 +6100,7 @@
   <item component="ComponentInfo{com.floweq.equalizer/com.floweq.equalizer.ui.activities.MainActivity}" drawable="flow_equalizer" name="Flow Equalizer" />
   <item component="ComponentInfo{com.floweq.equalizer/com.floweq.equalizer.ui.activities.SplashActivity}" drawable="flow_equalizer" name="Flow Equalizer" />
   <item component="ComponentInfo{com.bigduckgames.flow/com.bigduckgames.flow.flow}" drawable="flow_free" name="Flow Free" />
+  <item component="ComponentInfo{com.bigduckgames.flowbridges/com.bigduckgames.flow.flow}" drawable="flow_free" name="Flow Free" />
   <item component="ComponentInfo{com.bigduckgames.flowhexes/com.bigduckgames.flow.flow}" drawable="flow_free_hexes" name="Flow Free: Hexes" />
   <item component="ComponentInfo{com.flower.forest.word.puzzle/com.unity3d.player.UnityPlayerActivity}" drawable="flower_forest" name="Flower Forest" />
   <item component="ComponentInfo{com.bytehamster.flowitgame/com.bytehamster.flowitgame.Main}" drawable="flowit" name="Flowit!" />
@@ -6559,6 +6614,7 @@
   <item component="ComponentInfo{org.freenetproject.mobile/org.freenetproject.mobile.ui.main.activity.MainActivity}" drawable="freenet" name="Freenet" />
   <item component="ComponentInfo{de.freenet.funk/de.freenet.flex.DefaultLauncherAlias}" drawable="freenet_funk" name="Freenet FUNK" />
   <item component="ComponentInfo{de.md.meinmd/de.freenet.android.base.login.LoginActivity}" drawable="freenet_mobilfunk" name="freenet Mobilfunk" />
+  <item component="ComponentInfo{de.md.meinmd/de.freenet.android.base.MainActivity}" drawable="freenet_mobilfunk" name="freenet Mobilfunk" />
   <item component="ComponentInfo{taxi.android.client/com.mytaxi.passenger.startup.impl.ui.RouterActivity}" drawable="freenow" name="FREENOW" />
   <item component="ComponentInfo{taxi.android.client/taxi.android.client.feature.startup.ui.StartupActivity}" drawable="freenow" name="FREENOW" />
   <item component="ComponentInfo{org.fedorahosted.freeotp/org.fedorahosted.freeotp.MainActivity}" drawable="freeotp_authenticator" name="FreeOTP Authenticator" />
@@ -6873,6 +6929,7 @@
   <item component="ComponentInfo{com.groundspeak.geocaching.intro/com.groundspeak.geocaching.intro.main.MainActivity}" drawable="geocaching" name="Geocaching" />
   <item component="ComponentInfo{com.geode.launcher/com.geode.launcher.MainActivity}" drawable="geode" name="Geode" />
   <item component="ComponentInfo{com.geode.launcher/com.geode.launcher.MainActivityGeode}" drawable="geode" name="Geode" />
+  <item component="ComponentInfo{com.geode.launcher/com.geode.launcher.MainActivityPride}" drawable="geode" name="Geode" />
   <item component="ComponentInfo{com.geode.rcgdvers/com.geode.launcher.MainActivity}" drawable="geode" name="Geode For RCGD VERS" />
   <item component="ComponentInfo{com.geode.launcher/com.geode.launcher.MainActivitySapphire}" drawable="geode_sapphire_icon" name="Geode Sapphire Icon" />
   <item component="ComponentInfo{org.geogebra.android.geometry/org.geogebra.android.privatelibrary.splashscreen.SplashScreenActivity}" drawable="geogebra" name="GeoGebra" />
@@ -6919,6 +6976,7 @@
   <item component="ComponentInfo{hr.erstebank.george/at.beeone.george.splashscreen.SplashScreenVariantDefault}" drawable="george" name="George" />
   <item component="ComponentInfo{ro.bcr.georgego/at.beeone.george.app.splashscreen.SplashScreenVariantDefault}" drawable="george" name="George" />
   <item component="ComponentInfo{at.erstebank.george/at.beeone.george.splashscreen.SplashScreenVariantRed}" drawable="george" name="George" />
+  <item component="ComponentInfo{cz.csas.georgego/at.beeone.george.app.splashscreen.SplashScreenVariantDefault}" drawable="george" name="George" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.georgian/com.anysoftkeyboard.languagepack.georgian.MainActivity}" drawable="anysoftkeyboard" name="Georgian for AnySoftKeyboard" />
   <item component="ComponentInfo{io.geph.android/io.geph.android.MainActivity}" drawable="geph" name="Geph" />
   <item component="ComponentInfo{livio.pack.lang.de_DE/livio.pack.lang.de_DE.DictionaryView}" drawable="german_dictionary" name="German Dictionary" />
@@ -7068,6 +7126,7 @@
   <item component="ComponentInfo{com.gojek.app/com.gojek.home.splash.GojekSplashActivitySolvIconAlias}" drawable="gojek" name="Gojek" />
   <item component="ComponentInfo{com.gojek.app/com.gojek.app.home.GojekHomeActivityAlias}" drawable="gojek" name="Gojek" />
   <item component="ComponentInfo{com.gojek.partner/com.gojek.driver.splashscreen.SplashActivity}" drawable="gojek_driver" name="Gojek Driver" />
+  <item component="ComponentInfo{com.gojek.partner/com.gojek.driver.home.view.HomeActivity}" drawable="gojek_driver" name="Gojek Driver" />
   <item component="ComponentInfo{com.simplaapliko.goldenhour/com.simplaapliko.goldenhour.ui.LauncherActivity}" drawable="golden_hour" name="Golden Hour" />
   <item component="ComponentInfo{com.gscandroid.yk/com.gscandroid.yk.MainActivity}" drawable="golden_screen_cinemas" name="Golden Screen Cinemas" />
   <item component="ComponentInfo{com.playdemic.golf.android/com.playdemic.golf.android.Golf}" drawable="golf_clash" name="Golf Clash" />
@@ -7322,6 +7381,7 @@
   <item component="ComponentInfo{com.google.android.apps.labs.language.tailwind/com.google.android.apps.labs.language.tailwind.MainActivityDev}" drawable="google_notebooklm" name="Google NotebookLM" />
   <item component="ComponentInfo{com.google.android.apps.pixel.nowplaying/com.google.android.apps.pixel.nowplaying.mainscreen.NowPlayingMainActivity}" drawable="google_now_playing" name="Google Now Playing" />
   <item component="ComponentInfo{com.google.android.apps.subscriptions.red/com.google.android.apps.subscriptions.red.LauncherActivity}" drawable="google_one" name="Google One" />
+  <item component="ComponentInfo{com.google.android.apps.subscriptions.red/com.google.android.archive.ReactivateActivity}" drawable="google_one" name="Google One" />
   <item component="ComponentInfo{com.google.android.apps.paidtasks/com.google.android.apps.paidtasks.activity.LaunchActivity}" drawable="google_opinion_rewards" name="Google Opinion Rewards" />
   <item component="ComponentInfo{com.google.android.apps.paidtasks/com.google.android.apps.paidtasks.LaunchActivity}" drawable="google_opinion_rewards" name="Google Opinion Rewards" />
   <item component="ComponentInfo{com.google.android.apps.credentialmanager/com.google.android.apps.credentialmanager.launcher.LauncherActivity}" drawable="google_passwords" name="Google Passwords" />
@@ -7520,6 +7580,7 @@
   <item component="ComponentInfo{com.rockstargames.gtavc/com.rockstargames.gtavc.GameActivity}" drawable="grand_theft_auto_vice_city" name="Grand Theft Auto: Vice City" />
   <item component="ComponentInfo{com.rockstargames.gtavc.de/com.epicgames.ue4.GameActivity}" drawable="grand_theft_auto_vice_city" name="Grand Theft Auto: Vice City" />
   <item component="ComponentInfo{com.netflix.NGP.GTAViceCityDefinitiveEdition/com.android.support.MainActivity}" drawable="grand_theft_auto_vice_city" name="Grand Theft Auto: Vice City" />
+  <item component="ComponentInfo{com.rockstargames.gtavc/com.ty.rolling_2.proxys.MainActivity}" drawable="grand_theft_auto_vice_city" name="Grand Theft Auto: Vice City" />
   <item component="ComponentInfo{com.dvloper.granny/com.unity3d.player.UnityPlayerActivity}" drawable="granny" name="Granny" />
   <item component="ComponentInfo{com.dvloper.granny/com.dvloper.granny.UnityPlayerActivity}" drawable="granny" name="Granny" />
   <item component="ComponentInfo{com.dvloper.granny.gelin_hs.cheat/com.android.support.MainActivity}" drawable="granny" name="Granny" />
@@ -7693,6 +7754,7 @@
   <item component="ComponentInfo{com.ftw_and_co.happn/com.ftw_and_co.happn.ui.splash.SplashActivity}" drawable="happn" name="happn" />
   <item component="ComponentInfo{com.pixel.art.coloring.color.number/com.unity3d.player.HappyColorActivity}" drawable="happy_color" name="Happy Color" />
   <item component="ComponentInfo{com.pixel.art.coloring.color.number/com.fiveplay.mod.RMS.Recovery}" drawable="happy_color" name="Happy Color" />
+  <item component="ComponentInfo{com.pixel.art.coloring.color.number/com.coloring.game.MainActivity}" drawable="happy_color" name="Happy Color" />
   <item component="ComponentInfo{com.hcceg.veg.compassionfree/com.sisow.hcvg.healthydiningguide.app.splash.ui.SplashScreenActivity}" drawable="happycow" name="HappyCow" />
   <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.allfunction.LaunchActivity}" drawable="happymod" name="HappyMod" />
   <item component="ComponentInfo{com.happymod.apk/com.happymod.apk.hmmvp.main.LaunchActivity}" drawable="happymod" name="HappyMod" />
@@ -8048,6 +8110,7 @@
   <item component="ComponentInfo{com.htc.pitroad/com.htc.pitroad.landingpage.activity.LandingPageActivity}" drawable="htc_boost_plus" name="HTC Boost+" />
   <item component="ComponentInfo{com.qamar.editor.html/com.alif.app.AppActivity}" drawable="html_editor" name="Html Editor" />
   <item component="ComponentInfo{xyz.easypro.httpcustom/team.dev.epro.apkcustom.MainActivity}" drawable="http_custom" name="HTTP Custom" />
+  <item component="ComponentInfo{xyz.easypro.httpcustom/dev.epro.httpcustom.MainActivity}" drawable="http_custom" name="HTTP Custom" />
   <item component="ComponentInfo{com.evozi.injector/com.evozi.injector.views.MainActivity}" drawable="http_injector" name="HTTP Injector" />
   <item component="ComponentInfo{ch.rmy.android.http_shortcuts/ch.rmy.android.http_shortcuts.activities.misc.second_launcher.SecondLauncherActivity}" drawable="http_request_shortcuts" name="HTTP Request Shortcuts" />
   <item component="ComponentInfo{ch.rmy.android.http_shortcuts/ch.rmy.android.http_shortcuts.activities.main.MainActivity}" drawable="http_request_shortcuts" name="HTTP Request Shortcuts" />
@@ -8388,6 +8451,7 @@
   <item component="ComponentInfo{com.csam.icici.bank.imobile/com.csam.icici.bank.imobile.launcher_be5fee416d17a4d4bdcf67199a9cbb9893a784e44dbdba19087c3db5e1e61f81}" drawable="imobile_pay" name="iMobile Pay" />
   <item component="ComponentInfo{com.csam.icici.bank.imobile/com.csam.icici.bank.imobile.ICICIActivity}" drawable="imobile_pay" name="iMobile Pay" />
   <item component="ComponentInfo{com.csam.icici.bank.imobile/com.csam.icici.bank.imobile.IMOBILE}" drawable="imobile_pay" name="iMobile Pay" />
+  <item component="ComponentInfo{com.csam.icici.bank.imobile/com.icici.v3.activation.presentation.welcome.activity.WelcomeActivity}" drawable="imobile_pay" name="iMobile Pay" />
   <item component="ComponentInfo{com.imod.technobankai/com.imod.technobankai.mainactivity}" drawable="imod_pro" name="iMOD Pro" />
   <item component="ComponentInfo{com.mm.android.smartlifeiot/com.mm.android.easy4ip.SplashActivity}" drawable="imou_life" name="Imou Life" />
   <item component="ComponentInfo{com.mm.android.smartlifeiot/com.mm.android.ims.SplashActivity}" drawable="imou_life" name="Imou Life" />
@@ -8432,6 +8496,7 @@
   <item component="ComponentInfo{sinet.startup.inDriver/sinet.startup.inDriver.ui.splash.SplashActivity}" drawable="indrive" name="inDrive" />
   <item component="ComponentInfo{com.iexceed.ib.digitalbankingprod/com.iexceed.SplashScreen}" drawable="indsmart" name="IndSMART" />
   <item component="ComponentInfo{ai.sarvam.indus/ai.sarvam.indus.MainActivity}" drawable="indus" name="Indus" />
+  <item component="ComponentInfo{ai.sarvam.indus/ai.sarvam.app.MainActivity}" drawable="indus" name="Indus" />
   <item component="ComponentInfo{com.indus.appstore/com.indus.appstore.DefaultIconLauncherActivityAlias}" drawable="indus_appstore" name="Indus Appstore" />
   <item component="ComponentInfo{com.indus.appstore/com.indus.appstore.applicationLayer.onboarding.activity.LauncherActivity}" drawable="indus_appstore" name="Indus Appstore" />
   <item component="ComponentInfo{com.indus.appstore/com.indus.appstore.BetaIconLauncherActivityAlias}" drawable="indus_appstore_beta" name="Indus Appstore Beta" />
@@ -8472,6 +8537,7 @@
   <item component="ComponentInfo{lu.ing.mying.app/com.ing.banking.framework.features.welcome.WelcomeActivity}" drawable="ing" name="ING" />
   <item component="ComponentInfo{lu.ing.myingpro/com.ing.lu.mobile.activities.WrapperActivity}" drawable="ing" name="ING" />
   <item component="ComponentInfo{com.ing.mobile/com.ing.mobile.app.activities.SplashActivity}" drawable="ing" name="ING" />
+  <item component="ComponentInfo{au.com.ing.banking/com.ing.banking.framework.features.welcome.WelcomeActivity}" drawable="ing" name="ING" />
   <item component="ComponentInfo{com.comarch.security.mobilebanking/pl.ing.ingflutter.MainActivity}" drawable="ing" name="ING Business" />
   <item component="ComponentInfo{ru.ingos.ingomobile/ru.ingos.ingomobile.navigation.SingleActivity}" drawable="ingomobile" name="IngoMobile" />
   <item component="ComponentInfo{com.nianticproject.ingress/com.nianticproject.ingress.NemesisActivity}" drawable="ingress_prime" name="Ingress Prime" />
@@ -8570,6 +8636,7 @@
   <item component="ComponentInfo{com.transsion.insync.life/com.transsion.insync.life.FlashActivity}" drawable="insync" name="InSync" />
   <item component="ComponentInfo{com.intel.mde/com.screenovate.webphone.app.mde.MainActivity}" drawable="intel_unison" name="Intel Unison" />
   <item component="ComponentInfo{de.k3b.android.intentintercept/uk.co.ashtonbrsc.intentexplode.StartupActivity}" drawable="apk_info" name="Intent Intercept" />
+  <item component="ComponentInfo{de.k3b.android.intentintercept/de.k3b.intentintercept.SettingsActivity}" drawable="apk_info" name="Intent Intercept" />
   <item component="ComponentInfo{br.com.intermedium/br.com.intermedium.SplashActivity}" drawable="inter" name="Inter" />
   <item component="ComponentInfo{br.com.intermedium/br.com.intermedium.splash.SplashActivity}" drawable="inter" name="Inter" />
   <item component="ComponentInfo{br.com.Inter.CDPro/br.com.intermedium.splash.SplashActivity}" drawable="inter" name="Inter Empresas" />
@@ -9071,6 +9138,7 @@
   <item component="ComponentInfo{com.kunzisoft.hardware.key/com.kunzisoft.hardware.key.presentation.AppActivity}" drawable="key_driver" name="Key Driver" />
   <item component="ComponentInfo{io.github.sds100.keymapper/io.github.sds100.keymapper.SplashActivity}" drawable="key_mapper" name="Key Mapper" />
   <item component="ComponentInfo{io.github.sds100.keymapper/io.github.sds100.keymapper.MainActivity}" drawable="key_mapper" name="Key Mapper" />
+  <item component="ComponentInfo{io.github.sds100.keymapper/io.github.sds100.keymapper.mappings.assistant.DeviceAssistantActivity}" drawable="key_mapper" name="Key Mapper" />
   <item component="ComponentInfo{com.artemchep.keyguard/com.artemchep.keyguard.android.MainActivity}" drawable="keyguard_for_bitwarden" name="Keyguard for Bitwarden" />
   <item component="ComponentInfo{com.dvdfu.keylimba/com.unity3d.player.UnityPlayerActivity}" drawable="keylimba" name="Keylimba" />
   <item component="ComponentInfo{com.tavultesoft.kmapro/com.tavultesoft.kmapro.SplashScreenActivity}" drawable="keyman" name="Keyman" />
@@ -9360,6 +9428,7 @@
   <item component="ComponentInfo{com.kwai.video/com.yxcorp.gifshow.tiny.TinyLaunchActivity}" drawable="kwai" name="Kwai" />
   <item component="ComponentInfo{com.kwai.video/com.yxcorp.gifshow.homepage.HomeActivity}" drawable="kwai" name="Kwai" />
   <item component="ComponentInfo{com.kwai.kuaishou.video.live/com.yxcorp.gifshow.tiny.TinyLaunchActivity}" drawable="kwai" name="Kwai" />
+  <item component="ComponentInfo{com.kwai.kuaishou.video.live/com.yxcorp.gifshow.homepage.HomeActivity}" drawable="kwai" name="Kwai" />
   <item component="ComponentInfo{kwai.lite.video/com.yxcorp.gifshow.tiny.TinyLaunchActivity}" drawable="kwai" name="Kwai Lite" />
   <item component="ComponentInfo{org.kustom.widget/com.duapps.ad.DuAd}" drawable="kwgt" name="KWGT" />
   <item component="ComponentInfo{org.kustom.widget/org.kustom.app.OnBoardingActivity}" drawable="kwgt" name="KWGT" />
@@ -9706,6 +9775,7 @@
   <item component="ComponentInfo{jp.linecorp.linemusic.android/com.naver.vibe.MainHolderActivity}" drawable="line_music" name="LINE MUSIC" />
   <item component="ComponentInfo{com.linecorp.lineoa/com.linecorp.lineoa.MainActivity}" drawable="line_official_account" name="LINE Official Account" />
   <item component="ComponentInfo{line.vrapp.com/line.vrapp.com.activities.SplashActivity}" drawable="line_vpn" name="Line VPN" />
+  <item component="ComponentInfo{line.vrapp.com/base.appservice.com.activities.SplashActivity}" drawable="line_vpn" name="Line VPN" />
   <item component="ComponentInfo{org.lineageos.glimpse/org.lineageos.glimpse.MainActivity}" drawable="generic_gallery" name="LineageOS Gallery" />
   <item component="ComponentInfo{org.lineageos.glimpse.dev/org.lineageos.glimpse.MainActivity}" drawable="generic_gallery_dev" name="LineageOS Gallery Dev" />
   <item component="ComponentInfo{org.lineageos.jelly/org.lineageos.jelly.MainActivity}" drawable="lineageos_jelly_browser" name="LineageOS Jelly Browser" />
@@ -9785,6 +9855,7 @@
   <item component="ComponentInfo{pro.listy/pro.listy.presentation.MainActivity}" drawable="listy" name="Listy" />
   <item component="ComponentInfo{com.loptr.kherod.uygdl/com.loptr.kherod.uygdl.activity.MainActivity}" drawable="generic_player" name="lite player" />
   <item component="ComponentInfo{com.liteapks.androidapps/com.liteapks.ui.home.HomeActivity}" drawable="liteapks" name="Liteapks" />
+  <item component="ComponentInfo{com.liteapks.androidapps/com.liteapks.androidapps.ui.home.HomeActivity}" drawable="liteapks" name="Liteapks" />
   <item component="ComponentInfo{com.literal/com.zoontek.rnbootsplash.RNBootSplashActivity}" drawable="literal_club" name="Literal Club" />
   <item component="ComponentInfo{com.literal/com.literal.MainActivity}" drawable="literal_club" name="Literal Club" />
   <item component="ComponentInfo{com.literalword.mobile_app/com.literalword.mobile_app.MainActivity}" drawable="generic_bible" name="Literal Word" />
@@ -10238,6 +10309,7 @@
   <item component="ComponentInfo{com.bagatrix.mathway.android/com.bagatrix.mathway.android.SplashActivity}" drawable="mathway" name="Mathway" />
   <item component="ComponentInfo{com.bagatrix.mathway.android/com.chegg.feature.mathway.ui.splash.SplashActivity}" drawable="mathway" name="Mathway" />
   <item component="ComponentInfo{com.matiks.app/com.matiks.app.MainActivityDefault}" drawable="matiks" name="Matiks" />
+  <item component="ComponentInfo{com.matiks.app/com.matiks.app.MainActivity}" drawable="matiks" name="Matiks" />
   <item component="ComponentInfo{com.pluscubed.matlog/com.pluscubed.logcat.ui.LogcatActivity}" drawable="matlog" name="MatLog" />
   <item component="ComponentInfo{org.omnirom.logcat/com.pluscubed.logcat.ui.LogcatActivity}" drawable="matlog" name="MatLog" />
   <item component="ComponentInfo{com.pluscubed.matloglibre/com.pluscubed.logcat.ui.LogcatActivity}" drawable="matlog" name="MatLog Libre" />
@@ -10249,6 +10321,7 @@
   <item component="ComponentInfo{in.mediassist.malite/com.malite.MainActivity}" drawable="maven" name="MAven" />
   <item component="ComponentInfo{com.maverik.rewards/com.maverik.rewards.MainActivity}" drawable="maverik_rewards" name="Maverik Rewards" />
   <item component="ComponentInfo{com.mavi.kartus/com.mavi.kartus.MainActivityAlias1}" drawable="mavi" name="Mavi" />
+  <item component="ComponentInfo{com.mavi.kartus/com.mavi.kartus.core.MainActivity}" drawable="mavi" name="Mavi" />
   <item component="ComponentInfo{se.max.android.locator/com.google.android.archive.ReactivateActivity}" drawable="max" name="Max" />
   <item component="ComponentInfo{se.max.android.locator/se.max.android.locator.MainActivity}" drawable="max" name="Max" />
   <item component="ComponentInfo{se.max.android.locator/com.futureordering.android.mobile.ui.main.MainActivity}" drawable="max" name="Max" />
@@ -10299,6 +10372,7 @@
   <item component="ComponentInfo{ph.mobext.mcdelivery/ph.mobext.mcdelivery.view.splash.SplashActivity}" drawable="mcdelivery" name="McDelivery" />
   <item component="ComponentInfo{com.md.mcdonalds.gomcdo/main.java.com.md.mcdonalds.gomcdo.activities.SplashscreenActivity}" drawable="mcdo_plus" name="McDo+" />
   <item component="ComponentInfo{com.md.mcdonalds.gomcdo/fr.unifymcd.mcdplus.ui.MainActivity}" drawable="mcdo_plus" name="McDo+" />
+  <item component="ComponentInfo{com.md.mcdonalds.gomcdo/fr.unifymcd.mcdplus.ui.MainActivityDefault}" drawable="mcdo_plus" name="McDo+" />
   <item component="ComponentInfo{com.mcdonalds.mobileapp/com.mcdonalds.mobileapp.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdonalds.mobileapp/com.mcdonalds.mobileapp.redesign.MainActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdo.mcdonalds/com.gigigo.mcdonaldsbr.modules.splash.SplashActivity}" drawable="mcdonalds" name="McDonald's" />
@@ -10327,6 +10401,7 @@
   <item component="ComponentInfo{com.mcdonalds.mcdonaldsgt/com.mcdelivery.MainActivity}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mcdonalds.gma.cn/com.mcdonalds.gma.cn.activity.LaunchActivity.cny}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{il.co.inmanage.mcdonalds/il.co.inmanage.mcdonalds.activities.UnifiedMcActivity}" drawable="mcdonalds" name="McDonald's" />
+  <item component="ComponentInfo{com.mcdo.mcdonalds/com.gigigo.mcdonaldsbr.ui.activities.splash.SplashActivityDefault}" drawable="mcdonalds" name="McDonald's" />
   <item component="ComponentInfo{com.mysports.branded.mcfit/com.mysports.branded.mcfit.ms_mobile_app_mcfit.MainActivity}" drawable="mcfit" name="McFIT" />
   <item component="ComponentInfo{com.mysports.branded.mcfit/com.mysports.branded.premium.MainActivity}" drawable="mcfit" name="McFIT" />
   <item component="ComponentInfo{nz.co.solus.Kotui.Manawatu/solus.Libraries.MainActivity}" drawable="mchl_feilding" name="MCHL Feilding" />
@@ -10463,6 +10538,7 @@
   <item component="ComponentInfo{com.meizu.media.music/com.meizu.media.music.MusicActivity}" drawable="meizu_music" name="Meizu Music" />
   <item component="ComponentInfo{com.martinmagni.mekorama/com.martinmagni.mekorama.Mekorama}" drawable="mekorama" name="Mekorama" />
   <item component="ComponentInfo{com.meld.app/com.metrolist.music.MainActivityAlias}" drawable="music_player" name="Meld" />
+  <item component="ComponentInfo{com.meld.app/com.metrolist.music.MainActivityStatic}" drawable="music_player" name="Meld" />
   <item component="ComponentInfo{com.anticor.mellowdark/com.anticor.mellowdark.MainActivity}" drawable="mellow_dark_icons" name="Mellow Dark Icons" />
   <item component="ComponentInfo{com.anticor.mellowdark/com.anticor.mellowdark.activities.SplashActivity}" drawable="mellow_dark_icons" name="Mellow Dark Icons" />
   <item component="ComponentInfo{com.midicontroller.melodi/com.midicontroller.melodi.SplashActivity}" drawable="generic_piano" name="Melodi MIDI Controller" />
@@ -10699,8 +10775,10 @@
   <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.TestAlias7}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.TestAlias2}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.TestAlias8}" drawable="mi_video" name="Mi Video" />
+  <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.ExpAlias1}" drawable="mi_video" name="Mi Video" />
+  <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.ExpAlias3}" drawable="mi_video" name="Mi Video" />
+  <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.ExpAlias2}" drawable="mi_video" name="Mi Video" />
   <item component="ComponentInfo{es.vodafone.mobile.mivodafone/com.tsse.spain.myvodafone.splash.view.VfSplashActivity}" drawable="my_vodafone" name="Mi Vodafone" />
-  <item component="ComponentInfo{com.miui.videoplayer/com.miui.video.global.app.ExpAlias1}" drawable="mi_video" name="Mi Vídeo" />
   <item component="ComponentInfo{com.xiaomi.router/com.xiaomi.router.module.splash.SplashActivity}" drawable="mi_wi_fi" name="Mi Wi-Fi" />
   <item component="ComponentInfo{com.jlong.miccheck/com.jlong.miccheck.MainActivity}" drawable="miccheck" name="MicCheck" />
   <item component="ComponentInfo{com.michatapp.im/com.michatapp.launch.LaunchActivity}" drawable="michat" name="MiChat" />
@@ -10847,6 +10925,7 @@
   <item component="ComponentInfo{com.gameparadiso.milkchoco/org.cocos2dx.cpp.AppActivity}" drawable="milkchoco" name="MilkChoco" />
   <item component="ComponentInfo{jp.panta.misskeyandroidclient/jp.panta.misskeyandroidclient.MainActivity}" drawable="milktea_for_misskey" name="Milktea for Misskey" />
   <item component="ComponentInfo{com.solidict.millenicom/com.solidict.millenicom.activities.SplashActivity}" drawable="millenicom" name="Millenicom" />
+  <item component="ComponentInfo{com.solidict.millenicom/com.solidict.millenicom.MainActivityDefault}" drawable="millenicom" name="Millenicom" />
   <item component="ComponentInfo{com.morizero.milthm/com.morizero.milthm.Milauncher}" drawable="milthm" name="Milthm" />
   <item component="ComponentInfo{com.morizero.milthm/com.unity3d.player.UnityPlayerActivity}" drawable="milthm" name="Milthm" />
   <item component="ComponentInfo{com.getmimo/com.getmimo.ui.SplashActivity_ninja}" drawable="mimo" name="Mimo" />
@@ -11142,6 +11221,7 @@
   <item component="ComponentInfo{com.realbyteapps.moneymanagerfree/com.realbyte.money.ui.intro.Intro}" drawable="money_manager" name="Money Manager" />
   <item component="ComponentInfo{ru.innim.my_finance/ru.innim.my_finance.MainActivityAlias2}" drawable="money_manager" name="Money Manager" />
   <item component="ComponentInfo{ru.innim.my_finance/ru.innim.my_finance.MainActivity}" drawable="money_manager" name="Money Manager" />
+  <item component="ComponentInfo{ru.innim.my_finance/ru.innim.my_finance.MainActivityAlias1}" drawable="money_manager" name="Money manager" />
   <item component="ComponentInfo{com.blogspot.e_kanivets.moneytracker/com.blogspot.e_kanivets.moneytracker.activity.record.MainActivity}" drawable="money_tracker" name="Money Tracker" />
   <item component="ComponentInfo{com.moneyboxapp/com.moneyboxapp.app.REGULAR}" drawable="moneybox" name="Moneybox" />
   <item component="ComponentInfo{com.divum.MoneyControl/com.moneycontrol.handheld.SplashActivity.PRO}" drawable="moneycontrol" name="Moneycontrol" />
@@ -11293,6 +11373,7 @@
   <item component="ComponentInfo{com.motorola.ccc.notification/com.motorola.engageapp.ui.EngageActivity}" drawable="moto_notifications" name="Moto Notifications" />
   <item component="ComponentInfo{com.motorola.ccc.notification/com.motorola.engageapp.ui.HelloYouActivity}" drawable="moto_notifications" name="Moto Notifications" />
   <item component="ComponentInfo{com.motorola.ccc.notification/com.motorola.engageapp.ui.MotoNewsActivity}" drawable="moto_notifications" name="Moto Notifications" />
+  <item component="ComponentInfo{com.motorola.ccc.notification/com.motorola.engageapp.ui.HelloFeedActivity}" drawable="moto_notifications" name="Moto Notifications" />
   <item component="ComponentInfo{com.motorola.oemconfig.rel/com.motorola.oemconfig.rel.activities.MainActivity}" drawable="moto_oemconfig" name="Moto OEMConfig" />
   <item component="ComponentInfo{com.motorola.audiorecorder/com.motorola.audiorecorder.ui.main.MainActivity}" drawable="generic_voice_recorder_waves" name="Moto Recorder" />
   <item component="ComponentInfo{com.motorola.securityhub/com.motorola.securityhub.ui.view.MainActivity}" drawable="moto_secure" name="Moto Secure" />
@@ -11321,6 +11402,7 @@
   <item component="ComponentInfo{com.moveinsync.ets/com.moveinsync.ets.launch.LaunchActivity}" drawable="moveinsync" name="MoveInSync" />
   <item component="ComponentInfo{ar.com.crayonweb.movitaxi/ar.com.crayonweb.movitaxi.MainActivity}" drawable="movi_plus" name="Movi+" />
   <item component="ComponentInfo{com.moviebase/com.moviebase.ui.main.MainActivity}" drawable="moviebase" name="Moviebase" />
+  <item component="ComponentInfo{com.moviebase/app.moviebase.ui.main.MainActivity}" drawable="moviebase" name="Moviebase" />
   <item component="ComponentInfo{com.community.mbox.in/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
   <item component="ComponentInfo{com.community.mbox.ke/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
   <item component="ComponentInfo{com.community.oneroom/com.transsion.subroom.activity.SplashActivity}" drawable="moviebox" name="MovieBox" />
@@ -11438,6 +11520,7 @@
   <item component="ComponentInfo{com.appmusicdownload.musicdownloadervani2app/com.appmusicdownload.musicdownloadervani2app.view.splash.SplashActivity}" drawable="apple_music" name="Music Downloader" />
   <item component="ComponentInfo{com.musicdownloader.appdownloadmusic252/com.musicdownloader.appdownloadmusic252.ui.splash.SplashActivity}" drawable="apple_music" name="Music Downloader" />
   <item component="ComponentInfo{com.musicdownload.appmusicdownloader2025/com.musicdownload.appmusicdownloader2025.SplashActivity}" drawable="apple_music" name="Music Downloader" />
+  <item component="ComponentInfo{com.musicdownloader.musicfreeapp825v2/com.musicdownloader.appdownloadmusic25.ui.splash.SplashActivity}" drawable="apple_music" name="Music Downloader" />
   <item component="ComponentInfo{com.binghuo.audioeditor.mp3editor.musiceditor/com.binghuo.audioeditor.mp3editor.musiceditor.launcher.LauncherActivity}" drawable="generic_audio_editor" name="Music Editor" />
   <item component="ComponentInfo{com.fragileheart.mp3editor/com.fragileheart.mp3editor.activity.SplashActivity}" drawable="generic_audio_editor" name="Music Editor" />
   <item component="ComponentInfo{com.brainfm.app/com.brainfm.app.MainActivity}" drawable="music_for_focus" name="Music for Focus" />
@@ -11456,6 +11539,7 @@
   <item component="ComponentInfo{media.mp3player.musicplayer/com.ijoysoft.music.activity.WelcomeActivity}" drawable="apple_music" name="Music Player" />
   <item component="ComponentInfo{music.musicplayer/com.android.music.SplashActivity}" drawable="apple_music" name="Music Player" />
   <item component="ComponentInfo{com.nexnil.mediaplayer/com.musicplayer.mediaplayer.activities.PermissionActivity}" drawable="apple_music" name="Music Player" />
+  <item component="ComponentInfo{com.rocks.music/com.rocks.music.musicplayer.MusicSplash}" drawable="apple_music" name="Music Player" />
   <item component="ComponentInfo{musicplayer.musicapps.music.mp3player/musicplayer.musicapps.music.mp3player.activities.SplashActivity}" drawable="music_player_and_mp3_player" name="Music Player &amp; MP3 Player" />
   <item component="ComponentInfo{com.iven.musicplayergo/com.iven.musicplayergo.MainActivity}" drawable="music_player_go" name="Music Player GO" />
   <item component="ComponentInfo{com.iven.musicplayergo/com.iven.musicplayergo.ui.MainActivity}" drawable="music_player_go" name="Music Player GO" />
@@ -11471,6 +11555,7 @@
   <item component="ComponentInfo{hr.podlanica/hr.podlanica.Start}" drawable="music_volume_eq" name="Music Volume EQ" />
   <item component="ComponentInfo{com.lstapps.musicwidgetandroid12/com.lstapps.musicwidgetandroid12.MainActivity}" drawable="music_widget_android" name="Music Widget Android" />
   <item component="ComponentInfo{com.github.musicyou/it.vfsfitvnm.vimusic.MainActivity}" drawable="music_player" name="Music You" />
+  <item component="ComponentInfo{com.github.musicyou/com.github.musicyou.MainActivity}" drawable="music_player" name="Music You" />
   <item component="ComponentInfo{com.yamaha.av.musiccastcontroller/com.yamaha.av.musiccastcontroller.activity.MainActivity}" drawable="musiccast" name="MusicCast" />
   <item component="ComponentInfo{com.maximillianleonov.musicmax/com.maximillianleonov.musicmax.MusicmaxActivity}" drawable="musicmax" name="Musicmax" />
   <item component="ComponentInfo{in.krosbits.musicolet/in.krosbits.musicolet.MusicActivity}" drawable="musicolet_music_player" name="Musicolet Music Player" />
@@ -11672,8 +11757,10 @@
   <item component="ComponentInfo{al.myvodafone.android/com.oneapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{au.com.vodafone.mobile.gss/com.vfmobileapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{com.VodafoneIreland.MyVodafone/com.oneapp.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
+  <item component="ComponentInfo{com.vodafone.android/com.vodafone.android.MainActivity}" drawable="my_vodafone" name="My Vodafone" />
   <item component="ComponentInfo{com.vodafone.selfservis/com.vodafone.selfservis.FiveGAlias}" drawable="_5g_only" name="My Vodafone 5G" />
   <item component="ComponentInfo{fr.meteo/fr.meteo.activity.SplashscreenActivity_}" drawable="my_weather" name="My Weather" />
+  <item component="ComponentInfo{fr.meteo/fr.meteo.app.MainActivity}" drawable="my_weather" name="My Weather" />
   <item component="ComponentInfo{com.myworkoutplan.myworkoutplan/com.myworkoutplan.myworkoutplan.MainActivity}" drawable="my_workout_plan" name="My Workout Plan" />
   <item component="ComponentInfo{jp.co.yamahamotor.myyamahamotor/crc6414aa322ddbc6eef4.MainActivity}" drawable="my_yamaha_motor" name="My Yamaha Motor" />
   <item component="ComponentInfo{jp.co.yamahamotor.myyamahamotor/crc64941fda3054e05170.MainActivity}" drawable="my_yamaha_motor" name="My Yamaha Motor" />
@@ -11938,8 +12025,10 @@
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.ShadeIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.NamiweenIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.OokamiIcon}" drawable="namida" name="Namida" />
+  <item component="ComponentInfo{com.msob7y.namida/com.msob7y.namida.EddyIcon}" drawable="namida" name="Namida" />
   <item component="ComponentInfo{in.juspay.nammayatri/in.juspay.mobility.MainActivity}" drawable="namma_yatri" name="Namma Yatri" />
   <item component="ComponentInfo{in.juspay.nammayatri/com.mobility.movingtech.MainActivity}" drawable="namma_yatri" name="Namma Yatri" />
+  <item component="ComponentInfo{in.juspay.nammayatri/com.mobility.movingtech.AppIconAlias_default}" drawable="namma_yatri" name="Namma Yatri" />
   <item component="ComponentInfo{com.kazufukurou.nanji/com.kazufukurou.nanji.ui.MainActivity}" drawable="nanji_clock_widget" name="Nanji Clock Widget" />
   <item component="ComponentInfo{me.nanoleaf.nanoleaf/me.nanoleaf.nanoleaf.activities.SplashActivity}" drawable="nanoleaf" name="Nanoleaf" />
   <item component="ComponentInfo{me.nanoleaf.nanoleaf/me.nanoleaf.nanoleaf.feature.launcher.LauncherActivity}" drawable="nanoleaf" name="Nanoleaf" />
@@ -11950,6 +12039,7 @@
   <item component="ComponentInfo{com.franco.doze/com.franco.doze.activities.SplashActivity}" drawable="sleep" name="Naptime" />
   <item component="ComponentInfo{com.tarjetanaranja.ncuenta/com.naranja.ncuenta.app.ui.startup.StartupActivity}" drawable="naranja_x" name="Naranja X" />
   <item component="ComponentInfo{com.tarjetanaranja.ncuenta/com.naranja.ncuenta.app.ui.startup.StartupActivityWorldCup}" drawable="naranja_x" name="Naranja X" />
+  <item component="ComponentInfo{com.naranjax.mx/com.naranjax.MainActivity}" drawable="naranja_x" name="Naranja X" />
   <item component="ComponentInfo{xyz.narrowarrow.app/xyz.narrowarrow.app.MainActivity}" drawable="narrow_arrow" name="Narrow Arrow" />
   <item component="ComponentInfo{pl.stokrotka.app/pl.stokrotka.app.MainActivity}" drawable="nasza_stokrotka" name="Nasza Stokrotka" />
   <item component="ComponentInfo{pl.librus.synergiaJst/pl.librus.synergiaJst.MainActivity}" drawable="nasze_szkoly" name="Nasze Szkoły" />
@@ -11959,6 +12049,7 @@
   <item component="ComponentInfo{ca.bnc.android/ca.bnc.android.custom.BncMainActivity}" drawable="national_bank_of_canada" name="National Bank of Canada" />
   <item component="ComponentInfo{be.loterienationaleloterij/be.loterienationaleloterij.app.splash.SplashActivity}" drawable="national_lottery_belgium" name="National Lottery Belgium" />
   <item component="ComponentInfo{uk.co.nationalrail.google/uk.co.fortunecookie.nre.activities.SplashScreen}" drawable="national_rail" name="National Rail" />
+  <item component="ComponentInfo{uk.co.nationalrail.google/uk.co.nationalrail.google.MainActivity}" drawable="national_rail" name="National Rail" />
   <item component="ComponentInfo{com.abhyas.nta.com/com.embibe.app.activities.SplashActivity}" drawable="national_test_abhyas" name="National Test Abhyas" />
   <item component="ComponentInfo{cris.icms.ntes/cris.icms.ntes.LaunchApp}" drawable="national_train_enquiry_system" name="National Train Enquiry System" />
   <item component="ComponentInfo{co.uk.Nationwide.Mobile/co.uk.Nationwide.Mobile.ui.MainActivity}" drawable="nationwide_bank" name="Nationwide Bank" />
@@ -11986,6 +12077,8 @@
   <item component="ComponentInfo{com.naver.whale/com.google.android.apps.chrome.Main}" drawable="naver_whale_browser" name="Naver Whale Browser" />
   <item component="ComponentInfo{com.naviapp/com.naviapp.home.compose.activity.HomePageActivity}" drawable="navi" name="Navi" />
   <item component="ComponentInfo{paige.navic/paige.navic.androidApp.MainActivity}" drawable="navic" name="Navic" />
+  <item component="ComponentInfo{paige.navic/paige.navic.MainActivityDefault}" drawable="navic" name="Navic" />
+  <item component="ComponentInfo{paige.navic/paige.navic.MainActivity}" drawable="navic" name="Navic" />
   <item component="ComponentInfo{com.eab.se/com.eab.se.MainActivity}" drawable="navigate360_student" name="Navigate360 Student" />
   <item component="ComponentInfo{nu.nav.float/nu.nav.bar.activity.WelcomeActivity}" drawable="navigation_bar" name="Navigation Bar" />
   <item component="ComponentInfo{nu.nav.bar/nu.nav.bar.activity.WelcomeActivity}" drawable="navigation_bar" name="Navigation Bar" />
@@ -12405,6 +12498,7 @@
   <item component="ComponentInfo{notion.id/notion.local.id.MainActivity}" drawable="notion" name="Notion" />
   <item component="ComponentInfo{com.cron.calendar/com.cron.calendar.MainActivity}" drawable="notion_calendar" name="Notion Calendar" />
   <item component="ComponentInfo{com.tenqube.notisave/com.tenqube.notisave.presentation.splash.SplashActivity}" drawable="notisave" name="Notisave" />
+  <item component="ComponentInfo{com.tenqube.notisave/com.zipoapps.premiumhelper.ui.splash.PHSplashActivity}" drawable="notisave" name="Notisave" />
   <item component="ComponentInfo{com.noto/com.noto.app.Airplane}" drawable="noto" name="Noto" />
   <item component="ComponentInfo{com.noto/com.noto.app.AppActivity}" drawable="noto" name="Noto" />
   <item component="ComponentInfo{com.noto/com.noto.app.BlossomIce}" drawable="noto" name="Noto" />
@@ -12533,6 +12627,7 @@
   <item component="ComponentInfo{com.nunti/com.nunti.MainActivity}" drawable="nunti" name="Nunti" />
   <item component="ComponentInfo{com.nuvempay/com.nuvempay.MainActivity}" drawable="nuvem" name="Nuvem" />
   <item component="ComponentInfo{com.nuvio.app/com.nuvio.app.MainActivity}" drawable="nuvio" name="Nuvio" />
+  <item component="ComponentInfo{com.nuvio.app/com.nuvio.app.launcher.AppIconRoseGold}" drawable="nuvio" name="Nuvio" />
   <item component="ComponentInfo{it.madisoft.areatutorestudente/it.madisoft.areatutorestudente.MainActivity}" drawable="nuvola" name="Nuvola" />
   <item component="ComponentInfo{com.nvidia.geforcenow/com.nvidia.geforcenow.LauncherActivity}" drawable="nvidia_geforce_now" name="NVIDIA GeForce NOW" />
   <item component="ComponentInfo{com.nvidia.geforcenow/com.nvidia.tegrazone.MainActivity}" drawable="nvidia_geforce_now" name="NVIDIA GeForce NOW" />
@@ -12859,6 +12954,7 @@
   <item component="ComponentInfo{app.youicons.moto/app.youicons.moto.MainActivity}" drawable="oneyou_icons" name="OneYou Moto Icons" />
   <item component="ComponentInfo{com.pashapuma.oneyou.themed/com.pashapuma.oneyou.themed.activities.MainActivity}" drawable="oneyou_icons" name="OneYou Themed Icons" />
   <item component="ComponentInfo{com.pashapuma.oneyou.themed/com.pashapuma.oneyou.themed.activities.SplashActivity}" drawable="oneyou_icons" name="OneYou Themed Icons" />
+  <item component="ComponentInfo{com.pashapuma.oneyou.themed/com.pashapuma.oneyou.themed.MiniFolderLauncherIcon}" drawable="oneyou_icons" name="OneYou Themed Icons" />
   <item component="ComponentInfo{com.pashapuma.oneyou.accent/com.pashapuma.oneyou.accent.activities.MainActivity}" drawable="oneyou_icons" name="OneYou Three Accent Icons" />
   <item component="ComponentInfo{com.pashapuma.oneyou.accent/com.pashapuma.oneyou.accent.activities.SplashActivity}" drawable="oneyou_icons" name="OneYou Three Accent Icons" />
   <item component="ComponentInfo{pk.com.onic/com.circles.selfcare.v2.splash.LaunchActivity}" drawable="onic" name="Onic" />
@@ -13167,6 +13263,7 @@
   <item component="ComponentInfo{sarangal.packagemanager/sarangal.packagemanager.presentation.activities.MainActivity}" drawable="package_manager" name="Package Manager" />
   <item component="ComponentInfo{com.csdroid.pkg/com.csdroid.pkg.ui.home.MainActivity}" drawable="package_name_viewer" name="Package Name Viewer" />
   <item component="ComponentInfo{com.csdroid.pkg/com.csdroid.pkg.MainActivity}" drawable="package_name_viewer" name="Package Name Viewer" />
+  <item component="ComponentInfo{com.csdroid.pkg/com.csdroid.pkg.ui.MainActivity}" drawable="package_name_viewer" name="Package Name Viewer" />
   <item component="ComponentInfo{com.csdroid.pkg.pro/com.csdroid.pkg.MainActivity}" drawable="package_names_pro" name="Package Names Pro" />
   <item component="ComponentInfo{com.trackinglabs.parceltracker/com.trackinglabs.parceltracker.activity.SplashActivity}" drawable="package_tracking" name="Package Tracking" />
   <item component="ComponentInfo{cz.seeq.prog.android.packageviewer/cz.seeq.prog.android.packageviewer.PackagesActivity}" drawable="package_viewer" name="Package Viewer" />
@@ -13187,6 +13284,7 @@
   <item component="ComponentInfo{com.bonc.paintmyroom/com.bonc.paint_my_room.MainActivity}" drawable="substratum_lite" name="Paint my Room" />
   <item component="ComponentInfo{com.pairvpn/com.pairvpn.MainActivity}" drawable="pairvpn" name="PairVPN" />
   <item component="ComponentInfo{dev.hemanths.paisa/dev.hemanths.paisa.MainActivity}" drawable="paisa" name="Paisa" />
+  <item component="ComponentInfo{com.paisabazaar/com.pb.module.RnApp.activity.RnAppActivity}" drawable="policybazaar" name="Paisabazaar" />
   <item component="ComponentInfo{com.paisabazaar/com.pbNew.modules.app.ui.activity.SplashActivity}" drawable="policybazaar" name="Paisabazaar CreditScore" />
   <item component="ComponentInfo{com.treemengames.pakohighway/com.unity3d.player.UnityPlayerActivity}" drawable="pako_highway" name="Pako Highway" />
   <item component="ComponentInfo{com.ald.devs47.sam.beckman.palettesetups/com.ald.devs47.sam.beckman.palettesetups.activities.SplashActivity}" drawable="palette" name="Palette" />
@@ -13318,6 +13416,7 @@
   <item component="ComponentInfo{com.paypal.android.p2pmobile/com.paypal.android.p2pmobile.activity.IntroActivity}" drawable="paypal" name="PayPal" />
   <item component="ComponentInfo{com.paypal.android.p2pmobile/com.paypal.android.p2pmobile.p2p}" drawable="paypal" name="PayPal" />
   <item component="ComponentInfo{com.paypal.android.p2pmobile/com.paypal.android.p2pmobile.startup.activities.StartupActivity}" drawable="paypal" name="PayPal" />
+  <item component="ComponentInfo{com.paypal.android.p2pmobile/com.paypal.oslo.app.MainActivity}" drawable="paypal" name="PayPal" />
   <item component="ComponentInfo{com.paypal.merchant.client/com.paypal.merchant.client.features.startup.StartUpActivity}" drawable="paypal_business" name="PayPal Business" />
   <item component="ComponentInfo{jp.ne.paypay.android.app/jp.ne.paypay.android.app.MainActivity}" drawable="paypay" name="PayPay ~~ ペイペイ" />
   <item component="ComponentInfo{com.paypo.mobile/com.paypo.mobile.presentation.SplashActivity}" drawable="paypo" name="PayPo" />
@@ -13694,10 +13793,12 @@
   <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.activity.SplashActivity}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
   <item component="ComponentInfo{xyz.penpencil.physicswala/xyz.penpencil.physicswala.MainActivity}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
   <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.SplashActivityAliasVishwasDiwas}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
+  <item component="ComponentInfo{xyz.penpencil.physicswala/com.penpencil.physicswallah.SplashActivityAliasIndependenceDay}" drawable="physics_wallah_pw" name="Physics Wallah (PW)" />
   <item component="ComponentInfo{ai.inflection.pi/ai.inflection.pi.MainActivity}" drawable="inflection_pi" name="Pi" />
   <item component="ComponentInfo{dev.sanmer.pi/dev.sanmer.pi.ui.MainActivity}" drawable="generic_pi" name="PI" />
   <item component="ComponentInfo{dev.sanmer.pi/dev.sanmer.pi.ui.activity.MainActivity}" drawable="generic_pi" name="PI" />
   <item component="ComponentInfo{pi.browser/com.pinetwork.MainActivity}" drawable="pi_browser" name="Pi Browser" />
+  <item component="ComponentInfo{com.markduenas.android.apigen/com.markduenas.android.apigen.MainActivity}" drawable="generic_pi" name="Pi Generator" />
   <item component="ComponentInfo{com.blockchainvault/com.pinetwork.MainActivity}" drawable="pi_network" name="Pi Network" />
   <item component="ComponentInfo{io.github.tsutsu3.pi_hole_client/io.github.tsutsu3.pi_hole_client.MainActivity}" drawable="pi_hole_client" name="Pi-hole client" />
   <item component="ComponentInfo{beatmaker.edm.musicgames.PianoGames/com.cocos2dx.cpp.SplashActivity}" drawable="piano_fire" name="Piano Fire" />
@@ -13726,6 +13827,7 @@
   <item component="ComponentInfo{com.picsart.studio/com.socialin.android.photo.picsinphoto.MainActivity}" drawable="picsart" name="Picsart" />
   <item component="ComponentInfo{com.picsart.studio/com.socialin.android.photo.picsinphoto.MainPagerActivity}" drawable="picsart" name="Picsart" />
   <item component="ComponentInfo{com.picsart.studio/com.socialin.android.photo.picsinphoto.StartActivity}" drawable="picsart" name="Picsart" />
+  <item component="ComponentInfo{com.picsart.studio.light/com.socialin.android.photo.picsinphoto.MainPagerActivity}" drawable="picsart" name="Picsart" />
   <item component="ComponentInfo{com.picsart.draw/com.palabs.artboard.activity.SplashScreenActivity}" drawable="picsart_color" name="Picsart Color" />
   <item component="ComponentInfo{com.shinycore.picsaypro/com.shinycore.picsaypro.PicSay}" drawable="picsay_pro" name="PicSay Pro" />
   <item component="ComponentInfo{com.shinycore.picsaypro/com.shinycore.picsaypro.main}" drawable="picsay_pro" name="PicSay Pro" />
@@ -14066,6 +14168,7 @@
   <item component="ComponentInfo{com.sodexo.consumers.colombia/com.sodexo.consumers.SplashActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{com.sodexo.flexogift/com.sodexo.flexogift.MainActivity}" drawable="pluxee" name="Pluxee" />
   <item component="ComponentInfo{com.pluxeegroup.consumers.global/com.pluxeegroup.consumers.global.MainActivity}" drawable="pluxee" name="Pluxee" />
+  <item component="ComponentInfo{com.wedoogift/com.glady.MainActivityic_launcher}" drawable="pluxee" name="Pluxee Cadeaux" />
   <item component="ComponentInfo{com.Version1/com.Version1.Version1}" drawable="pnb_one" name="PNB ONE" />
   <item component="ComponentInfo{com.Version1/com.Version1.MainActivity}" drawable="pnb_one" name="PNB ONE" />
   <item component="ComponentInfo{in.pnb.pnbparivaar/in.pnb.pnbparivaar.MainActivity}" drawable="pnb_one" name="PNB Parivar" />
@@ -14074,6 +14177,7 @@
   <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.pnc.ecommerce.mobile.PncMobileActivity}" drawable="pnc" name="PNC" />
   <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.fisglobal.lfi.pnc.ui.MainActivity}" drawable="pnc" name="PNC" />
   <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.pnc.mbl.ui.MainActivity}" drawable="pnc" name="PNC" />
+  <item component="ComponentInfo{com.pnc.ecommerce.mobile/com.pnc.mbl.android.application.redesign.ui.RedesignMainActivity}" drawable="pnc" name="PNC" />
   <item component="ComponentInfo{com.ideashower.readitlater.pro/com.ideashower.readitlater.activity.AppCacheCheckActivity}" drawable="pocket" name="Pocket" />
   <item component="ComponentInfo{com.potradeweb/com.potradeweb.activities.MainActivity}" drawable="pocket_broker" name="Pocket Broker" />
   <item component="ComponentInfo{au.com.shiftyjelly.pocketcasts/au.com.shiftyjelly.pocketcasts.ui.MainActivity_18}" drawable="pocket_casts" name="Pocket Casts" />
@@ -14412,6 +14516,7 @@
   <item component="ComponentInfo{com.psiphon3.subscription/com.qihoo.util.StartActivity}" drawable="psiphon_pro" name="Psiphon Pro" />
   <item component="ComponentInfo{com.psiphon3.subscription/com.psiphon3.StatusActivity}" drawable="psiphon_pro" name="Psiphon Pro" />
   <item component="ComponentInfo{com.psiphon3.subscription/com.psiphon3.MainActivity}" drawable="psiphon_pro" name="Psiphon Pro" />
+  <item component="ComponentInfo{com.psiphon3.subscription/ca.psiphon.psiphon4.MainActivity}" drawable="psiphon_pro" name="Psiphon Pro" />
   <item component="ComponentInfo{com.psono.psono/com.psono.psono.MainActivity}" drawable="psono" name="Psono" />
   <item component="ComponentInfo{com.pttem.epttavm/com.pttem.epttavm.SplashActivityAlias1}" drawable="pttavm" name="PttAVM" />
   <item component="ComponentInfo{com.pttem.epttavm/com.pttem.epttavm.SplashActivityAlias2}" drawable="pttavm" name="PttAVM" />
@@ -14425,6 +14530,7 @@
   <item component="ComponentInfo{com.tencent.igxiaomi/com.tencent.igxiaomi.MainActivity}" drawable="pubg" name="PUBG Gift Box" />
   <item component="ComponentInfo{com.tencent.iglite/com.epicgames.ue4.SplashActivity}" drawable="pubg" name="PUBG LITE" />
   <item component="ComponentInfo{com.cardfeed.video_public/com.cardfeed.video_public.ui.activity.SplashActivity}" drawable="public_local_videos" name="Public Local Videos" />
+  <item component="ComponentInfo{com.cardfeed.video_public/com.cardfeed.core.ui.features.splash.SplashActivity}" drawable="public_local_videos" name="Public Local Videos" />
   <item component="ComponentInfo{au.gov.vic.ptv/au.gov.vic.ptv.ui.splash.SplashActivity}" drawable="public_transport_victoria_ptv" name="Public Transport Victoria (PTV)" />
   <item component="ComponentInfo{au.gov.vic.ptv/au.gov.vic.ptv.ui.main.MainActivity}" drawable="public_transport_victoria_ptv" name="Public Transport Victoria (PTV)" />
   <item component="ComponentInfo{com.publix.main/com.shockoe.publix.flagship.MainActivity}" drawable="publix" name="Publix" />
@@ -14440,6 +14546,7 @@
   <item component="ComponentInfo{xyz.klinker.messenger/xyz.klinker.messenger.activity.MessengerActivity}" drawable="pulse_sms" name="Pulse SMS" />
   <item component="ComponentInfo{com.pulsoid.swung/com.pulsoid.swung.activities.login.LoginActivity}" drawable="pulsoid" name="PULSOID" />
   <item component="ComponentInfo{eu.hxreborn.phdp/eu.hxreborn.phdp.ui.MainActivity}" drawable="punch_hole_download_progress" name="Punch-hole Download Progress" />
+  <item component="ComponentInfo{eu.hxreborn.phdp/eu.hxreborn.phdp.LauncherAlias}" drawable="punch_hole_download_progress" name="Punch-hole Download Progress" />
   <item component="ComponentInfo{com.punto.punto/com.punto.punto.MainActivity}" drawable="punto" name="Punto" />
   <item component="ComponentInfo{com.pco.app.cliente/com.example.pco_app.MainActivity}" drawable="puntos" name="Puntos" />
   <item component="ComponentInfo{xyz.quaver.pupil/xyz.quaver.pupil.ui.MainActivity}" drawable="pupil" name="Pupil" />
@@ -14491,6 +14598,7 @@
   <item component="ComponentInfo{com.qnap.com.qgetpro/com.qnap.com.qgetpro.Splash}" drawable="tiktokdownloader" name="Qget" />
   <item component="ComponentInfo{com.mutangtech.qianji/com.mutangtech.qianji.ui.main.MainActivity}" drawable="qianji" name="QianJi" />
   <item component="ComponentInfo{qibla.compass.finddirection.hijricalendar/qibla.compass.finddirection.hijricalendar.activities.SplashActivity}" drawable="qibla_compass" name="Qibla Compass" />
+  <item component="ComponentInfo{qibladirectioncompass.qiblafinder.truenorthcompass/qibladirectioncompass.qiblafinder.truenorthcompass.activities.SplashActivity}" drawable="qibla_compass" name="Qibla Compass" />
   <item component="ComponentInfo{com.moez.QKSMS/com.moez.QKSMS.feature.main.MainActivity}" drawable="qksms" name="QKSMS" />
   <item component="ComponentInfo{com.moez.QKSMS/com.moez.QKSMS.ui.MainActivity-Black}" drawable="qksms" name="QKSMS" />
   <item component="ComponentInfo{com.moez.QKSMS/com.moez.QKSMS.ui.MainActivity-Blue}" drawable="qksms" name="QKSMS" />
@@ -14555,6 +14663,7 @@
   <item component="ComponentInfo{com.maqr.barcode.free.qrandbarcodescanner.mavach.qrcode.reader.qrcodereader.qrcodescanner.quickbarecodescanner/com.core.ads.SplashToMain}" drawable="generic_qr_reader" name="QR Code Reader" />
   <item component="ComponentInfo{com.axiomatic.qrcodereader/com.axiomatic.qrcodereader.MainActivity}" drawable="generic_qr_reader" name="QR Code Reader" />
   <item component="ComponentInfo{com.gamma.scan.app/com.atharok.barcodescanner.ads.SplashActivity}" drawable="generic_qr_reader" name="QR Code Reader" />
+  <item component="ComponentInfo{com.qrfamily.qrcodereaderscanner/com.qrfamily.qrcodereaderscanner.scanner.activity.SplashActivity}" drawable="generic_qr_reader" name="QR Code Reader" />
   <item component="ComponentInfo{com.scannerapp.qrcodereader/com.scannerapp.qrcodereader.activity.SplashActivity}" drawable="generic_qr_reader" name="QR Code Reader &amp; Scanner" />
   <item component="ComponentInfo{com.peace.QRcodeReader/com.peace.QRcodeReader.CameraActivity}" drawable="generic_qr_reader" name="QR Code Reader Barcode Scanner" />
   <item component="ComponentInfo{com.barcode.qrcode.scanner.reader.pro/com.barcode.qrcode.scanner.reader.pro.activity.MainActivity}" drawable="generic_qr_reader" name="QR Code Reader PRO" />
@@ -14602,6 +14711,7 @@
   <item component="ComponentInfo{com.querodelivery/com.querodelivery.SplashActivity}" drawable="quero_delivery" name="quero delivery" />
   <item component="ComponentInfo{br.com.queropassagem/br.com.queropassagem.MainActivity}" drawable="quero_passagem" name="Quero Passagem" />
   <item component="ComponentInfo{com.qianfan.aihomework/com.qianfan.aihomework.ui.MainActivity}" drawable="question_ai" name="Question.AI" />
+  <item component="ComponentInfo{com.qianfan.aihomework/com.qianfan.aihomework.ui.init.InitActivity}" drawable="question_ai" name="Question.AI" />
   <item component="ComponentInfo{com.questrade.questmobile/com.questrade.questmobile.MainActivity}" drawable="questmobile" name="QuestMobile" />
   <item component="ComponentInfo{com.questrade.edgemobile/com.questrade.edgemobile.MainActivity}" drawable="questmobile" name="Questrade Edge" />
   <item component="ComponentInfo{net.quetta.browser/com.google.android.apps.chrome.Main}" drawable="quetta" name="Quetta" />
@@ -14787,6 +14897,7 @@
   <item component="ComponentInfo{com.rapido.passenger/com.rapido.passenger.launcher.ui.LauncherActivity}" drawable="rapido" name="Rapido" />
   <item component="ComponentInfo{com.rapido.passenger/com.rapido.passenger.ChristmasAlias}" drawable="rapido" name="Rapido" />
   <item component="ComponentInfo{com.rapido.passenger/com.rapido.passenger.NewYearAlias}" drawable="rapido" name="Rapido" />
+  <item component="ComponentInfo{com.rapido.passenger/com.rapido.passenger.FlagAlias}" drawable="rapido" name="Rapido" />
   <item component="ComponentInfo{com.rapid.short.tv/com.drama.rapid.ui.activity.FirstActivity}" drawable="rapidtv" name="RapidTV" />
   <item component="ComponentInfo{com.grability.rappi/com.rappi.discovery.onboarding.impl.activities.RappiMainEntryActivity}" drawable="rappi" name="Rappi" />
   <item component="ComponentInfo{com.rarlab.rar/com.google.android.archive.ReactivateActivity}" drawable="rar" name="RAR" />
@@ -14995,6 +15106,7 @@
   <item component="ComponentInfo{com.bigwinepot.nwdn.international/com.bigwinepot.nwdn.MainActivity}" drawable="remini" name="Remini" />
   <item component="ComponentInfo{com.bigwinepot.nwdn.international/com.bendingspoons.remini.MainActivity}" drawable="remini" name="Remini" />
   <item component="ComponentInfo{com.remini.xyy/com.bendingspoons.remini.MainActivity}" drawable="remini" name="Remini" />
+  <item component="ComponentInfo{com.remini.xyz/com.bendingspoons.remini.MainActivity}" drawable="remini" name="Remini" />
   <item component="ComponentInfo{com.mixvibes.remixlive/com.mixvibes.remixlive.app.RemixliveSplashScreenActivity}" drawable="generic_grid_3x3" name="Remixlive" />
   <item component="ComponentInfo{com.remnote.v2/com.remnote.v2.MainActivity}" drawable="remnote" name="RemNote" />
   <item component="ComponentInfo{remote.control.tv.universal.forall.roku/remote.control.tv.universal.forall.roku.activity.SplashActivity}" drawable="remote_control_for_tv" name="Remote Control for TV" />
@@ -15080,6 +15192,7 @@
   <item component="ComponentInfo{com.thinkfree.searchbyimage/com.thinkfree.searchbyimage.MainActivity}" drawable="reverse_image_search" name="Reverse Image Search" />
   <item component="ComponentInfo{com.bluepoch.m.en.reverse1999/com.ssgame.mobile.overseas.frame.activity.AppStartUpActivity}" drawable="reverse_1999" name="Reverse: 1999" />
   <item component="ComponentInfo{uk.co.aifactory.rrfree/uk.co.aifactory.rrfree.ReversiFreeActivity}" drawable="reversi" name="Reversi" />
+  <item component="ComponentInfo{livio.reversi/livio.reversi.ReversiBase}" drawable="reversi" name="Reversi" />
   <item component="ComponentInfo{com.softissimo.reverso.context/com.softissimo.reverso.context.activity.CTXSplashActivity}" drawable="reverso_context" name="Reverso Context" />
   <item component="ComponentInfo{com.softissimo.reverso.context/com.softissimo.reverso.context.activity.SplashActivity}" drawable="reverso_context" name="Reverso Context" />
   <item component="ComponentInfo{au.com.revheadz.revheadz/au.com.revheadz.revheadz.RevHeadzNativeActivity}" drawable="revheadz" name="RevHeadz" />
@@ -15107,6 +15220,7 @@
   <item component="ComponentInfo{com.ketchapp.rider/com.ansca.corona.CoronaActivity}" drawable="rider" name="Rider" />
   <item component="ComponentInfo{com.ketchapp.rider/com.unity3d.player.UnityPlayerActivity}" drawable="rider" name="Rider" />
   <item component="ComponentInfo{ridmik.keyboard/com.android.inputmethod.latin.setup.MainActivity}" drawable="ridmik_keyboard" name="Ridmik Keyboard" />
+  <item component="ComponentInfo{ridmik.keyboard/ridmik.keyboard.composeUi.MainActivity}" drawable="ridmik_keyboard" name="Ridmik Keyboard" />
   <item component="ComponentInfo{ridmik.news/com.ridmik.rc.newsic.MainActivity}" drawable="ridmik_news" name="Ridmik News" />
   <item component="ComponentInfo{com.goodwy.contacts/com.goodwy.contacts.activities.SplashActivity.Orange}" drawable="right_contacts" name="Right Contacts" />
   <item component="ComponentInfo{com.goodwy.contacts/com.goodwy.contacts.activities.SplashActivity.Original}" drawable="right_contacts" name="Right Contacts" />
@@ -15232,6 +15346,7 @@
   <item component="ComponentInfo{de.rtli.tvnow/de.rtli.everest.activity.SplashActivity}" drawable="rtl_plus" name="RTL+" />
   <item component="ComponentInfo{hu.telekomnewmedia.android.rtlmost/fr.m6.m6replay.activity.SplashActivity}" drawable="rtl_plus" name="RTL+" />
   <item component="ComponentInfo{hu.telekomnewmedia.android.rtlmost/com.bedrockstreaming.shared.mobile.activity.SplashActivity}" drawable="rtl_plus" name="RTL+" />
+  <item component="ComponentInfo{de.rtli.tvnow/com.bedrockstreaming.shared.mobile.activity.SplashActivity}" drawable="rtl_plus" name="RTL+" />
   <item component="ComponentInfo{marto.rtl_tcp_andro/com.sdrtouch.rtlsdr.StreamActivity}" drawable="rtl_sdr_driver" name="Rtl-sdr driver" />
   <item component="ComponentInfo{pt.rtp.play/pt.rtp.play.MainActivity}" drawable="rtp_play" name="RTP Play" />
   <item component="ComponentInfo{appinventor.ai_itiel_maimon.Rubiks_cube/appinventor.ai_itiel_maimon.Rubiks_cube.MainActivity}" drawable="generic_grid_3x3" name="Rubik's Cube Solver" />
@@ -15604,6 +15719,7 @@
   <item component="ComponentInfo{com.meditation.tracker.android/com.meditation.tracker.android.SplashScreen}" drawable="sattva" name="Sattva" />
   <item component="ComponentInfo{ddt.free.icon.packs/ddt.free.icon.packs.activities.SplashActivity}" drawable="saturate_icons" name="Saturate Icons" />
   <item component="ComponentInfo{ddt.free.icon.packs/ddt.free.icon.packs.MainActivity}" drawable="saturate_icons" name="Saturate Icons" />
+  <item component="ComponentInfo{ddt.free.icon.packs/dev.ddt.dashboard.engine.MainActivity}" drawable="saturate_icons" name="Saturate Icons" />
   <item component="ComponentInfo{com.telkom.tracencare/com.telkom.tracencare.MainActivity}" drawable="satusehat" name="SATUSEHAT" />
   <item component="ComponentInfo{com.telkom.tracencare/com.telkom.tracencare.ui.MainActivity}" drawable="satusehat" name="SATUSEHAT" />
   <item component="ComponentInfo{com.luk.saucenao/com.luk.saucenao.MainActivity}" drawable="saucenao" name="SauceNAO" />
@@ -15992,6 +16108,7 @@
   <item component="ComponentInfo{com.zzkko/com.shein.user_service.welcome.WelcomeActivity}" drawable="shein" name="SHEIN" />
   <item component="ComponentInfo{com.zzkko/com.shein.welcome.WelcomeActivity}" drawable="shein" name="SHEIN" />
   <item component="ComponentInfo{com.ril.shein/com.ril.shein.launch.activity.SplashScreenActivity}" drawable="shein" name="SHEIN" />
+  <item component="ComponentInfo{com.ril.shein/com.ril.shein.MainActivity}" drawable="shein" name="SHEIN" />
   <item component="ComponentInfo{com.shelf.app/com.shelf.app.main.ShelfActivity}" drawable="shelf" name="Shelf" />
   <item component="ComponentInfo{allterco.bg.shelly/allterco.bg.shelly.activities.MainActivity}" drawable="shelly_cloud" name="Shelly Cloud" />
   <item component="ComponentInfo{net.typeblog.shelter/net.typeblog.shelter.ui.DummyActivity}" drawable="shelter" name="Shelter" />
@@ -16001,6 +16118,7 @@
   <item component="ComponentInfo{com.gnoemes.shikimori/com.gnoemes.shikimori.presentation.view.splash.SplashActivity}" drawable="shikimori" name="Shikimori" />
   <item component="ComponentInfo{com.miraisoft.shiori/com.miraisoft.shiori.MainActivity}" drawable="shiori" name="Shiori" />
   <item component="ComponentInfo{moe.shizuku.privileged.api/moe.shizuku.manager.MainActivity}" drawable="shizuku" name="Shizuku" />
+  <item component="ComponentInfo{moe.shizuku.privileged.api/af.shizuku.manager.LauncherAlias}" drawable="shizuku" name="Shizuku" />
   <item component="ComponentInfo{com.noxinfinity.shell/com.noxinfinity.shell.MainActivity}" drawable="terminal" name="ShizuShell" />
   <item component="ComponentInfo{com.legendsayantan.adbtools/com.legendsayantan.adbtools.InitialActivity}" drawable="system_ui_tuner" name="ShizuTools" />
   <item component="ComponentInfo{com.arslan.shizuwall/com.arslan.shizuwall.ui.MainActivity}" drawable="shizuwall" name="ShizuWall" />
@@ -17026,6 +17144,7 @@
   <item component="ComponentInfo{com.soundcloud.android/com.google.android.archive.ReactivateActivity}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.luna.music/com.soundcloud.android.launcher.LauncherActivity}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.soundcloud.android/com.soundcloud.android.launcher.LauncherActivityChromeIconAlias}" drawable="soundcloud" name="SoundCloud" />
+  <item component="ComponentInfo{com.apple.android.music/com.soundcloud.android.launcher.LauncherActivity}" drawable="soundcloud" name="SoundCloud" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.google.android.archive.ReactivateActivity}" drawable="soundcore" name="Soundcore" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.oceanwing.soundcore.activity.SelectCategoryNewActivity}" drawable="soundcore" name="Soundcore" />
   <item component="ComponentInfo{com.oceanwing.soundcore/com.oceanwing.soundcore.activity.WelcomeActivity}" drawable="soundcore" name="Soundcore" />
@@ -17258,6 +17377,7 @@
   <item component="ComponentInfo{com.starbucks.uk/com.starbucks.emea.app.splash.SplashActivity}" drawable="starbucks" name="Starbucks" />
   <item component="ComponentInfo{com.starbucks.bh/com.starbucks.emea.app.splash.SplashActivity}" drawable="starbucks" name="Starbucks" />
   <item component="ComponentInfo{com.starbucks.peru/com.starbucks.peru.MainActivity}" drawable="starbucks" name="Starbucks" />
+  <item component="ComponentInfo{com.starbucks.fr/com.starbucks.emea.app.splash.SplashActivity}" drawable="starbucks" name="Starbucks" />
   <item component="ComponentInfo{com.chucklefish.stardewvalley/io.unity.sdk.android.UnityLauncher}" drawable="stardew_valley" name="Stardew Valley" />
   <item component="ComponentInfo{com.chucklefish.stardewvalley/md5dee79b5aa46d0ac87adbcd4b193daa49.MainActivity}" drawable="stardew_valley" name="Stardew Valley" />
   <item component="ComponentInfo{com.chucklefish.stardewvalley/com.komodias.mod.SS}" drawable="stardew_valley" name="Stardew Valley" />
@@ -17377,6 +17497,7 @@
   <item component="ComponentInfo{dk.kvittering/com.storebox.features.splash.SplashActivity}" drawable="storebox" name="Storebox" />
   <item component="ComponentInfo{ai.powerup.stori/ai.powerup.stori.home.mvp.ui.activity.NewSplashActivity}" drawable="stori" name="Stori" />
   <item component="ComponentInfo{ai.powerup.stori/ai.powerup.stori.ui.splash.NewSplashActivity}" drawable="stori" name="Stori" />
+  <item component="ComponentInfo{ai.powerup.stori/ai.powerup.stori.ui.splash.SplashActivity}" drawable="stori" name="Stori" />
   <item component="ComponentInfo{com.storysaver.saveig/com.storysaver.saveig.view.activity.SplashActivity}" drawable="story_saver" name="Story Saver" />
   <item component="ComponentInfo{storysaverforinstagram.storydownloaderforinstagram/appfry.storysaver.activities.SplashActivity}" drawable="download_twitter_videos" name="Story Saver" />
   <item component="ComponentInfo{com.instasaver.downloader.instadownloader.igsaver/com.insta.downloader.instasaver.igdownloader.MainActivity}" drawable="download_twitter_videos" name="Story Saver" />
@@ -17604,6 +17725,7 @@
   <item component="ComponentInfo{com.sweatwallet/com.sweatwallet.MainActivity}" drawable="sweat_wallet" name="Sweat Wallet" />
   <item component="ComponentInfo{com.sweatwallet/com.sweatwallet.MainActivityDefault}" drawable="sweat_wallet" name="Sweat Wallet" />
   <item component="ComponentInfo{in.sweatco.app/com.app.sweatcoin.ui.activities.RootActivity}" drawable="sweatcoin" name="Sweatcoin" />
+  <item component="ComponentInfo{in.sweatco.app/com.app.sweatcoin.AppIconDefault}" drawable="sweatcoin" name="Sweatcoin" />
   <item component="ComponentInfo{lt.swedbank.mobile/com.swedbank.mobile.app.MainActivity}" drawable="swedbank" name="Swedbank" />
   <item component="ComponentInfo{com.swedbank/com.swedbank.mobile.app.MainActivity}" drawable="swedbank" name="Swedbank" />
   <item component="ComponentInfo{lv.swedbank.mobile/com.swedbank.mobile.app.MainActivity}" drawable="swedbank" name="Swedbank" />
@@ -17661,6 +17783,7 @@
   <item component="ComponentInfo{com.nutomic.syncthingandroid/com.nutomic.syncthingandroid.activities.MainActivity}" drawable="syncthing" name="Syncthing" />
   <item component="ComponentInfo{com.github.catfriend1.syncthingandroid.debug/com.nutomic.syncthingandroid.activities.FirstStartActivity}" drawable="syncthing" name="Syncthing Debug" />
   <item component="ComponentInfo{io.github.martchus.syncthingtray/io.github.martchus.syncthingtray.MainActivity}" drawable="syncthing" name="Syncthing Tray" />
+  <item component="ComponentInfo{com.github.catfriend1.syncthingandroid/com.nutomic.syncthingandroid.onboarding.OnboardingActivity}" drawable="syncthing" name="Syncthing-Fork" />
   <item component="ComponentInfo{com.synology.dsdrive/com.synology.dsdrive.activity.SplashActivity}" drawable="synology_drive" name="Synology Drive" />
   <item component="ComponentInfo{com.synology.projectkailash/com.synology.projectkailash.ui.splash.SplashActivity}" drawable="synology_photos" name="Synology Photos" />
   <item component="ComponentInfo{com.synology.securesignin/com.synology.securesignin.MainActivity}" drawable="synology_secure_signin" name="Synology Secure SignIn" />
@@ -17755,6 +17878,7 @@
   <item component="ComponentInfo{de.cliff.strichliste/de.cliff.strichliste.MainActivity}" drawable="tally_counter" name="Tally Counter" />
   <item component="ComponentInfo{com.klinker.android.twitter_l/com.klinker.android.twitter_l.activities.MainActivity}" drawable="talon" name="Talon" />
   <item component="ComponentInfo{com.klinker.android.twitter_l/com.klinker.android.twitter_l.ui.MainActivity}" drawable="talon" name="Talon" />
+  <item component="ComponentInfo{co.tamara.user/co.tamara.user.DEFAULT}" drawable="tamara" name="Tamara" />
   <item component="ComponentInfo{com.spbtv.mobilinktv/com.spbtv.mobilinktv.Splash.SplashActivityNew}" drawable="tamasha" name="Tamasha" />
   <item component="ComponentInfo{com.anysoftkeyboard.languagepack.tamazight/com.anysoftkeyboard.languagepack.tamazight.MainActivity}" drawable="anysoftkeyboard" name="Tamazight for AnySoftKeyboard" />
   <item component="ComponentInfo{lt.zet.tamo/lt.zet.tamo.ui.content.ContentActivity}" drawable="tamo_ismaniems" name="TAMO Išmaniems" />
@@ -17977,6 +18101,7 @@
   <item component="ComponentInfo{com.imangi.templerun/com.imangi.unityactivity.ImangiUnityActivity}" drawable="temple_run" name="Temple Run" />
   <item component="ComponentInfo{com.imangi.templerun2/com.imangi.unityactivity.ImangiUnityActivity}" drawable="temple_run_2" name="Temple Run 2" />
   <item component="ComponentInfo{com.imangi.templerun2/com.applisto.appcloner.classes.SplashScreenActivity}" drawable="temple_run_2" name="Temple Run 2" />
+  <item component="ComponentInfo{com.imangi.templerun2/com.imangi.unityactivity.ImangiUnityProxyActivity}" drawable="temple_run_2" name="Temple Run 2" />
   <item component="ComponentInfo{com.draco.tempo/com.draco.tempo.views.MainActivity}" drawable="tempo" name="Tempo" />
   <item component="ComponentInfo{com.cappielloantonio.notquitemy.tempo/com.cappielloantonio.tempo.ui.activity.MainActivity}" drawable="tempo_music" name="Tempo Music" />
   <item component="ComponentInfo{com.cappielloantonio.tempo/com.cappielloantonio.tempo.ui.activity.MainActivity}" drawable="tempo_music" name="Tempo Music" />
@@ -18059,182 +18184,7 @@
   <item component="ComponentInfo{com.enflick.android.TextNow/com.enflick.android.TextNow.appicon.winter}" drawable="textnow" name="TextNow" />
   <item component="ComponentInfo{com.enflick.android.TextNow/com.enflick.android.TextNow.appicon.pride}" drawable="textnow" name="TextNow" />
   <item component="ComponentInfo{com.gogii.textplus/com.nextplus.android.activity.SplashScreenActivity}" drawable="textplus" name="textPlus" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1de9b6_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff448aff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff64ffda}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00b8d4}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffd81b60_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_*}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff000000_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff000000}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff004d40}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff006064_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff006064}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00695c}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00796b}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00838f}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00897b}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff0091ea}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff0097a7}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00acc1}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00b0ff_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00b0ff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00bcd4}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00c853}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00e5ff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff00e676}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff01579b_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff01579b}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff0277bd}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff0288d1}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff039be5}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff03a9f4}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff0d47a1}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1565c0}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff18ffff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1976d2_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1976d2}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1a237e}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1b5e20}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1de9b6}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff1e88e5}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff212121_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff212121}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff2196f3_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff2196f3}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff263238_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff263238}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff26a69a}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff26c6da}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff283593}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff2962ff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff2979ff_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff2979ff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff29b6f6}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff2e7d32}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff303f9f}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff304ffe}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff311b92_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff311b92}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff33691e}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff37474f}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff388e3c}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff3d5afe}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff3e2723}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff3f51b5}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff40c4ff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff424242}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff42a5f5}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff43a047}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff448aff_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff4527a0}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff455a64}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff4a148c}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff4caf50}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff4db6ac}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff4dd0e1}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff4fc3f7}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff512da8}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff546e7a}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff558b2f}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff5d4037}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff5e35b1}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff607d8b}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff616161}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff64b5f6}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff64dd17}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff651fff_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff651fff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff66bb6a}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff673ab7_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff673ab7}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff689f38}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff69f0ae_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff69f0ae}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff6a1b9a}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff757575}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff76ff03}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff78909c}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff7b1fa2}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff7c4dff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff7cb342}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff7e57c2}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff81c784_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff81c784}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff880e4f}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff8bc34a}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff8d6e63}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff90a4ae}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff9575cd}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff9c27b0}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff9ccc65}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff9e9e9e}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffa1887f}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffaa00ff}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffab47bc}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffad1457}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffb71c1c_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffb71c1c}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffba68c8}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffbdbdbd}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffbf360c}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffc2185b}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffc62828}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffd32f2f_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffd50000_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffd50000}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffd500f9_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffd81b60}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffdd2c00_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffdd2c00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffe040fb}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffe53935}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffe57373_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffe57373}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffe64a19}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffe65100}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffe91e63}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffec407a_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffec407a}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffeeff41}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffef5350_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffef6c00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff06292}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff44336}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff4511e}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff50057_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff50057}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff57c00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff57f17}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fff9a825}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_fffdd835}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff1744_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff1744}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff3d00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff4081}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff6e40}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff6f00_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff6f00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff7043}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff8f00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffff9800}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffa000}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffa726}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffab00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffab40}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffb300}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffb74d}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffc107}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffca28}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffd54f}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffd740}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffea00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffeb3b}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffff00}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffffff_bare}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ffffffff}" drawable="textra_sms" name="Textra SMS" />
   <item component="ComponentInfo{com.textra/com.mplus.lib.ui.main.Main}" drawable="textra_sms" name="Textra SMS" />
-  <item component="ComponentInfo{com.textra/com.mplus.lib.Main_ff64dd17_bare}" drawable="textra_sms" name="Textra SMS" />
   <item component="ComponentInfo{com.JellyBeanUser.apk.app.editor/com.JellyBeanUser.apk.app.editor.MainActivity}" drawable="textverse" name="TextVerse" />
   <item component="ComponentInfo{uk.gov.tfl.gotfl/uk.gov.tfl.tflgo.view.ui.splash.SplashActivity}" drawable="tfl_go" name="TfL Go" />
   <item component="ComponentInfo{com.c3r5b8.telegram_monet/com.c3r5b8.telegram_monet.AquaIcon}" drawable="tgmonet_theme" name="TgMonet Theme" />
@@ -18405,6 +18355,7 @@
   <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.activity.MeTaskActivity}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.activity.TickTickStartActivity}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{cn.ticktick.task/cn.ticktick.task.HomeAlia_default}" drawable="ticktick" name="TickTick" />
+  <item component="ComponentInfo{com.ticktick.task/com.ticktick.task.HomeAlia_ai}" drawable="ticktick" name="TickTick" />
   <item component="ComponentInfo{com.aspiro.tidal/com.aspiro.wamp.LoginFragmentActivity}" drawable="tidal" name="TIDAL" />
   <item component="ComponentInfo{com.android.tidal.campaigninstaller/com.android.campaigninstaller.MainActivity}" drawable="tidal" name="TIDAL" />
   <item component="ComponentInfo{com.tidiochat.app/com.tidiochat.app.activity.MainActivity}" drawable="tidio" name="Tidio" />
@@ -18458,6 +18409,7 @@
   <item component="ComponentInfo{it.telecomitalia.centodiciannove/it.tim.mytim.SplashActivity}" drawable="tim" name="TIM" />
   <item component="ComponentInfo{br.com.timbrasil.meutim/br.com.timbrasil.meutim.MainActivity}" drawable="tim" name="TIM" />
   <item component="ComponentInfo{br.com.timbrasil.meutim/br.com.timbrasil.meutim.MainActivityDefault}" drawable="tim" name="TIM" />
+  <item component="ComponentInfo{br.com.timbrasil.meutim/br.com.timbrasil.meutim.MainActivityRockInRio}" drawable="tim" name="TIM" />
   <item component="ComponentInfo{com.tencent.tim/com.qihoo.util.StartActivity}" drawable="tim_qq" name="TIM (QQ)" />
   <item component="ComponentInfo{com.tencent.tim/com.tencent.mobileqq.activity.SplashActivity}" drawable="tim_qq" name="TIM (QQ)" />
   <item component="ComponentInfo{digital.rbi.timhortons/rbi.android.app.MainActivity}" drawable="tim_hortons" name="Tim Hortons" />
@@ -18510,6 +18462,7 @@
   <item component="ComponentInfo{tipster.evolutioit.app/info.androidhive.evolutioit.ui.common.base_activity.BaseActivity}" drawable="tipster" name="Tipster" />
   <item component="ComponentInfo{com.free.tiptop.vpn.proxy/com.tiptopvpn.app.ui.SplashActivity}" drawable="tiptop_vpn" name="TipTop VPN" />
   <item component="ComponentInfo{com.ril.tira/co.go.uniket.screens.activity.MainActivity}" drawable="tira" name="Tira" />
+  <item component="ComponentInfo{com.ril.tira/com.ril.tira.MainActivityAliasDefault}" drawable="tira" name="Tira" />
   <item component="ComponentInfo{app.tiszavilag/app.tiszavilag.MainActivity}" drawable="tisza_vilag" name="TISZA Világ" />
   <item component="ComponentInfo{email.titan.app/to.go.cassie.HomeActivity}" drawable="titan_email" name="Titan Email" />
   <item component="ComponentInfo{com.keramidas.TitaniumBackup/com.keramidas.TitaniumBackup.MainActivity}" drawable="titanium_backup" name="Titanium Backup" />
@@ -18524,6 +18477,9 @@
   <item component="ComponentInfo{ch.tkb.twint/ch.twint.payment.ui.activities.start.StartActivity}" drawable="tkb_twint" name="TKB TWINT" />
   <item component="ComponentInfo{com.tcl.android.video/com.tct.video.View.activities.VideoMainActivity}" drawable="generic_player" name="TLC Video" />
   <item component="ComponentInfo{app.tln.plus/app.tln.plus.SplashScreen}" drawable="tln_plus" name="TLN+" />
+  <item component="ComponentInfo{app.tln.plus/com.lagradost.cloudstream3.ui.account.AccountSelectActivity}" drawable="tln_plus" name="TLN+" />
+  <item component="ComponentInfo{com.minimalisttodolist.pleasebethelastrecyclerview/com.minimalisttodolist.pleasebethelastrecyclerview.MainActivityAlias}" drawable="tasks" name="To Do" />
+  <item component="ComponentInfo{com.splendapps.splendo/com.splendapps.splendo.activity.MainActivity}" drawable="tasks" name="To Do List" />
   <item component="ComponentInfo{rocks.poopjournal.todont/rocks.poopjournal.todont.SplashScreenActivity}" drawable="to_dont" name="To Don't" />
   <item component="ComponentInfo{rocks.poopjournal.todont/rocks.poopjournal.todont.MainActivity}" drawable="to_dont" name="To Donʼt" />
   <item component="ComponentInfo{rocks.poopjournal.todont/rocks.poopjournal.todont.Splash_Screen}" drawable="to_dont" name="To Donʼt" />
@@ -18552,6 +18508,7 @@
   <item component="ComponentInfo{com.todoist/com.todoist.alias.HomeActivityNoir}" drawable="todoist" name="Todoist" />
   <item component="ComponentInfo{com.todoist/com.todoist.alias.HomeActivityTangerine}" drawable="todoist" name="Todoist" />
   <item component="ComponentInfo{com.todoist/com.todoist.alias.HomeActivityTodoist}" drawable="todoist" name="Todoist" />
+  <item component="ComponentInfo{com.todoist/com.todoist.alias.HomeActivityMoonstone}" drawable="todoist" name="Todoist" />
   <item component="ComponentInfo{jp.tokyo.metro.kotsu.toei.naviapp/jp.tokyo.metro.kotsu.toei.naviapp.MainActivity}" drawable="toei_transportation" name="TOEI TRANSPORTATION" />
   <item component="ComponentInfo{com.banglalink.toffee/com.banglalink.toffee.ui.home.HomeActiv}" drawable="toffee" name="Toffee" />
   <item component="ComponentInfo{com.banglalink.toffee/com.banglalink.toffee.ui.splash.SplashScreenActivity}" drawable="toffee" name="Toffee" />
@@ -18615,15 +18572,7 @@
   <item component="ComponentInfo{com.totaladblock.adblocker/com.ts.adblocker.ui.splash.SplashRouteActivity}" drawable="abp_for_samsung_internet" name="Total Adblock" />
   <item component="ComponentInfo{com.ghisler.android.TotalCommander/com.ghisler.android.TotalCommander.TotalCommander}" drawable="total_commander" name="Total Commander" />
   <item component="ComponentInfo{com.ss.launcher2/com.ss.launcher2.MainActivity}" drawable="total_launcher" name="Total Launcher" />
-  <item component="ComponentInfo{com.TotalPlay.totalplay/mx.n68586854.if6cd7eff.p38b712a2.abda5b048.te0ada535}" drawable="totalplay" name="Totalplay" />
-  <item component="ComponentInfo{com.TotalPlay.totalplay/mx.m8a1c45e9.j852aae68.b86b545ae.ufc28f856.r2c7a48d8}" drawable="totalplay" name="Totalplay" />
-  <item component="ComponentInfo{com.TotalPlay.totalplay/mx.jfaf2b29f.u9d6228b3.a1193a142.l49498e2b.jc21ca4ab}" drawable="totalplay" name="Totalplay" />
-  <item component="ComponentInfo{com.TotalPlay.totalplay/mx.c8c86303e.k52e0945d.r82436aa9.z2be8e8dc.wfb6ad06e}" drawable="totalplay" name="Totalplay" />
-  <item component="ComponentInfo{com.TotalPlay.totalplay/mx.i59d112b8.nf49bcd39.w6b335353.n16af8539.g4e199448}" drawable="totalplay" name="Totalplay" />
   <item component="ComponentInfo{com.TotalPlay.totalplay/mx.com.totalplay.core2.home.Core2SplashActivity}" drawable="totalplay" name="Totalplay" />
-  <item component="ComponentInfo{com.TotalPlay.totalplay/mx.x2b3c7c31.w5de1f4c5.nfb092626.o866eb15b.z8299e07c}" drawable="totalplay" name="Totalplay" />
-  <item component="ComponentInfo{com.TotalPlay.totalplay/mx.sb0f1c21c.yf00b9b06.l71c5ee2b.efe01a9ad.e55105f50}" drawable="totalplay" name="Totalplay" />
-  <item component="ComponentInfo{TotalPlay.totalplay/mx.m8a1c45e9.j852aae68.b86b545ae.ufc28f856.r2c7a48d8}" drawable="totalplay" name="Totalplay" />
   <item component="ComponentInfo{com.toters.customer/com.toters.customer.presentation.MainActivity}" drawable="toters" name="Toters" />
   <item component="ComponentInfo{com.toters.customer/com.toters.customer.ui.splash.SplashActivity}" drawable="toters" name="Toters" />
   <item component="ComponentInfo{mobi.foo.touch/mobi.foo.touch.SplashActivity}" drawable="touch" name="Touch" />
@@ -18694,6 +18643,7 @@
   <item component="ComponentInfo{org.paoloconte.treni_lite/org.paoloconte.orariotreni.app.activities.MainActivity}" drawable="train_timetable_italy" name="Train Timetable Italy" />
   <item component="ComponentInfo{fit.trainiac.android.client/fit.trainiac.android.client.presentation.view.activity.MainActivity}" drawable="trainiac" name="Trainiac" />
   <item component="ComponentInfo{com.peaksware.trainingpeaks/com.peaksware.trainingpeaks.onboarding.OnBoardingActivity}" drawable="trainingpeaks" name="TrainingPeaks" />
+  <item component="ComponentInfo{com.peaksware.trainingpeaks/com.peaksware.trainingpeaks.feature.app.AppActivity}" drawable="trainingpeaks" name="TrainingPeaks" />
   <item component="ComponentInfo{com.thetrainline/com.thetrainline.activities.home_screen.SplashScreenActivity}" drawable="trainline" name="Trainline" />
   <item component="ComponentInfo{com.thetrainline/com.thetrainline.activities.home_screen.SplashScreenActivityHeartIcon}" drawable="trainline" name="Trainline" />
   <item component="ComponentInfo{tv.trakt.trakt/tv.trakt.trakt.ui.main.MainActivity}" drawable="trakt" name="Trakt" />
@@ -19295,12 +19245,14 @@
   <item component="ComponentInfo{com.vortilla.myline/com.vortilla.myline.screens.SplashActivity}" drawable="v_line" name="V/Line" />
   <item component="ComponentInfo{me.ghui.v2er/me.ghui.v2er.module.general.RouteActivity}" drawable="v2er" name="V2er" />
   <item component="ComponentInfo{com.v2ray.ang/com.v2ray.ang.ui.MainActivity}" drawable="v2rayng" name="v2rayNG" />
+  <item component="ComponentInfo{com.v2ray.ang.fdroid/com.v2ray.ang.ui.MainActivity}" drawable="v2rayng" name="v2rayNG" />
   <item component="ComponentInfo{com.v2raytun.android/com.v2raytun.android.ui.activity.MainActivity}" drawable="v2raytun" name="v2RayTun" />
   <item component="ComponentInfo{com.ahnlab.v3mobileplus/com.ahnlab.v3mobileplus.mainwebview.SplashActivity}" drawable="v3_mobile_plus" name="V3 Mobile Plus" />
   <item component="ComponentInfo{com.ahnlab.v3mobilesecurity.soda/com.ahnlab.v3mobilesecurity.main.DummyMain}" drawable="v3_mobile_security" name="V3 Mobile Security" />
   <item component="ComponentInfo{com.macrovideo.v380/com.macrovideo.v380.activities.LaunchActivityTopOnAD}" drawable="v380" name="V380" />
   <item component="ComponentInfo{com.macrovideo.v380pro/com.macrovideo.v380pro.activities.LaunchActivityTopOnAD}" drawable="v380_pro" name="V380 Pro" />
   <item component="ComponentInfo{com.macrovideo.v380pro/com.macrovideo.v380pro.activities.LaunchActivityAdHubOversea}" drawable="v380_pro" name="V380 Pro" />
+  <item component="ComponentInfo{com.macrovideo.v380pro/com.macrovideo.v380pro.activities.LaunchActivityWithAd}" drawable="v380_pro" name="V380 Pro" />
   <item component="ComponentInfo{gov.va.mobileapp/gov.va.mobileapp.MainActivity}" drawable="va" name="VA" />
   <item component="ComponentInfo{nl.VakantieVeilingen.android/nl.emesa.auctionplatform.launcher.LauncherDefaultAlias}" drawable="vakantieveilingen" name="VakantieVeilingen" />
   <item component="ComponentInfo{ba.vaktija.android/ba.vaktija.android.MainActivity}" drawable="vaktija_ba" name="Vaktija.ba" />
@@ -19416,6 +19368,7 @@
   <item component="ComponentInfo{com.watch.life/com.ido.life.module.splash.SplashDefaultActivity}" drawable="veryfit" name="VeryFit" />
   <item component="ComponentInfo{com.vincentengelsoftware.vesandroidimagecompare/com.vincentengelsoftware.androidimagecompare.Activities.MainActivity}" drawable="photo_compare" name="VES" />
   <item component="ComponentInfo{com.vincentengelsoftware.vesandroidimagecompare/com.vincentengelsoftware.androidimagecompare.MainActivity}" drawable="photo_compare" name="VES" />
+  <item component="ComponentInfo{com.vincentengelsoftware.vesandroidimagecompare/com.vincentengelsoftware.androidimagecompare.ui.main.MainActivity}" drawable="photo_compare" name="vesIC" />
   <item component="ComponentInfo{de.blau.android/de.blau.android.Splash}" drawable="vespucci" name="Vespucci" />
   <item component="ComponentInfo{de.blau.android/de.blau.android.Main}" drawable="vespucci" name="Vespucci" />
   <item component="ComponentInfo{com.astrapaging.vff/com.astrapaging.vff.MainActivity}" drawable="vesselfinder" name="VesselFinder" />
@@ -19522,6 +19475,7 @@
   <item component="ComponentInfo{com.projectmaterial.videos/com.projectmaterial.videos.activities.VideoLibraryActivity}" drawable="videos" name="Videos" />
   <item component="ComponentInfo{com.projectmaterial.videos/com.projectmaterial.videos.activity.VideoLibraryActivity}" drawable="videos" name="Videos" />
   <item component="ComponentInfo{com.vidio.android/com.vidio.android.splash.SplashScreen}" drawable="vidio" name="Vidio" />
+  <item component="ComponentInfo{com.vidio.android/com.vidio.android.splash.SplashScreenActivity}" drawable="vidio" name="Vidio" />
   <item component="ComponentInfo{vidma.screenrecorder.videorecorder.videoeditor.lite/com.atlasv.android.screen.recorder.ui.splash.LaunchActivity}" drawable="vidma_rec" name="Vidma REC" />
   <item component="ComponentInfo{vidma.screenrecorder.videorecorder.videoeditor.pro/com.atlasv.android.screen.recorder.ui.splash.LaunchActivity}" drawable="vidma_record" name="Vidma Record" />
   <item component="ComponentInfo{com.nemo.vidmate/com.nemo.vidmate.host.WelcomeActivity}" drawable="v_downloader" name="VidMate" />
@@ -19617,6 +19571,7 @@
   <item component="ComponentInfo{com.videoeditorpro.android/com.quvideo.vivacut.app.splash.SplashActivity}" drawable="vivacut" name="VivaCut" />
   <item component="ComponentInfo{com.vivaldi.browser/com.google.android.apps.chrome.Main}" drawable="vivaldi" name="Vivaldi" />
   <item component="ComponentInfo{com.vivaldi.browser/com.vivaldi.browser.IconAlt0}" drawable="vivaldi" name="Vivaldi" />
+  <item component="ComponentInfo{com.vivaldi.browser/com.vivaldi.browser.IconAlt19}" drawable="vivaldi" name="Vivaldi" />
   <item component="ComponentInfo{com.vivaldi.browser.snapshot/com.google.android.apps.chrome.Main}" drawable="vivaldi" name="Vivaldi Snapshot" />
   <item component="ComponentInfo{com.quvideo.xiaoying/com.quvideo.xiaoying.app.splash.SplashActivity}" drawable="vivavideo" name="VivaVideo" />
   <item component="ComponentInfo{com.vivi.vivimusic/com.music.vivi.MainActivityAlias}" drawable="vivi_music" name="VIVI Music" />
@@ -20019,6 +19974,7 @@
   <item component="ComponentInfo{com.weawow/com.weawow.MainActivity}" drawable="weawow" name="Weawow" />
   <item component="ComponentInfo{com.weawow/com.weawow.DefaultIcon}" drawable="weawow" name="Weawow" />
   <item component="ComponentInfo{com.weawow/com.weawow.SnowIcon}" drawable="weawow" name="Weawow" />
+  <item component="ComponentInfo{com.weawow/com.weawow.DarkIcon}" drawable="weawow" name="Weawow" />
   <item component="ComponentInfo{md.elway.webapp/md.elway.webapp.screen.loader.LoaderActivity}" drawable="web_app" name="Web App" />
   <item component="ComponentInfo{md.elway.webapp/md.elway.webapp.screen.launcher.LauncherActivity}" drawable="web_app" name="Web App" />
   <item component="ComponentInfo{com.beta9dev.imagedownloader/com.beta9dev.imagedownloader.main.MainActivity}" drawable="tiktokdownloader" name="WEB Image Downloader" />
@@ -20230,6 +20186,8 @@
   <item component="ComponentInfo{com.sathwbg.easymessager/com.sathwbg.easymessager.Icon0}" drawable="whatsapp" name="WhatsApp" />
   <item component="ComponentInfo{com.somessenger.site/com.whatsapp.Main}" drawable="whatsapp" name="WhatsApp" />
   <item component="ComponentInfo{com.whatsapp/com.whatsapp.AppIcon10}" drawable="whatsapp" name="WhatsApp" />
+  <item component="ComponentInfo{com.whatsapp/com.whatsapp.AppIcon04}" drawable="whatsapp" name="WhatsApp" />
+  <item component="ComponentInfo{com.whatsapp/com.whatsapp.AppIcon03}" drawable="whatsapp" name="WhatsApp" />
   <item component="ComponentInfo{com.whatsapp.w4b/com.whatsapp.Main}" drawable="whatsapp_business" name="WhatsApp Business" />
   <item component="ComponentInfo{io.kuenzler.whatsappwebtogo/io.kuenzler.whatsappwebtogo.MainActivity}" drawable="whatsapp_web_to_go" name="WhatsApp Web To Go" />
   <item component="ComponentInfo{io.kuenzler.whatsappwebtogo/io.kuenzler.whatsappwebtogo.WebviewActivity}" drawable="whatsapp_web_to_go" name="WhatsApp Web To Go" />
@@ -20244,6 +20202,7 @@
   <item component="ComponentInfo{sh.whisper/sh.whisper.WMainActivity}" drawable="whisper" name="Whisper" />
   <item component="ComponentInfo{org.woheller69.whisperplus/com.whisperonnx.MainActivity}" drawable="generic_microphone" name="Whisper+" />
   <item component="ComponentInfo{com.vector123.whiteborder/com.vector123.blank.activity.HomeActivity}" drawable="white_border" name="White Border" />
+  <item component="ComponentInfo{com.vector123.whiteborder/com.vector123.blank.activity.TemplateListActivity}" drawable="white_border" name="White Border" />
   <item component="ComponentInfo{com.tmsoft.whitenoise.full/com.tmsoft.whitenoise.full.MainSplashActivity}" drawable="white_noise" name="White Noise" />
   <item component="ComponentInfo{net.relaxio.relaxio/net.relaxio.relaxio.SplashActivity}" drawable="generic_voice_recorder_waves" name="White Noise Generator" />
   <item component="ComponentInfo{com.hungrydroid.whitescreen/com.hungrydroid.whitescreen.MainActivity}" drawable="black_screen" name="White Screen" />
@@ -20330,8 +20289,10 @@
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.vpn.ui.activities.EntryPointActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.ui.AppStartActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.ui.preferences.icons.GlitchScribeActivity}" drawable="windscribe" name="Windscribe" />
+  <item component="ComponentInfo{com.windscribe.vpn/com.windscribe.mobile.ui.preferences.icons.VaporScribeActivity}" drawable="windscribe" name="Windscribe" />
   <item component="ComponentInfo{com.windyty.android/com.windyty.android.MainActivity}" drawable="windy" name="Windy" />
   <item component="ComponentInfo{com.windyty.android/com.windyty.android.Standard}" drawable="windy" name="Windy" />
+  <item component="ComponentInfo{com.windyty.android/com.windyty.android.default}" drawable="windy" name="Windy" />
   <item component="ComponentInfo{com.wingos.wingcamera/com.wingos.wingcamera.Camera}" drawable="generic_camera" name="WingOS Camera" />
   <item component="ComponentInfo{com.fintechla.wink/com.fintechla.wink.MainActivity}" drawable="wink" name="Wink" />
   <item component="ComponentInfo{com.meitu.wink/com.meitu.wink.page.main.MainActivity}" drawable="wink_video_enhancing" name="Wink" />
@@ -20415,6 +20376,7 @@
   <item component="ComponentInfo{com.peoplefun.wordcross/com.peoplefun.wordcross.MonkeyGame}" drawable="wordscapes" name="Wordscapes" />
   <item component="ComponentInfo{com.peoplefun.wordcross/com.peoplefun.wordscapesunity.MonkeyGame}" drawable="wordscapes" name="Wordscapes" />
   <item component="ComponentInfo{co.wordupapp.app/crc646f45dd7a1b6aab56.SplashScreen}" drawable="wordup" name="WordUp" />
+  <item component="ComponentInfo{co.wordupapp.app/co.wordupapp.app.MainActivity}" drawable="wordup" name="WordUp" />
   <item component="ComponentInfo{com.wordwebsoftware.android.wordweb/com.wordwebsoftware.android.wordweb.activity.WordWebActivity}" drawable="wordweb" name="WordWeb" />
   <item component="ComponentInfo{arproductions.andrew.worklog/arproductions.andrew.worklog.MainActivity}" drawable="work_log" name="Work Log" />
   <item component="ComponentInfo{com.lrhsoft.shiftercalendar/com.lrhsoft.shiftercalendar.MainActivity}" drawable="work_shift_calendar" name="Work Shift Calendar" />
@@ -20434,6 +20396,7 @@
   <item component="ComponentInfo{com.phstudio.freetv/com.phstudio.freetv.MainActivity}" drawable="world_tv" name="World TV" />
   <item component="ComponentInfo{com.mkarpenko.worldbox/com.unity3d.player.UnityPlayerActivity}" drawable="worldbox" name="WorldBox" />
   <item component="ComponentInfo{com.mkarpenko.worldbox/com.byfen.archiver.MainActivity}" drawable="worldbox" name="WorldBox" />
+  <item component="ComponentInfo{com.mkarpenko.worldbox/com.me.game.pmupdatesdk.MainActivity}" drawable="worldbox" name="WorldBox" />
   <item component="ComponentInfo{com.worldcoin/com.worldcoin.app.main.MainActivity}" drawable="worldcoin_wallet" name="Worldcoin Wallet" />
   <item component="ComponentInfo{com.sigseg.android.worldmap/com.sigseg.android.map.ImageViewerActivity}" drawable="generic_earth" name="WorldMap" />
   <item component="ComponentInfo{com.funbase.xradio/com.funbase.xradio.activity.SplashActivity}" drawable="wow_fm" name="WOW FM" />
@@ -20449,6 +20412,7 @@
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice.main.local.HomeRootActivity}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_eng/cn.wps.moffice.Smart}" drawable="wps_office" name="WPS Office" />
   <item component="ComponentInfo{cn.wps.moffice_i18n/cn.wps.moffice.documentmanager.PreStartActivity}" drawable="wps_office_lite" name="WPS Office Lite" />
+  <item component="ComponentInfo{cn.wps.moffice_i18n/cn.wps.moffice.documentmanager.ab.proxy.main}" drawable="wps_office_lite" name="WPS Office Lite" />
   <item component="ComponentInfo{com.themausoft.wpsapp/com.themausoft.wpsapp.InitActivity}" drawable="bell_wi_fi" name="WPSApp" />
   <item component="ComponentInfo{com.themausoft.wpsapppro/com.themausoft.wpsapppro.SplashActivity}" drawable="wpsapp_pro" name="WPSApp Pro" />
   <item component="ComponentInfo{com.themausoft.wpsapppro/com.themausoft.wpsapppro.InitActivity}" drawable="wpsapp_pro" name="WPSApp Pro" />
@@ -20497,6 +20461,7 @@
   <item component="ComponentInfo{video.downloader.tiktok.instagram.file.saver.vault/com.videodownloader.main.ui.activity.LandingActivity}" drawable="x_downloader" name="X Downloader" />
   <item component="ComponentInfo{io.hexman.xiconchanger/io.hexman.xiconchanger.activity.SplashActivity}" drawable="x_icon_changer" name="X Icon Changer" />
   <item component="ComponentInfo{twittervideodownloader.twitter.videoindir.savegif.twdown/com.atlasv.android.downloader.app.x.feature.splash.SplashActivity}" drawable="tiktokdownloader" name="X Saver" />
+  <item component="ComponentInfo{twittervideodownloader.twitter.videoindir.savegif.twdown/com.atlasv.android.downloader.scaffold.ui.feature.splash.SplashActivity}" drawable="tiktokdownloader" name="X Saver" />
   <item component="ComponentInfo{pl.xkom/pl.xkom.ui.MainActivity}" drawable="x_kom" name="x-kom" />
   <item component="ComponentInfo{com.x.android.lite/com.x.android.main.MainActivity}" drawable="x_lite" name="X-Lite" />
   <item component="ComponentInfo{com.lonelycatgames.Xplore/com.lonelycatgames.Xplore.Browser}" drawable="x_plore" name="X-plore" />
@@ -20588,6 +20553,7 @@
   <item component="ComponentInfo{com.xplor.xplor_user/com.xplor.xplor_user.MainActivity}" drawable="xplor" name="Xplor" />
   <item component="ComponentInfo{com.github.tianma8023.xposed.smscode/com.github.tianma8023.xposed.smscode.HomeActivityAlias}" drawable="sms_organizer" name="XposedSmsCode" />
   <item component="ComponentInfo{com.xproguard.passwd/com.xproguard.passwd.ui.auth.AuthenticationActivity}" drawable="xproguard_password_manager" name="Xproguard Password Manager" />
+  <item component="ComponentInfo{com.xproguard.passwd/com.xproguard.passwd.ui.splash.NewLoginActivity}" drawable="xproguard_password_manager" name="Xproguard Password Manager" />
   <item component="ComponentInfo{com.xproguard.photovault/com.xproguard.photovault.MainLauncher}" drawable="xproguard_photo_vault" name="Xproguard Photo Vault" />
   <item component="ComponentInfo{videoeditor.videorecorder.screenrecorder/com.inshot.screenrecorder.activities.SplashBeforeActivity}" drawable="xrecorder" name="XRecorder" />
   <item component="ComponentInfo{videoeditor.videorecorder.screenrecorder/com.google.android.archive.ReactivateActivity}" drawable="xrecorder" name="XRecorder" />
@@ -20603,6 +20569,7 @@
   <item component="ComponentInfo{tv.accedo.airtel.wynk/tv.accedo.airtel.wynk.presentation.view.activity.SplashActivity}" drawable="xstream" name="Xstream" />
   <item component="ComponentInfo{tv.accedo.airtel.wynk/tv.accedo.wynk.android.airtel.activity.AirtelInitializationActivity}" drawable="xstream" name="Xstream" />
   <item component="ComponentInfo{com.xtb.xmobile2/com.xtb.xmobile2.ui.root.SingleRootActivity}" drawable="xtb" name="XTB" />
+  <item component="ComponentInfo{com.xtb.xmobile2/com.xtb.xmobile2.ui.root.SingleRootActivityDefault}" drawable="xtb" name="XTB" />
   <item component="ComponentInfo{com.transsion.theme/com.transsion.theme.common.XThemeMain}" drawable="xtheme" name="XTheme" />
   <item component="ComponentInfo{com.github.andreyasadchy.xtra/com.github.andreyasadchy.xtra.ui.main.MainActivity}" drawable="xtra" name="Xtra" />
   <item component="ComponentInfo{com.planmyfood.app/com.planmyfood.app.MainActivity}" drawable="xume" name="Xume" />
@@ -20736,6 +20703,7 @@
   <item component="ComponentInfo{app.morphe.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube" name="YouTube" />
   <item component="ComponentInfo{com.rve.android.youtube/com.google.android.youtube.app.honeycomb.Shell$HomeActivity}" drawable="youtube" name="YouTube" />
   <item component="ComponentInfo{com.morphe.youtube/com.morphe.youtube.morphe_original_1}" drawable="youtube" name="YouTube" />
+  <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_custom_5}" drawable="youtube" name="YouTube" />
   <item component="ComponentInfo{ma.wanam.youtubeadaway/ma.wanam.youtubeadaway.SettingsActivity}" drawable="youtube_adaway" name="YouTube AdAway" />
   <item component="ComponentInfo{com.google.android.apps.youtube.producer/com.google.android.apps.youtube.producer.application.MainActivity}" drawable="youtube_create" name="YouTube Create" />
   <item component="ComponentInfo{com.google.android.youtube.tv/com.google.android.apps.youtube.tv.activity.ShellActivity}" drawable="youtube" name="YouTube for Android TV" />
@@ -20750,6 +20718,7 @@
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_black_5}" drawable="morphe" name="YouTube Morphe" />
   <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_black_4}" drawable="morphe" name="Youtube Morphe" />
   <item component="ComponentInfo{yt.morphe.noname.exe/yt.morphe.noname.exe.morphe_black_2}" drawable="morphe" name="YouTube Morphe" />
+  <item component="ComponentInfo{app.morphe.android.youtube/app.morphe.android.youtube.morphe_original_3}" drawable="youtube" name="YouTube Morphe" />
   <item component="ComponentInfo{com.morphe.youtube.music/com.morphe.youtube.music.morphe_original_1}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.google.android.apps.youtube.music/com.google.android.archive.ReactivateActivity}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{com.google.android.music/com.google.android.music.tombstone.LauncherActivity}" drawable="generic_player" name="YouTube Music" />
@@ -20766,6 +20735,7 @@
   <item component="ComponentInfo{com.android.youtube.music.premium/com.google.android.apps.youtube.music.activities.MusicActivity}" drawable="generic_player_pro" name="YouTube Music" />
   <item component="ComponentInfo{com.android.youtube.music.premium/com.android.youtube.music.premium.morphe_original_1}" drawable="generic_player_pro" name="YouTube Music" />
   <item component="ComponentInfo{ytm.morphe.noname.exe/ytm.morphe.noname.exe.morphe_original_1}" drawable="generic_player" name="YouTube Music" />
+  <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_custom_5}" drawable="generic_player" name="YouTube Music" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_original_2}" drawable="generic_player" name="YouTube Music Morphe" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_2}" drawable="morphe" name="YouTube Music Morphe" />
   <item component="ComponentInfo{app.morphe.android.apps.youtube.music/app.morphe.android.apps.youtube.music.morphe_black_3}" drawable="morphe" name="YouTube Music Morphe" />
@@ -21046,6 +21016,7 @@
   <item component="ComponentInfo{com.zorinos.zorin_connect/org.kde.kdeconnect.UserInterface.MainActivity}" drawable="zorin_connect" name="Zorin Connect" />
   <item component="ComponentInfo{xyz.deepdaikon.zoysii/xyz.deepdaikon.zoysii.MainActivity}" drawable="zoysii" name="Zoysii" />
   <item component="ComponentInfo{com.zozoplayer/com.zozoplayer.activity.SplashActivity}" drawable="generic_player" name="ZoZo Player" />
+  <item component="ComponentInfo{com.zozoplayer/com.zozoplayer.ui.activities.MainActivity}" drawable="generic_player" name="ZoZo Player" />
   <item component="ComponentInfo{com.zte.storagecleanup/com.zte.storagecleanup.mainui.SplashActivity}" drawable="zte_cleanup" name="ZTE Cleanup" />
   <item component="ComponentInfo{com.zte.cn.compass/com.zte.cn.compass.activity.CompassActivity}" drawable="generic_compass" name="ZTE Compass" />
   <item component="ComponentInfo{com.zte.onekeycp/com.ume.weshare.activity.NewMainActivity}" drawable="zte_phone_switch" name="ZTE Phone Switch" />
@@ -21189,6 +21160,7 @@
   <item component="ComponentInfo{ua.epicentrk/com.epicentrk.epicentr.SplashActivity}" drawable="epicentr" name="Епіцентр ~~ Epicentr" />
   <item component="ComponentInfo{com.zvooq.openplay/com.zvooq.openplay.SplashAliasDefault}" drawable="zvuk" name="Звук ~~ Zvuk" />
   <item component="ComponentInfo{ru.zdravcity.app/ru.zdravcity.app.main.MainActivityReDesign}" drawable="zdravcity" name="Здравсити ~~ Zdravcity" />
+  <item component="ComponentInfo{ru.zdravcity.app/ru.zdravcity.app.main.MainActivity.Default}" drawable="zdravcity" name="Здравсити ~~ Zdravcity" />
   <item component="ComponentInfo{ru.ivi.client/ru.ivi.client.MainActivityPotemnee}" drawable="ivi" name="Иви ~~ Ivi" />
   <item component="ComponentInfo{ru.ivi.client/ru.ivi.client.activity.MainActivity}" drawable="ivi" name="Иви ~~ Ivi" />
   <item component="ComponentInfo{ru.ivi.client/ru.ivi.client.MainActivityAppIcon}" drawable="ivi" name="Иви ~~ Ivi" />
@@ -21288,6 +21260,7 @@
   <item component="ComponentInfo{com.gramotnee.orpho/com.gramotnee.orpho.view.screen.main.MainActivity}" drawable="orthography" name="Орфография русского языка ~~ Orthography" />
   <item component="ComponentInfo{ua.oschadbank.flumo/com.openwaygroup.flumo.MainActivity}" drawable="oschad" name="Ощад ~~ Oschad" />
   <item component="ComponentInfo{ru.mosparking.appnew/ru.parking.featuresplash.internal.presentation.view.SplashActivity}" drawable="parking_russia" name="Парковки России ~~ Parking Russia" />
+  <item component="ComponentInfo{ru.mosparking.appnew/ru.mosparking.ng.ui.activities.SplashScreenActivity}" drawable="parking_russia" name="Парковки России ~~ Parking Russia" />
   <item component="ComponentInfo{com.pervayapomosh/com.pervayapomosh.MainActivity}" drawable="generic_aid" name="Первая Помощь ~~ First Aid" />
   <item component="ComponentInfo{ru.perekrestok.app/ru.perekrestok.app.presentation.MainActivity}" drawable="perekrestok" name="Перекресток ~~ Perekrestok" />
   <item component="ComponentInfo{ru.nskes.paysphera/ru.nskes.paysphera.presentation_v2.screen.activity.splash_activity.SplashActivity}" drawable="paysphera" name="Платосфера ~~ Paysphera" />
@@ -21504,6 +21477,7 @@
   <item component="ComponentInfo{com.adpdigital.mbs.ayande/com.adpdigital.mbs.ayande.HamrahCardHomeActivity}" drawable="hamrahcard" name="همراه کارت ~~ HamrahCard" />
   <item component="ComponentInfo{com.adpdigital.mbs.ayande/com.adpdigital.mbs.authUI.SplashActivity}" drawable="hamrahcard" name="همراه کارت ~~ HamrahCard" />
   <item component="ComponentInfo{com.adpdigital.mbs.ayande/com.adpdigital.mbs.ayande.ui.startup.StartupActivity}" drawable="hamrahcard" name="همراه کارت ~~ HamrahCard" />
+  <item component="ComponentInfo{com.adpdigital.mbs.ayande/com.adpdigital.mbs.ayande.activity.HamrahCardHomeActivity}" drawable="hamrahcard" name="همراه کارت ~~ HamrahCard" />
   <item component="ComponentInfo{com.app.wafeer/com.app.wafeer.MainActivity}" drawable="wafeer" name="وفير ~~ Wafeer" />
   <item component="ComponentInfo{com.urpay.consumer/com.urpay.consumer.MainActivity}" drawable="urpay" name="يور باي ~~ urpay" />
   <item component="ComponentInfo{com.ktb.customer.qr/com.ktb.customer.qr.feature.ekyc.ui.splashscreen.EkycSplashScreenActivity}" drawable="paotang" name="เป๋าตัง ~~ Paotang" />
@@ -21616,6 +21590,7 @@
   <item component="ComponentInfo{com.hermes.mk.bilibili/com.hermes.mk.SDKActivity}" drawable="hatsune_miku_colorful_stage" name="初音未来：缤纷舞台 ~~ HATSUNE MIKU: COLORFUL STAGE!" />
   <item component="ComponentInfo{com.jingcai.apps.qualitydev/com.jingcai.apps.qualitydev.qualitync.SplashActivity}" drawable="dream" name="到梦空间 ~~ Dream" />
   <item component="ComponentInfo{com.lemon.lv/com.vega.main.MainActivity}" drawable="capcut" name="剪映 ~~ CapCut" />
+  <item component="ComponentInfo{com.lemon.lv/com.vega.launcher.precondition.PreInstallConfirmActivity}" drawable="capcut" name="剪映 ~~ CapCut" />
   <item component="ComponentInfo{tw.com.gamer.android.animad/tw.com.gamer.android.animad.AnimadActivity}" drawable="animation_crazy" name="動畫瘋 ~~ Animation Crazy" />
   <item component="ComponentInfo{tw.com.gamer.android.animad/tw.com.gamer.android.animad.LandingActivity}" drawable="animation_crazy" name="動畫瘋 ~~ Animation Crazy" />
   <item component="ComponentInfo{com.gamamobi.nikke/com.shiftup.nk.MainActivity}" drawable="goddess_of_victory_nikke" name="勝利女神：妮姬 ~~ GODDESS OF VICTORY: NIKKE" />
@@ -21754,6 +21729,7 @@
   <item component="ComponentInfo{com.tencent.tmgp.sgame/com.tencent.tmgp.sgame.SGameActivity}" drawable="honor_of_kings" name="王者荣耀 ~~ Honor of Kings" />
   <item component="ComponentInfo{com.lucky.luckyclient/com.luckin.client.main.splash.SplashActivity}" drawable="luckin_coffee" name="瑞幸咖啡 ~~ Luckin Coffee" />
   <item component="ComponentInfo{com.luckin.client.i/com.luckin.client.intl.SplashActivity}" drawable="luckin_coffee" name="瑞幸咖啡 ~~ Luckin Coffee" />
+  <item component="ComponentInfo{com.lucky.luckyclient/com.lucky.luckincoffee.splash.SplashActivity}" drawable="luckin_coffee" name="瑞幸咖啡 ~~ Luckin Coffee" />
   <item component="ComponentInfo{com.ryuunoakaihitomi.rebootmenu/github.ryuunoakaihitomi.powerpanel.ui.main.MainActivity}" drawable="generic_power" name="电源面板 ~~ Reboot Menu" />
   <item component="ComponentInfo{com.dragon.read/com.dragon.read.pages.splash.SplashActivity}" drawable="dragon_read" name="番茄免费小说 ~~ Dragon Read" />
   <item component="ComponentInfo{com.uzero.baimiao/com.uzero.baimiao.Hello}" drawable="baimiao" name="白描 ~~ Baimiao" />
@@ -21768,6 +21744,7 @@
   <item component="ComponentInfo{com.baidu.netdisk/com.baidu.netdisk.ui.SvipLauncherActivity}" drawable="baidu_netdisk" name="百度网盘 ~~ Baidu Netdisk" />
   <item component="ComponentInfo{com.baidu.netdisk/com.baidu.netdisk.ui.DefaultMainActivity}" drawable="baidu_netdisk" name="百度网盘 ~~ Baidu Netdisk" />
   <item component="ComponentInfo{com.baidu.netdisk.samsung/com.baidu.netdisk.ui.DefaultMainActivity}" drawable="baidu_netdisk" name="百度网盘 ~~ Baidu Netdisk" />
+  <item component="ComponentInfo{com.baidu.netdisk/com.baidu.netdisk.ui.Navigate}" drawable="baidu_netdisk" name="百度网盘 ~~ Baidu Netdisk" />
   <item component="ComponentInfo{com.baidu.tieba/com.baidu.tieba.tblauncher.MainTabActivity}" drawable="baidu_tieba" name="百度贴吧 ~~ Baidu Tieba" />
   <item component="ComponentInfo{com.baidu.input/com.baidu.input.ImeLauncherActivity}" drawable="baidu_ime" name="百度输入法 ~~ Baidu IME" />
   <item component="ComponentInfo{com.zhihu.android/com.zhihu.android.app.ui.activity.LauncherActivity}" drawable="zhihu" name="知乎 ~~ Zhihu" />
@@ -21789,6 +21766,7 @@
   <item component="ComponentInfo{com.HoYoverse.Nap/com.mihoyoos.sdk.platform.SchemeActivity}" drawable="zenless_zone_zero" name="绝区零 ~~ Zenless Zone Zero" />
   <item component="ComponentInfo{com.HoYoverse.Nap/com.mihoyo.combosdk.ComboSDKActivity}" drawable="zenless_zone_zero" name="绝区零 ~~ Zenless Zone Zero" />
   <item component="ComponentInfo{com.mybank.android.phone/com.mybank.android.phone.MainActivity}" drawable="mybank" name="网商银行 ~~ MYBank" />
+  <item component="ComponentInfo{com.mybank.android.phone/com.alipay.mobile.quinox.LauncherActivity}" drawable="mybank" name="网商银行 ~~ MYBank" />
   <item component="ComponentInfo{com.sankuai.meituan/com.sankuai.meituan.MPMainActivity}" drawable="meituan" name="美团 ~~ Meituan" />
   <item component="ComponentInfo{com.sankuai.meituan/com.meituan.android.pt.homepage.activity.MainActivity}" drawable="meituan" name="美团 ~~ Meituan" />
   <item component="ComponentInfo{com.sankuai.meituan/com.sankuai.meituan.activity.Welcome}" drawable="meituan" name="美团 ~~ Meituan" />
@@ -21818,6 +21796,7 @@
   <item component="ComponentInfo{com.android.superli.btremote/com.android.superli.btremote.ui.activity.SplashActivity}" drawable="bluetooth_control" name="蓝牙遥控 ~~ Bluetooth control" />
   <item component="ComponentInfo{com.RoamingStar.BlueArchive/com.yostar.supersdk.activity.YoStarSplashActivity}" drawable="blue_archive" name="蔚蓝档案 ~~ Blue Archive" />
   <item component="ComponentInfo{com.RoamingStar.BlueArchive.bilibili/com.yostar.supersdk.activity.YoStarSplashActivity}" drawable="blue_archive" name="蔚蓝档案 ~~ Blue Archive" />
+  <item component="ComponentInfo{com.RoamingStar.BlueArchive/com.tech.core.TechSplashActivity}" drawable="blue_archive" name="蔚蓝档案 ~~ Blue Archive" />
   <item component="ComponentInfo{com.mxbc.mxsa/com.mxbc.mxsa.modules.splash.SplashActivity}" drawable="mixue_ice_city" name="蜜雪冰城 ~~ Mixue Ice City" />
   <item component="ComponentInfo{com.shopee.tw/com.shopee.app.ui.home.HomeActivity_}" drawable="shopee" name="蝦皮購物 ~~ Shopee" />
   <item component="ComponentInfo{jp.seibugroup.seiburailway.seibuapp.client/jp.seibugroup.seiburailway.seibuapp.client.view.splash.SplashActivity}" drawable="seibu_line" name="西武線アプリ ~~ Seibu Line" />


### PR DESCRIPTION
I also removed some dynamic app IDs, since it's a never-ending chase for updates.

<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
9Now (`au.com.mi9.jumpin.app` → `_9now.svg`)
ADB WiFi (`com.rair.adbwifi` → `ladb.svg`)
Adda247 (`com.adda247.app` → `adda247.svg`)
American Express (Amex) (`com.americanexpress.android.acctsvcs.it` → `american_express_amex.svg`)
American Express (Amex) (`com.americanexpress.android.acctsvcs.de` → `american_express_amex.svg`)
American Express (Amex) (`com.americanexpress.android.acctsvcs.fr` → `american_express_amex.svg`)
APK Editor Pro (`com.apkeditor.new.explorer3` → `apk_editor_pro.svg`)
AppBlock (`cz.mobilesoft.appblock` → `appblock.svg`)
ArchiveTune (`moe.rukamori.archivetune` → `archivetune.svg`)
Autobusų bilietai (`com.kautra.android.autobusubilietai` → `autobusu_bilietai.svg`)
AVG AntiVirus (`com.antivirus` → `avg_antivirus.svg`)
Bad Piggies (`com.rovio.BadPiggiesHD` → `bad_piggies.svg`)
Bajaj Finance (`org.altruist.BajajExperia` → `bajaj_finserv.svg`)
Banana Kong (`com.fdgentertainment.bananakong` → `banana_kong.svg`)
Banco PAN (`br.com.bancopan.cartoes` → `banco_pan.svg`)
BeReal. (`com.bereal.ft` → `bereal.svg`)
Birbank (`az.kapitalbank.mbanking` → `birbank.svg`)
Block Blast! (`com.block.juggle` → `block_blast.svg`)
Boyner (`com.mobisoft.boyner` → `boyner.svg`)
Bridgefy (`me.bridgefy.main` → `bridgefy.svg`)
BUFF (`com.netease.market.buff` → `buff.svg`)
Bybit (`com.bybit.eu` → `bybit.svg`)
Camera (`com.vayunmathur.camera` → `generic_camera.svg`)
Castorama (`com.kingfisher.cafr` → `castorama.svg`)
Cetelem (`pt.cetelem.homebanking` → `cetelem.svg`)
Chess (`com.birds.chess` → `generic_chess.svg`)
CLEAR (`com.clearme.clearapp` → `clear.svg`)
Clearpay (`com.afterpaymobile.uk` → `clearpay.svg`)
Clone App Calculator Icon (`com.pengyou.cloneapp` → `generic_calculator_plus_minus_multi_equal.svg`)
Clue (`com.clue.android` → `clue.svg`)
Costco (`com.costco.app.android` → `costco.svg`)
Crosshair Hero (`me.okitastudio.crosshairherofps` → `crosshair_hero.svg`)
DankChat (`com.flxrs.dankchat` → `dankchat.svg`)
Day One Journal (`com.dayoneapp.dayone` → `day_one_journal.svg`)
Dhikr &amp;amp; Dua (`com.alifewithallah.app` → `dhikr_and_dua.svg`)
Dice Yatzy (`com.funcraft.diceyatzy` → `random_dice_defense.svg`)
DIKSHA (`in.gov.diksha.app` → `diksha.svg`)
Doctoralia (`co.doctoralia` → `doctoralia.svg`)
Domino's Pizza (`com.Dominos` → `dominos_pizza.svg`)
Dream11 (`com.app.dream11Pro` → `dream11.svg`)
du (`duleaf.duapp.splash` → `du.svg`)
Duolingo (`com.duolingo` → `duolingo.svg`)
Enel (`br.com.deway.coelce` → `enel.svg`)
Ente Locker (`io.ente.locker.independent` → `ente_locker.svg`)
ExpressVPN (`com.unlimited.unblock.free.accelerator.top` → `expressvpn.svg`)
9 × Facebook (`com.facebook.katana` → `facebook.svg`)
Fasten (`ru.yandex.uber` → `fasten.svg`)
Flipkart (`com.flipkart.android` → `flipkart.svg`)
Flow Free (`com.bigduckgames.flowbridges` → `flow_free.svg`)
freenet Mobilfunk (`de.md.meinmd` → `freenet_mobilfunk.svg`)
Geode (`com.geode.launcher` → `geode.svg`)
George (`cz.csas.georgego` → `george.svg`)
Gojek Driver (`com.gojek.partner` → `gojek_driver.svg`)
Google One (`com.google.android.apps.subscriptions.red` → `google_one.svg`)
Grand Theft Auto: Vice City (`com.rockstargames.gtavc` → `grand_theft_auto_vice_city.svg`)
Happy Color (`com.pixel.art.coloring.color.number` → `happy_color.svg`)
HTTP Custom (`xyz.easypro.httpcustom` → `http_custom.svg`)
iMobile Pay (`com.csam.icici.bank.imobile` → `imobile_pay.svg`)
Indus (`ai.sarvam.indus` → `indus.svg`)
ING (`au.com.ing.banking` → `ing.svg`)
Intent Intercept (`de.k3b.android.intentintercept` → `apk_info.svg`)
Key Mapper (`io.github.sds100.keymapper` → `key_mapper.svg`)
Kwai (`com.kwai.kuaishou.video.live` → `kwai.svg`)
Line VPN (`line.vrapp.com` → `line_vpn.svg`)
Liteapks (`com.liteapks.androidapps` → `liteapks.svg`)
Matiks (`com.matiks.app` → `matiks.svg`)
Mavi (`com.mavi.kartus` → `mavi.svg`)
McDo+ (`com.md.mcdonalds.gomcdo` → `mcdo_plus.svg`)
McDonald's (`com.mcdo.mcdonalds` → `mcdonalds.svg`)
Meld (`com.meld.app` → `music_player.svg`)
3 × Mi Video (`com.miui.videoplayer` → `mi_video.svg`)
Millenicom (`com.solidict.millenicom` → `millenicom.svg`)
Money manager (`ru.innim.my_finance` → `money_manager.svg`)
Moto Notifications (`com.motorola.ccc.notification` → `moto_notifications.svg`)
Moviebase (`com.moviebase` → `moviebase.svg`)
Music Downloader (`com.musicdownloader.musicfreeapp825v2` → `apple_music.svg`)
Music Player (`com.rocks.music` → `apple_music.svg`)
Music You (`com.github.musicyou` → `music_player.svg`)
My Vodafone (`com.vodafone.android` → `my_vodafone.svg`)
My Weather (`fr.meteo` → `my_weather.svg`)
Namida (`com.msob7y.namida` → `namida.svg`)
Namma Yatri (`in.juspay.nammayatri` → `namma_yatri.svg`)
Naranja X (`com.naranjax.mx` → `naranja_x.svg`)
National Rail (`uk.co.nationalrail.google` → `national_rail.svg`)
2 × Navic (`paige.navic` → `navic.svg`)
Notisave (`com.tenqube.notisave` → `notisave.svg`)
Nuvio (`com.nuvio.app` → `nuvio.svg`)
OneYou Themed Icons (`com.pashapuma.oneyou.themed` → `oneyou_icons.svg`)
Package Name Viewer (`com.csdroid.pkg` → `package_name_viewer.svg`)
Paisabazaar (`com.paisabazaar` → `policybazaar.svg`)
PayPal (`com.paypal.android.p2pmobile` → `paypal.svg`)
Physics Wallah (PW) (`xyz.penpencil.physicswala` → `physics_wallah_pw.svg`)
Pi Generator (`com.markduenas.android.apigen` → `generic_pi.svg`)
Picsart (`com.picsart.studio.light` → `picsart.svg`)
Pluxee Cadeaux (`com.wedoogift` → `pluxee.svg`)
PNC (`com.pnc.ecommerce.mobile` → `pnc.svg`)
Psiphon Pro (`com.psiphon3.subscription` → `psiphon_pro.svg`)
Public Local Videos (`com.cardfeed.video_public` → `public_local_videos.svg`)
Punch-hole Download Progress (`eu.hxreborn.phdp` → `punch_hole_download_progress.svg`)
Qibla Compass (`qibladirectioncompass.qiblafinder.truenorthcompass` → `qibla_compass.svg`)
QR Code Reader (`com.qrfamily.qrcodereaderscanner` → `generic_qr_reader.svg`)
Question.AI (`com.qianfan.aihomework` → `question_ai.svg`)
Rapido (`com.rapido.passenger` → `rapido.svg`)
Remini (`com.remini.xyz` → `remini.svg`)
Reversi (`livio.reversi` → `reversi.svg`)
Ridmik Keyboard (`ridmik.keyboard` → `ridmik_keyboard.svg`)
RTL+ (`de.rtli.tvnow` → `rtl_plus.svg`)
Saturate Icons (`ddt.free.icon.packs` → `saturate_icons.svg`)
SHEIN (`com.ril.shein` → `shein.svg`)
Shizuku (`moe.shizuku.privileged.api` → `shizuku.svg`)
SoundCloud (`com.apple.android.music` → `soundcloud.svg`)
Starbucks (`com.starbucks.fr` → `starbucks.svg`)
Stori (`ai.powerup.stori` → `stori.svg`)
Sweatcoin (`in.sweatco.app` → `sweatcoin.svg`)
Syncthing-Fork (`com.github.catfriend1.syncthingandroid` → `syncthing.svg`)
Tamara (`co.tamara.user` → `tamara.svg`)
Temple Run 2 (`com.imangi.templerun2` → `temple_run_2.svg`)
TickTick (`com.ticktick.task` → `ticktick.svg`)
TIM (`br.com.timbrasil.meutim` → `tim.svg`)
Tira (`com.ril.tira` → `tira.svg`)
TLN+ (`app.tln.plus` → `tln_plus.svg`)
To Do (`com.minimalisttodolist.pleasebethelastrecyclerview` → `tasks.svg`)
To Do List (`com.splendapps.splendo` → `tasks.svg`)
Todoist (`com.todoist` → `todoist.svg`)
TrainingPeaks (`com.peaksware.trainingpeaks` → `trainingpeaks.svg`)
v2rayNG (`com.v2ray.ang.fdroid` → `v2rayng.svg`)
V380 Pro (`com.macrovideo.v380pro` → `v380_pro.svg`)
vesIC (`com.vincentengelsoftware.vesandroidimagecompare` → `photo_compare.svg`)
Vidio (`com.vidio.android` → `vidio.svg`)
Vivaldi (`com.vivaldi.browser` → `vivaldi.svg`)
Weawow (`com.weawow` → `weawow.svg`)
2 × WhatsApp (`com.whatsapp` → `whatsapp.svg`)
White Border (`com.vector123.whiteborder` → `white_border.svg`)
Windscribe (`com.windscribe.vpn` → `windscribe.svg`)
Windy (`com.windyty.android` → `windy.svg`)
WordUp (`co.wordupapp.app` → `wordup.svg`)
WorldBox (`com.mkarpenko.worldbox` → `worldbox.svg`)
WPS Office Lite (`cn.wps.moffice_i18n` → `wps_office_lite.svg`)
X Saver (`twittervideodownloader.twitter.videoindir.savegif.twdown` → `tiktokdownloader.svg`)
Xproguard Password Manager (`com.xproguard.passwd` → `xproguard_password_manager.svg`)
XTB (`com.xtb.xmobile2` → `xtb.svg`)
YouTube (`app.morphe.android.youtube` → `youtube.svg`)
YouTube Morphe (`app.morphe.android.youtube` → `youtube.svg`)
YouTube Music (`app.morphe.android.apps.youtube.music` → `generic_player.svg`)
ZoZo Player (`com.zozoplayer` → `generic_player.svg`)
Здравсити ~~ Zdravcity (`ru.zdravcity.app` → `zdravcity.svg`)
Парковки России ~~ Parking Russia (`ru.mosparking.appnew` → `parking_russia.svg`)
همراه کارت ~~ HamrahCard (`com.adpdigital.mbs.ayande` → `hamrahcard.svg`)
剪映 ~~ CapCut (`com.lemon.lv` → `capcut.svg`)
瑞幸咖啡 ~~ Luckin Coffee (`com.lucky.luckyclient` → `luckin_coffee.svg`)
百度网盘 ~~ Baidu Netdisk (`com.baidu.netdisk` → `baidu_netdisk.svg`)
网商银行 ~~ MYBank (`com.mybank.android.phone` → `mybank.svg`)
蔚蓝档案 ~~ Blue Archive (`com.RoamingStar.BlueArchive` → `blue_archive.svg`)