### PR TITLE
+15 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4334,6 +4334,8 @@
   <item component="ComponentInfo{com.zuler.deskin/com.zuler.deskin.activity.WelcomeActivity}" drawable="deskin" name="DeskIn" />
   <item component="ComponentInfo{com.desmos.calculator/com.desmos.calculator.MainActivity}" drawable="desmos" name="Desmos" />
   <item component="ComponentInfo{com.desmos.scientific/com.desmos.calculator.MainActivity}" drawable="desmos_scientific_calculator" name="Desmos Scientific Calculator" />
+  <item component="ComponentInfo{com.gm.despegar/com.despegar.whitelabel.XMasLauncher25}" drawable="decolar" name="Despegar" />
+  <item component="ComponentInfo{com.gm.despegar/com.despegar.whitelabel.DefaultLauncher}" drawable="decolar" name="Despegar" />
   <item component="ComponentInfo{com.despezzas/com.despezzas.MainActivity}" drawable="despezzas" name="Despezzas" />
   <item component="ComponentInfo{com.KonfaGames.Despotism3k/com.unity3d.player.UnityPlayerActivity}" drawable="despotism_3k" name="Despotism 3k" />
   <item component="ComponentInfo{com.KonfaGames.Despotism3k/com.fiveplay.mod.RMS.Recovery}" drawable="despotism_3k" name="Despotism 3k" />
@@ -9858,6 +9860,7 @@
   <item component="ComponentInfo{project.listick.fakegps/project.listick.fakegps.UI.SplashActivity}" drawable="lipstick_fake_gps" name="Lipstick Fake GPS" />
   <item component="ComponentInfo{com.woi.liputan6.android/com.woi.liputan6.android.activity.Splash}" drawable="liputan6" name="Liputan6" />
   <item component="ComponentInfo{com.woi.liputan6.android/com.woi.liputan6.android.Launcher}" drawable="liputan6" name="Liputan6" />
+  <item component="ComponentInfo{com.grice.call/com.grice.call.icon.Default}" drawable="generic_dialer" name="Liquid Dialer" />
   <item component="ComponentInfo{com.shvenergy.liquigas/com.shv.consumerportals.MainActivity}" drawable="liquigas" name="Liquigas" />
   <item component="ComponentInfo{com.teamliquid.liquipedia.liquipedia_app/com.teamliquid.liquipedia.liquipedia_app.MainActivity}" drawable="liquipedia" name="Liquipedia" />
   <item component="ComponentInfo{me.echeung.moemoekyun/me.echeung.moemoekyun.ui.activity.MainActivity}" drawable="listen_moe" name="LISTEN.moe" />
@@ -9919,6 +9922,7 @@
   <item component="ComponentInfo{com.lmr.lfm/com.lmr.lfm.MainActivity}" drawable="lmr" name="LMR" />
   <item component="ComponentInfo{com.rajarsheechatterjee.LNReader/com.rajarsheechatterjee.LNReader.MainActivity}" drawable="lnreader" name="LNReader" />
   <item component="ComponentInfo{app.polarbear/android.app.NativeActivity}" drawable="local_desktop" name="Local Desktop" />
+  <item component="ComponentInfo{com.cvc953.localplayer/com.cvc953.localplayer.MainActivity}" drawable="music_player" name="Local Player" />
   <item component="ComponentInfo{org.localsend.localsend_app/org.localsend.localsend_app.MainActivity}" drawable="localsend" name="LocalSend" />
   <item component="ComponentInfo{com.xfarrow.locatemydevice/com.xfarrow.locatemydevice.MainActivity}" drawable="generic_shell" name="Locate My Device" />
   <item component="ComponentInfo{com.locationchanger/com.locationchanger.MainActivity}" drawable="location_changer" name="Location Changer" />
@@ -10472,6 +10476,7 @@
   <item component="ComponentInfo{tv.medal.recorder/tv.medal.ui.LaunchActivity.Reverse}" drawable="medal" name="Medal" />
   <item component="ComponentInfo{de.medflex.app.flutter/de.medflex.app.flutter.MainActivity}" drawable="medflex" name="medflex" />
   <item component="ComponentInfo{com.mediaon.apt/com.mediaon.apt.MainActivity}" drawable="media_on" name="Media ON" />
+  <item component="ComponentInfo{instagram.video.downloader.story.saver.ig.insaver/instasaver.instagram.video.downloader.photo.ui.startup.StartupActivity}" drawable="download_progress_plus_plus" name="Media Saver" />
   <item component="ComponentInfo{de.benzac.msx/de.benzac.tvx.activities.MainActivity}" drawable="media_station_x" name="Media Station X" />
   <item component="ComponentInfo{com.speechcycle.smartcare.android.mediacom/com.speechcycle.smartcare.android.mediacom.MainActivity}" drawable="mediacom_support" name="Mediacom Support" />
   <item component="ComponentInfo{pl.mediaexpert.app/pl.mediaexpert.app.MainActivity}" drawable="generic_player" name="MediaExpert" />
