### PR TITLE
+3 links

### DIFF
--- a/app/assets/appfilter.xml
+++ b/app/assets/appfilter.xml
@@ -7119,6 +7119,7 @@
   <item component="ComponentInfo{dev.glare.kwgt.app/com.example.novel.MainActivity}" drawable="glare_kwgt" name="Glare KWGT" />
   <item component="ComponentInfo{com.appslab.glass.widgets/com.appslab.glass.widgets.MainActivity}" drawable="glass_widgets" name="Glass Widgets" />
   <item component="ComponentInfo{com.glassdoor.app/com.glassdoor.app.presentation.ui.MainActivity}" drawable="glassdoor" name="Glassdoor" />
+  <item component="ComponentInfo{io.mo.glassmic/io.mo.glassmic.MainActivity}" drawable="generic_microphone" name="GlassMic" />
   <item component="ComponentInfo{com.glasswire.android/com.glasswire.android.presentation.activities.start.StartActivity}" drawable="glasswire" name="GlassWire" />
   <item component="ComponentInfo{nl.viter.glider/nl.viter.glider.MainActivity}" drawable="glider" name="Glider" />
   <item component="ComponentInfo{com.asus.glidex/com.asus.glidex.MainActivity}" drawable="glidex" name="GlideX" />
@@ -8886,6 +8887,7 @@
   <item component="ComponentInfo{com.asis.izmirimkart/io.flutter.app.MainActivity}" drawable="izmirim_kart" name="İzmirim Kart" />
   <item component="ComponentInfo{com.asis.izmirimkart/com.asis.izmirimkart.MainActivity}" drawable="izmirim_kart" name="İzmirim Kart" />
   <item component="ComponentInfo{com.pozitron.iscep/com.pozitron.iscep.features.prelogin.splash.SplashActivity}" drawable="iscep" name="İşCep" />
+  <item component="ComponentInfo{com.inphase.itv/com.inphase.itv.StartActivity}" drawable="ladb" name="i视 ~~ iShi" />
   <item component="ComponentInfo{com.jtexpress.MyClient/com.jtexpress.MyClient.ui.SplashActivity}" drawable="j_and_t" name="J&amp;amp;T" />
   <item component="ComponentInfo{com.msd.JTClient/com.msd.JTClient.ui.SplashActivity}" drawable="j_and_t" name="J&amp;T" />
   <item component="ComponentInfo{com.jt.indonesiaexpress/com.jt.indonesiaexpress.ui.activity.SplashActivity}" drawable="j_and_t" name="J&amp;T CARGO" />
@@ -10009,6 +10011,7 @@
   <item component="ComponentInfo{org.localsend.localsend_app/org.localsend.localsend_app.MainActivity}" drawable="localsend" name="LocalSend" />
   <item component="ComponentInfo{com.xfarrow.locatemydevice/com.xfarrow.locatemydevice.MainActivity}" drawable="generic_shell" name="Locate My Device" />
   <item component="ComponentInfo{com.locationchanger/com.locationchanger.MainActivity}" drawable="location_changer" name="Location Changer" />
+  <item component="ComponentInfo{com.suseoaa.locationspoofer/com.suseoaa.locationspoofer.MainActivity}" drawable="mock_locations" name="LocationSpoofer" />
   <item component="ComponentInfo{name.seguri.android.lock/name.seguri.android.lock.MainActivity}" drawable="generic_lock" name="Lock" />
   <item component="ComponentInfo{net.blumia.pineapple.lockscreen/net.blumia.pineapple.lockscreen.shortcuts.LockScreenShortcut}" drawable="generic_lock" name="Lock (Pineapple Lock Screen)" />
   <item component="ComponentInfo{net.blumia.pineapple.lockscreen.oss/net.blumia.pineapple.lockscreen.shortcuts.LockScreenShortcut}" drawable="generic_lock" name="Lock (Pineapple Lock Screen)" />


### PR DESCRIPTION
<!-- ICON ADDITIONS
- The bot will automatically describe icon changes below your description (if any).
- You can add extra notes or attach original icons that are hard to find.
- Please make sure the title is correct — it's parsed for the Nightly changelog stats.
- Title example: "+1 icon, +2 links, +3 updates".
  +1 icon = +1 brand new icon (related links aren't considered).
  +2 links = +2 missing app IDs for existing icons.
  +3 updates = redesign of 3 existing icons.
  In other cases, choose something else to avoid confusion.
-->

<!-- GENERAL CHANGES / BUGS
- Leave a short summary.
- If there's an issue, link it (Fix #123 or Close #123).
-->

<!-- bot: icons -->
## Icons

### Linked
GlassMic (`io.mo.glassmic` → `generic_microphone.svg`)
i视 ~~ iShi (`com.inphase.itv` → `ladb.svg`)
LocationSpoofer (`com.suseoaa.locationspoofer` → `mock_locations.svg`)