### PR TITLE
+3 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -4421,6 +4421,7 @@
   <item component="ComponentInfo{com.rosan.dhizuku/com.rosan.dhizuku.ui.activity.SettingsActivity}" drawable="dhizuku" name="Dhizuku" />
   <item component="ComponentInfo{com.dhlparcel.nl/com.dhlparcel.MainActivity}" drawable="dhl" name="DHL" />
   <item component="ComponentInfo{com.dhl.frt.mittdhl/com.dhl.frt.mittdhl.MainActivity}" drawable="dhl" name="DHL" />
+  <item component="ComponentInfo{com.dhlparcel.consumerapp/com.dhlparcel.consumerapp.MainActivity}" drawable="dhl" name="DHL eCom" />
   <item component="ComponentInfo{com.dhl.exp.dhlmobile/com.dhl.exp.dhlmobile.MainActivity}" drawable="dhl" name="DHL Express" />
   <item component="ComponentInfo{com.android.contacts/com.android.contacts.activities.TwelveKeyDialer}" drawable="generic_dialer" name="Dialer" />
   <item component="ComponentInfo{com.motorola.dialer/com.motorola.dialer.CallLogShortcut}" drawable="generic_dialer" name="Dialer" />
@@ -6016,6 +6017,7 @@
   <item component="ComponentInfo{epic.org.flappybird/com.unity3d.player.UnityPlayerActivity}" drawable="flappy_bird" name="Flappy Bird" />
   <item component="ComponentInfo{com.flappybird.game/android.app.NativeActivity}" drawable="flappy_bird" name="Flappy Bird" />
   <item component="ComponentInfo{com.flappybird.recreation/com.flappybird.recreation.GearslogoActivity}" drawable="flappy_bird" name="Flappy Bird" />
+  <item component="ComponentInfo{appinventor.ai_logiscool869.FlappyCopter/appinventor.ai_logiscool869.FlappyCopter.Screen1}" drawable="flappy_bird" name="Flappy Copter" />
   <item component="ComponentInfo{dev.dimension.flare/dev.dimension.flare.MainActivity}" drawable="flare" name="Flare" />
   <item component="ComponentInfo{app.useflash.teller/app.useflash.teller.MainActivity}" drawable="flash" name="Flash" />
   <item component="ComponentInfo{com.my.newproject15/com.my.newproject15.MainActivity}" drawable="generic_shell" name="FLASH" />
@@ -14196,6 +14198,7 @@
   <item component="ComponentInfo{com.plexapp.android/tv.plex.app.MainActivity}" drawable="plex" name="Plex" />
   <item component="ComponentInfo{com.plexapp.android/com.plexapp.android.MainActivityTranscoder}" drawable="plex" name="Plex" />
   <item component="ComponentInfo{com.plexapp.android/com.plexapp.android.MainActivityStars}" drawable="plex" name="Plex" />
+  <item component="ComponentInfo{com.plexapp.android/com.plexapp.android.MainActivityDefault}" drawable="plex" name="Plex" />
   <item component="ComponentInfo{tv.plex.labs.dash/tv.plex.labs.dashboard.MainActivity}" drawable="plex_dash" name="Plex Dash" />
   <item component="ComponentInfo{tv.plex.labs.plexamp/com.plexamp.MainActivity}" drawable="plexamp" name="Plexamp" />
   <item component="ComponentInfo{tv.plex.labs.plexamp/com.google.android.archive.ReactivateActivity}" drawable="plexamp" name="Plexamp" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
DHL eCom (`com.dhlparcel.consumerapp` → `dhl.svg`)
Flappy Copter (`appinventor.ai_logiscool869.FlappyCopter` → `flappy_bird.svg`)
Plex (`com.plexapp.android` → `plex.svg`)