### PR TITLE
+3 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -6758,6 +6758,7 @@
   <item component="ComponentInfo{com.snackshotvideos.videostatus.videosaver/com.snackshotvideos.videostatus.videosaver.activitys.SplashActivity}" drawable="gallery_by_zipoapps" name="Gallery by ZipoApps" />
   <item component="ComponentInfo{com.thinkyeah.galleryvault/com.thinkyeah.galleryvault.ads.GvAppOpenSplashActivity}" drawable="gallery_vault" name="Gallery Vault" />
   <item component="ComponentInfo{com.thinkyeah.galleryvault/com.thinkyeah.galleryvault.LockingActivity}" drawable="gallery_vault" name="Gallery Vault" />
+  <item component="ComponentInfo{gallery.photogallery.pictures.vault.album/gallery.photogallery.pictures.vault.album.activity.splash.SplashActivity}" drawable="xgallery" name="Galleryit" />
   <item component="ComponentInfo{farrukh.gameboost/farrukh.gameboost.core.SplashActivity}" drawable="game_space" name="Game Boost" />
   <item component="ComponentInfo{com.g19mobile.gameboosterplus/com.g19mobile.gameboosterplus.SplashActivity}" drawable="game_booster" name="Game Booster" />
   <item component="ComponentInfo{com.g19mobile.gamebooster/com.fenixphoneboosterltd.gamebooster.SplashActivity}" drawable="game_booster" name="Game Booster" />
@@ -16949,6 +16950,7 @@
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.LavaAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.ClassicGhostAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.google.android.archive.ReactivateActivity}" drawable="snapchat" name="Snapchat" />
+  <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.BlackPantherAlias}" drawable="snapchat" name="Snapchat" />
   <item component="ComponentInfo{com.snapchat.android/com.snapchat.android.Plus2Alias}" drawable="snapchat_plus" name="Snapchat Plus" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivity}" drawable="snapdeal" name="Snapdeal" />
   <item component="ComponentInfo{com.snapdeal.main/com.snapdeal.ui.material.activity.MaterialMainActivityDefault}" drawable="snapdeal" name="Snapdeal" />
@@ -21703,6 +21705,7 @@
   <item component="ComponentInfo{hello.litiaotiao.app/hello.litiaotiao.app.LauncherActivity}" drawable="li_tiaotiao" name="李跳跳是 ~~ Li Tiaotiao" />
   <item component="ComponentInfo{hello.litiaotiao.app/hello.litiaotiao.app.MainActivity}" drawable="li_tiaotiao" name="李跳跳是 ~~ Li Tiaotiao" />
   <item component="ComponentInfo{jp.lg.tokyo.metro.app/jp.tokyo.tokyopoint.MainActivity}" drawable="tokyo_metropolitan_government" name="東京都公式 ~~ Tokyo Metropolitan Government" />
+  <item component="ComponentInfo{jp.co.rakuten.android/jp.co.rakuten.android.home.RakutenHome}" drawable="rakuten" name="楽天 ~~ Rakuten" />
   <item component="ComponentInfo{jp.co.rakuten.pay/jp.co.rakuten.wallet.activities.StartActivity}" drawable="rakuten_pay" name="楽天ペイ ~~ Rakuten Pay" />
   <item component="ComponentInfo{com.east2west.minimetro.bilibili/com.east2west.unitygame.MainActivity}" drawable="mini_metro" name="模拟地铁 ~~ Mini Metro" />
   <item component="ComponentInfo{cn.lyric.getter/cn.lyric.getter.launcher}" drawable="generic_shell" name="歌词获取 ~~ Lyric Getter" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
Galleryit (`gallery.photogallery.pictures.vault.album` → `xgallery.svg`)
Snapchat (`com.snapchat.android` → `snapchat.svg`)
楽天 ~~ Rakuten (`jp.co.rakuten.android` → `rakuten.svg`)