@@ -11524,6 +11529,7 @@
   <item component="ComponentInfo{com.android.music/com.android.music.MusicBrowserActivity}" drawable="generic_player" name="Music" />
   <item component="ComponentInfo{com.android.bbkmusic/com.android.bbkmusic.WidgetToTrackActivity}" drawable="music_player" name="Music" />
   <item component="ComponentInfo{com.vayunmathur.music/com.vayunmathur.music.MainActivity}" drawable="music_player" name="Music" />
+  <item component="ComponentInfo{com.android.music/com.android.music.TrackBrowserActivity}" drawable="apple_music" name="Music" />
   <item component="ComponentInfo{siva.app.music7pro/siva.app.music7pro.app.activities.M7Player}" drawable="apple_music" name="Music 7 Pro" />
   <item component="ComponentInfo{com.tianxingjian.supersound/com.tianxingjian.supersound.MainActivity}" drawable="music_audio_editor" name="Music Audio Editor" />
   <item component="ComponentInfo{com.musicmaker.mobile.android/com.musicmaker.mobile.android.AndroidLauncher}" drawable="ddmusic" name="Music Creator" />
@@ -11552,6 +11558,7 @@
   <item component="ComponentInfo{music.musicplayer/com.android.music.SplashActivity}" drawable="apple_music" name="Music Player" />
   <item component="ComponentInfo{com.nexnil.mediaplayer/com.musicplayer.mediaplayer.activities.PermissionActivity}" drawable="apple_music" name="Music Player" />
   <item component="ComponentInfo{com.rocks.music/com.rocks.music.musicplayer.MusicSplash}" drawable="apple_music" name="Music Player" />
+  <item component="ComponentInfo{com.musicplan.playermusic/com.musicplan.playermusic.activities.MainActivity}" drawable="apple_music" name="Music Player" />
   <item component="ComponentInfo{musicplayer.musicapps.music.mp3player/musicplayer.musicapps.music.mp3player.activities.SplashActivity}" drawable="music_player_and_mp3_player" name="Music Player &amp; MP3 Player" />
   <item component="ComponentInfo{com.iven.musicplayergo/com.iven.musicplayergo.MainActivity}" drawable="music_player_go" name="Music Player GO" />
   <item component="ComponentInfo{com.iven.musicplayergo/com.iven.musicplayergo.ui.MainActivity}" drawable="music_player_go" name="Music Player GO" />
@@ -11568,6 +11575,7 @@
   <item component="ComponentInfo{com.lstapps.musicwidgetandroid12/com.lstapps.musicwidgetandroid12.MainActivity}" drawable="music_widget_android" name="Music Widget Android" />
   <item component="ComponentInfo{com.github.musicyou/it.vfsfitvnm.vimusic.MainActivity}" drawable="music_player" name="Music You" />
   <item component="ComponentInfo{com.github.musicyou/com.github.musicyou.MainActivity}" drawable="music_player" name="Music You" />
+  <item component="ComponentInfo{jl.musicalnotes/jl.musicalnotes.activity.MainActivity}" drawable="music_player" name="Musical Notes" />
   <item component="ComponentInfo{com.yamaha.av.musiccastcontroller/com.yamaha.av.musiccastcontroller.activity.MainActivity}" drawable="musiccast" name="MusicCast" />
   <item component="ComponentInfo{com.maximillianleonov.musicmax/com.maximillianleonov.musicmax.MusicmaxActivity}" drawable="musicmax" name="Musicmax" />
   <item component="ComponentInfo{in.krosbits.musicolet/in.krosbits.musicolet.MusicActivity}" drawable="musicolet_music_player" name="Musicolet Music Player" />
@@ -12464,6 +12472,7 @@
   <item component="ComponentInfo{dev.narikdesign.nothingblue/dev.narikdesign.nothingblue.MainActivity}" drawable="nothing_adaptive_blue_icons" name="Nothing Adaptive Blue Icons" />
   <item component="ComponentInfo{dev.narikdesign.nothingadaptive/dev.narikdesign.nothingadaptive.MainActivity}" drawable="nothing_adaptive_icons" name="Nothing Adaptive Icons" />
   <item component="ComponentInfo{com.nothing.camera/com.nothing.camera.activity.CameraActivity}" drawable="nothing_camera" name="Nothing Camera" />
+  <item component="ComponentInfo{com.rkkvishva.nothing_dialer/com.rkkvishva.nothing_dialer.LauncherAliasRed}" drawable="generic_dialer" name="Nothing Dialer" />
   <item component="ComponentInfo{com.nothing.ntessentialspace/com.nothing.ntessentialspace.MainActivity}" drawable="nothing_essential_space" name="Nothing Essential Space" />
   <item component="ComponentInfo{com.nothing.gallery/com.nothing.gallery.activity.EntryActivity}" drawable="nothing_gallery" name="Nothing Gallery" />
   <item component="ComponentInfo{com.nothing.icon.free/com.nothing.icon.free.MainActivity}" drawable="nothing_icons" name="Nothing Icons" />
@@ -12975,6 +12984,7 @@
   <item component="ComponentInfo{org.onionshare.android/org.onionshare.android.ui.MainActivity}" drawable="onionshare" name="OnionShare" />
   <item component="ComponentInfo{com.onlyone.onlyonestarter/com.onlyone.onlyonestarter.MainActivity}" drawable="only_one" name="Only One" />
   <item component="ComponentInfo{com.onlyone.onlyonestarter/com.oneseries.starter.MainActivity}" drawable="only_one" name="Only One" />
+  <item component="ComponentInfo{one.only.player/one.only.player.MainActivity}" drawable="just_player" name="Only Player" />
   <item component="ComponentInfo{com.onlyoffice.documents/app.editors.manager.ui.activities.main.MainActivity}" drawable="onlyoffice_documents" name="ONLYOFFICE Documents" />
   <item component="ComponentInfo{com.onlyoffice.documents/app.editors.manager.ui.activities.login.SplashActivity}" drawable="onlyoffice_documents" name="ONLYOFFICE Documents" />
   <item component="ComponentInfo{com.onlyoffice.documents/app.editors.manager.ui.activities.main.OnBoardingActivity}" drawable="onlyoffice_documents" name="ONLYOFFICE Documents" />
@@ -15151,6 +15161,7 @@
   <item component="ComponentInfo{com.mohu.repont/com.mohu.repont.MainActivity}" drawable="repont" name="REpont" />
   <item component="ComponentInfo{com.mohu.repont/com.mohu.repont.LaunchActivity}" drawable="repont" name="REpont" />
   <item component="ComponentInfo{ventures.bench.repost/ventures.bench.repost.activities.PostsActivity}" drawable="repost" name="Repost" />
+  <item component="ComponentInfo{android.rk.RockVideoPlayer/android.rk.RockVideoPlayer.RockVideoPlayer}" drawable="just_player" name="ReproductorVideo" />
   <item component="ComponentInfo{app.republik/app.republik.MainActivity}" drawable="republik" name="Republik" />
   <item component="ComponentInfo{com.reqable.android/com.reqable.android.MainActivity}" drawable="reqable" name="Reqable" />
   <item component="ComponentInfo{ga.edvin.resecentrum/ga.edvin.resecentrum.MainActivity}" drawable="resecentrum" name="Resecentrum" />
@@ -17045,6 +17056,7 @@
   <item component="ComponentInfo{home.solo.launcher.free/home.solo.launcher.free.SplashActivity}" drawable="solo_launcher" name="Solo Launcher" />
   <item component="ComponentInfo{com.sololearn/com.sololearn.app.activities.LauncherActivity}" drawable="sololearn" name="Sololearn" />
   <item component="ComponentInfo{com.sololearn/com.sololearn.app.ui.launcher.LauncherActivity}" drawable="sololearn" name="Sololearn" />
+  <item component="ComponentInfo{com.solo.link.music.player.pro/com.jober.music.player.ui.activity.SplashActivity}" drawable="apple_music" name="SoloPro" />
   <item component="ComponentInfo{nothing.kwgt.app/nothing.kwgt.app.MainActivity}" drawable="something_kwgt" name="Something KWGT" />
   <item component="ComponentInfo{tj.somon.somontj/tj.somon.somontj.AppActivity}" drawable="somon" name="Somon" />
   <item component="ComponentInfo{nl.topicus.somtoday.leerling/nl.topicus.somtoday.leerling.MainActivity}" drawable="somtoday" name="Somtoday" />
@@ -17433,6 +17445,7 @@
   <item component="ComponentInfo{app.status.mobile/app.status.mobile.StatusQtActivity}" drawable="status" name="Status" />
   <item component="ComponentInfo{ch.rmy.android.statusbar_tacho/ch.rmy.android.statusbar_tacho.activities.SettingsActivity}" drawable="status_bar_speedometer" name="Status Bar Speedometer" />
   <item component="ComponentInfo{com.downlood.sav.whmedia/com.downlood.sav.whmedia.Activity.SplashScreenActivity}" drawable="status_download" name="Status Download" />
+  <item component="ComponentInfo{wasaver.downloadstatus.videosaver.wasticker.downloader/wasaver.downloadstatus.videosaver.wasticker.downloader.features.MainActivity}" drawable="download_twitter_videos" name="Status Save" />
   <item component="ComponentInfo{statussaver.statusdownloader.downloadstatus.videoimagesaver/statussaver.statusdownloader.downloadstatus.videoimagesaver.app.ui.splash.SplashActivity}" drawable="download_twitter_videos" name="Status Saver" />
   <item component="ComponentInfo{savestatus.videodownloader.storysaver.statuskeeper/savestatus.videodownloader.storysaver.statuskeeper.app.ui.splash.SplashActivity}" drawable="download_twitter_videos" name="Status Saver" />
   <item component="ComponentInfo{com.magic.whatsapp.status.saver.download/com.magic.whatsapp.status.saver.download.ui.activity.SplashActivity}" drawable="download_progress_plus_plus" name="Status Saver" />
@@ -18943,6 +18956,7 @@
   <item component="ComponentInfo{com.tmobile.pr.mytmobile/com.tmobile.pr.mytmobile.MyTMobileActivity}" drawable="t_mobile" name="T‑Mobile" />
   <item component="ComponentInfo{com.youdao.hindict/com.youdao.hindict.activity.MainActivity}" drawable="u_dictionary" name="U Dictionary" />
   <item component="ComponentInfo{com.youdao.hindict/com.youdao.hindict.activity.SplashActivity}" drawable="u_dictionary" name="U Dictionary" />
+  <item component="ComponentInfo{com.hk.s.all.video.player/com.hk.s.all.video.player.HlsPlay}" drawable="generic_player" name="U Player" />
   <item component="ComponentInfo{com.lguplus.mobile.cs/com.lguplus.mobile.cs.activity.main.MainActivity}" drawable="u_plus" name="U+" />
   <item component="ComponentInfo{com.lguplus.mobile.cs/com.lguplus.mobile.cs.activity.MainActivity}" drawable="u_plus" name="U+" />
   <item component="ComponentInfo{jp.unext.mediaplayer/jp.unext.mediaplayer.main.MainActivity}" drawable="u_next" name="U-NEXT" />
@@ -19422,6 +19436,7 @@
   <item component="ComponentInfo{com.astl.vidalink/com.astl.vidalink.ui.splash.SplashActivity}" drawable="vidalink" name="Vidalink" />
   <item component="ComponentInfo{aculix.viddit.downloader/aculix.viddit.downloader.ui.MainActivity}" drawable="viddit" name="Viddit" />
   <item component="ComponentInfo{aculix.viddit.downloader/aculix.viddit.downloader.MainActivity}" drawable="viddit" name="Viddit" />
+  <item component="ComponentInfo{com.mediatek.videoplayer/com.mediatek.videoplayer.MovieListActivity}" drawable="generic_player" name="Video" />
   <item component="ComponentInfo{com.sony.tvsideview.phone/com.sony.tvsideview.MainActivity}" drawable="video_and_tv_sideview" name="Video &amp; TV SideView" />
   <item component="ComponentInfo{org.xjiop.vkvideoapp/org.xjiop.vkvideoapp.AuthActivity}" drawable="video_app_for_vk" name="Video App for VK" />
   <item component="ComponentInfo{com.videoconverter.videocompressor/com.google.android.archive.ReactivateActivity}" drawable="video_compressor" name="Video Compressor" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
2 × Despegar (`com.gm.despegar` → `decolar.svg`)
Liquid Dialer (`com.grice.call` → `generic_dialer.svg`)
Local Player (`com.cvc953.localplayer` → `music_player.svg`)
Media Saver (`instagram.video.downloader.story.saver.ig.insaver` → `download_progress_plus_plus.svg`)
Music (`com.android.music` → `apple_music.svg`)
Music Player (`com.musicplan.playermusic` → `apple_music.svg`)
Musical Notes (`jl.musicalnotes` → `music_player.svg`)
Nothing Dialer (`com.rkkvishva.nothing_dialer` → `generic_dialer.svg`)
Only Player (`one.only.player` → `just_player.svg`)
ReproductorVideo (`android.rk.RockVideoPlayer` → `just_player.svg`)
SoloPro (`com.solo.link.music.player.pro` → `apple_music.svg`)
Status Save (`wasaver.downloadstatus.videosaver.wasticker.downloader` → `download_twitter_videos.svg`)
U Player (`com.hk.s.all.video.player` → `generic_player.svg`)
Video (`com.mediatek.videoplayer` → `generic_player.svg`)